### PR TITLE
Document Id

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractQuery.java
+++ b/common/main/java/com/couchbase/lite/AbstractQuery.java
@@ -285,6 +285,8 @@ abstract class AbstractQuery implements Query {
         catch (LiteCoreException e) { throw CBLStatus.convertException(e); }
     }
 
+    // https://issues.couchbase.com/browse/CBL-21
+    // Using c4query_columnTitle is not an improvement, as of 12/2019
     private Map<String, Integer> getColumnNames() throws CouchbaseLiteException {
         final Map<String, Integer> map = new HashMap<>();
         int index = 0;

--- a/common/main/java/com/couchbase/lite/AbstractReplicatorConfiguration.java
+++ b/common/main/java/com/couchbase/lite/AbstractReplicatorConfiguration.java
@@ -352,11 +352,24 @@ abstract class AbstractReplicatorConfiguration {
     public final Endpoint getTarget() { return target; }
 
 
+    @Override
+    public String toString() { return "ReplicatorConfig{" + database + " => " + target + "}"; }
+
     //---------------------------------------------
     // Package level access
     //---------------------------------------------
 
     abstract ReplicatorConfiguration getReplicatorConfiguration();
+
+    boolean isPush() {
+        return replicatorType == ReplicatorConfiguration.ReplicatorType.PUSH_AND_PULL
+            || replicatorType == ReplicatorConfiguration.ReplicatorType.PUSH;
+    }
+
+    boolean isPull() {
+        return replicatorType == ReplicatorConfiguration.ReplicatorType.PUSH_AND_PULL
+            || replicatorType == ReplicatorConfiguration.ReplicatorType.PULL;
+    }
 
     final ReplicatorConfiguration readonlyCopy() {
         final ReplicatorConfiguration config = new ReplicatorConfiguration(getReplicatorConfiguration());

--- a/common/main/java/com/couchbase/lite/ReplicatorChange.java
+++ b/common/main/java/com/couchbase/lite/ReplicatorChange.java
@@ -36,24 +36,15 @@ public final class ReplicatorChange {
      * Return the source replicator object.
      */
     @NonNull
-    public Replicator getReplicator() {
-        return replicator;
-    }
+    public Replicator getReplicator() { return replicator; }
 
     /**
      * Return the replicator status.
      */
     @NonNull
-    public Replicator.Status getStatus() {
-        return status;
-    }
+    public Replicator.Status getStatus() { return status; }
 
     @NonNull
     @Override
-    public String toString() {
-        return "ReplicatorChange{" +
-            "replicator=" + replicator +
-            ", status=" + status +
-            '}';
-    }
+    public String toString() {return "ReplicatorChange{replicator=" + replicator + ", status=" + status + '}'; }
 }

--- a/common/main/java/com/couchbase/lite/internal/core/C4ReplicatorStatus.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4ReplicatorStatus.java
@@ -22,7 +22,7 @@ package com.couchbase.lite.internal.core;
 /**
  * WARNING!
  * This class and its members are referenced by name, from native code.
- *
+ * <p>
  * Keep this class immutable.
  */
 public final class C4ReplicatorStatus {

--- a/common/test/java/com/couchbase/lite/TestReplicatorChangeListener.java
+++ b/common/test/java/com/couchbase/lite/TestReplicatorChangeListener.java
@@ -6,6 +6,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.jetbrains.annotations.NotNull;
 
+import com.couchbase.lite.utils.Report;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -38,6 +40,7 @@ public class TestReplicatorChangeListener implements ReplicatorChangeListener {
 
     @Override
     public void changed(@NotNull ReplicatorChange change) {
+        Report.log(LogLevel.DEBUG, "Test change listener: " + change);
         final Replicator.Status status = change.getStatus();
         try {
             if (continuous) { checkContinuousStatus(status); }


### PR DESCRIPTION
Abstract Replicator is thread safe
New C4 Database lifecycle support (except: CBL-787)
Document Id feature (still need tests: CBL-792)

This is still pretty big, I am afraid.  (I really am trying to make them smaller!).  Changing the lifecycle of the C4Replicator was a great opportunity finally, to make the Replicator thread-safe.
Note also that several of the complexity warning are gone!  Hurray!

There are still two outstanding problems: CBL-787 (resetCheckpoint doesn't work right) and CBL-792 (need automated tests for DocId)

All existing tests pass.