### PR TITLE
CBL-689: Rip out old implementation of OFFLINE

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/core/C4Replicator.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Replicator.java
@@ -81,18 +81,6 @@ public class C4Replicator extends C4NativePeer {
     private static final Map<Object, C4Replicator> CONTEXT_TO_C4_REPLICATOR_MAP = new HashMap<>();
 
     //-------------------------------------------------------------------------
-    // Public static methods
-    //-------------------------------------------------------------------------
-
-    public static boolean mayBeTransient(@NonNull C4Error err) {
-        return mayBeTransient(err.getDomain(), err.getCode(), err.getInternalInfo());
-    }
-
-    public static boolean mayBeNetworkDependent(@NonNull C4Error err) {
-        return mayBeNetworkDependent(err.getDomain(), err.getCode(), err.getInternalInfo());
-    }
-
-    //-------------------------------------------------------------------------
     // Static Factory Methods
     //-------------------------------------------------------------------------
 
@@ -535,17 +523,5 @@ public class C4Replicator extends C4NativePeer {
      * Returns true if there are documents that have not been resolved.
      */
     private static native boolean isDocumentPending(long handle, String id) throws LiteCoreException;
-
-    /**
-     * Returns true if this is a network error that may be transient,
-     * i.e. the client should retry after a delay.
-     */
-    private static native boolean mayBeTransient(int domain, int code, int info);
-
-    /**
-     * Returns true if this error might go away when the network environment changes,
-     * i.e. the client should retry after notification of a network status change.
-     */
-    private static native boolean mayBeNetworkDependent(int domain, int code, int info);
 }
 

--- a/common/main/java/com/couchbase/lite/internal/core/C4ReplicatorStatus.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4ReplicatorStatus.java
@@ -81,17 +81,6 @@ public final class C4ReplicatorStatus {
             errorInternalInfo);
     }
 
-    public C4ReplicatorStatus copyAtlevel(int newLevel) {
-        return new C4ReplicatorStatus(
-            newLevel,
-            progressUnitsCompleted,
-            progressUnitsTotal,
-            progressDocumentCount,
-            errorDomain,
-            errorCode,
-            errorInternalInfo);
-    }
-
     public int getActivityLevel() { return activityLevel; }
 
     public long getProgressUnitsCompleted() { return progressUnitsCompleted; }

--- a/common/test/java/com/couchbase/lite/ArrayTest.java
+++ b/common/test/java/com/couchbase/lite/ArrayTest.java
@@ -549,6 +549,7 @@ public class ArrayTest extends BaseDbTest {
         }
     }
 
+    // !!! Failing on Nexus 4
     @Test
     public void testGetNumber() throws CouchbaseLiteException {
         for (int i = 0; i < 2; i++) {

--- a/common/test/java/com/couchbase/lite/LogTest.java
+++ b/common/test/java/com/couchbase/lite/LogTest.java
@@ -110,7 +110,11 @@ public class LogTest extends BaseDbTest {
     @After
     @Override
     public void tearDown() {
-        try { FileUtils.eraseFileOrDir(scratchDirPath); }
+        try {
+            // if setup failed, don't obscure its failure.
+            // !!! Failing on Nexus 4
+            if (scratchDirPath != null) { FileUtils.eraseFileOrDir(scratchDirPath); }
+        }
         finally { super.tearDown(); }
     }
 

--- a/common/test/java/com/couchbase/lite/ReplicatorOfflineTest.java
+++ b/common/test/java/com/couchbase/lite/ReplicatorOfflineTest.java
@@ -22,6 +22,7 @@ import java.net.URISyntaxException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static com.couchbase.lite.utils.TestUtils.assertThrows;
@@ -105,6 +106,7 @@ public class ReplicatorOfflineTest extends BaseReplicatorTest {
     }
 
     @Test
+    @Ignore("Platform no longer has control of network reachablity")
     public void testNetworkRetry() throws URISyntaxException, InterruptedException {
         final CountDownLatch offline = new CountDownLatch(2);
         final CountDownLatch stopped = new CountDownLatch(1);
@@ -118,7 +120,8 @@ public class ReplicatorOfflineTest extends BaseReplicatorTest {
                         Replicator r = change.getReplicator();
                         offline.countDown();
                         if (offline.getCount() <= 0) { r.stop(); }
-                        else { r.networkReachable(); }
+                        // !!! Platform no longer has controll of network reachablity
+                        //else { r.networkReachable(); }
                         return;
                     case STOPPED:
                         stopped.countDown();


### PR DESCRIPTION
This commit removes all of the old platform logic for the OFFLINE state.  It also disables the NetworkReachabilityManager.  CBL-760 tracks re-enabling it