### PR TITLE
Implement replicator’s server cert and accept only self-signed cert

### DIFF
--- a/android/main/java/com/couchbase/lite/internal/replicator/CBLWebSocket.java
+++ b/android/main/java/com/couchbase/lite/internal/replicator/CBLWebSocket.java
@@ -43,9 +43,10 @@ public class CBLWebSocket extends AbstractCBLWebSocket {
         String hostname,
         int port,
         String path,
-        Map<String, Object> options)
+        Map<String, Object> options,
+        CBLTrustManager.CBLTrustManagerListener trustManagerListener)
         throws GeneralSecurityException, URISyntaxException {
-        super(handle, scheme, hostname, port, path, options);
+        super(handle, scheme, hostname, port, path, options, trustManagerListener);
     }
 
     @SuppressWarnings("PMD.CollapsibleIfStatements")

--- a/android/main/java/com/couchbase/lite/internal/replicator/CBLWebSocket.java
+++ b/android/main/java/com/couchbase/lite/internal/replicator/CBLWebSocket.java
@@ -25,9 +25,12 @@ import java.net.ConnectException;
 import java.net.SocketException;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
+import java.security.cert.Certificate;
+import java.util.List;
 import java.util.Map;
 
 import com.couchbase.lite.internal.core.C4Constants;
+import com.couchbase.lite.internal.utils.Fn;
 
 
 public class CBLWebSocket extends AbstractCBLWebSocket {
@@ -44,9 +47,9 @@ public class CBLWebSocket extends AbstractCBLWebSocket {
         int port,
         String path,
         Map<String, Object> options,
-        CBLTrustManager.CBLTrustManagerListener trustManagerListener)
+        Fn.Consumer<List<Certificate>> serverCertsListener)
         throws GeneralSecurityException, URISyntaxException {
-        super(handle, scheme, hostname, port, path, options, trustManagerListener);
+        super(handle, scheme, hostname, port, path, options, serverCertsListener);
     }
 
     @SuppressWarnings("PMD.CollapsibleIfStatements")

--- a/common/main/java/com/couchbase/lite/AbstractReplicator.java
+++ b/common/main/java/com/couchbase/lite/AbstractReplicator.java
@@ -355,7 +355,7 @@ public abstract class AbstractReplicator extends InternalReplicator {
     protected AbstractReplicator(@NonNull ReplicatorConfiguration config) {
         Preconditions.assertNotNull(config, "config");
         this.config = config.readonlyCopy();
-        this.socketFactory = new SocketFactory(config, certificates -> serverCertificates.set(certificates));
+        this.socketFactory = new SocketFactory(config, this::setServerCertificates);
     }
 
     /**
@@ -954,6 +954,11 @@ public abstract class AbstractReplicator extends InternalReplicator {
             if (element.length() > 0) { path.addLast(element); }
         }
         return path;
+    }
+
+    // Consumer callback to set the server certificates received during the TLS Handshake
+    private void setServerCertificates(List<Certificate> certificates) {
+        serverCertificates.set(certificates);
     }
 
     private String description() { return baseDesc() + "," + getDatabase() + " => " + config.getTarget() + "}"; }

--- a/common/main/java/com/couchbase/lite/AbstractReplicator.java
+++ b/common/main/java/com/couchbase/lite/AbstractReplicator.java
@@ -20,6 +20,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.net.URI;
+import java.security.cert.Certificate;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -342,6 +344,9 @@ public abstract class AbstractReplicator extends InternalReplicator {
 
     private volatile String desc;
 
+    // Server certificates received from the server during the TLS handshake
+    private final AtomicReference<List<Certificate>> serverCertificates = new AtomicReference<>();
+
     /**
      * Initializes a replicator with the given configuration.
      *
@@ -350,7 +355,7 @@ public abstract class AbstractReplicator extends InternalReplicator {
     protected AbstractReplicator(@NonNull ReplicatorConfiguration config) {
         Preconditions.assertNotNull(config, "config");
         this.config = config.readonlyCopy();
-        this.socketFactory = new SocketFactory(config);
+        this.socketFactory = new SocketFactory(config, certificates -> serverCertificates.set(certificates));
     }
 
     /**
@@ -422,6 +427,13 @@ public abstract class AbstractReplicator extends InternalReplicator {
     public Status getStatus() {
         synchronized (lock) { return status.copy(); }
     }
+
+    /**
+     * The server certificates received from the server during the TLS handshake.
+     * @return this replicator's server certificates.
+     */
+    @Nullable
+    public List<Certificate> getServerCertificates() { return serverCertificates.get(); }
 
     /**
      * Get a best effort list of documents still pending replication.

--- a/common/main/java/com/couchbase/lite/AbstractReplicatorConfiguration.java
+++ b/common/main/java/com/couchbase/lite/AbstractReplicatorConfiguration.java
@@ -369,7 +369,7 @@ abstract class AbstractReplicatorConfiguration {
         return config;
     }
 
-    final Map<String, Object> effectiveOptions() {
+    protected Map<String, Object> effectiveOptions() {
         final Map<String, Object> options = new HashMap<>();
 
         if (authenticator != null) { authenticator.authenticate(options); }

--- a/common/main/java/com/couchbase/lite/internal/core/C4Socket.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Socket.java
@@ -34,7 +34,6 @@ public abstract class C4Socket extends C4NativePeer {
     //-------------------------------------------------------------------------
     private static final LogDomain LOG_DOMAIN = LogDomain.NETWORK;
 
-
     // C4SocketFraming (C4SocketFactory.framing)
     public static final int WEB_SOCKET_CLIENT_FRAMING = 0; ///< Frame as WebSocket client messages (masked)
     public static final int NO_FRAMING = 1;                ///< No framing; use messages as-is

--- a/common/main/java/com/couchbase/lite/internal/replicator/CBLTrustManager.java
+++ b/common/main/java/com/couchbase/lite/internal/replicator/CBLTrustManager.java
@@ -1,0 +1,159 @@
+package com.couchbase.lite.internal.replicator;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.security.InvalidKeyException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.SignatureException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+
+/**
+ * The trust manager that supports the followings:
+ * 1. Supports pinned server certificate.
+ * 2. Supports acceptOnlySelfSignedServerCertificate mode.
+ * 3. Supports default trust manager for validating certs when the pinned server
+ *    certificate and acceptOnlySelfSignedServerCertificate are not used.
+ * 4. Allows to listen for the server certificates.
+ */
+public final class CBLTrustManager implements X509TrustManager {
+    public interface CBLTrustManagerListener {
+        void onReceivedServerCertificate(@Nullable List<Certificate> serverCertificates);
+    }
+
+    private final @Nullable byte[] pinnedServerCertificate;
+
+    private final boolean acceptOnlySelfSignedServerCertificate;
+
+    private final @NonNull CBLTrustManagerListener listener;
+
+    private final AtomicReference<X509TrustManager> defaultTrustManager = new AtomicReference<>();
+
+    public CBLTrustManager(
+        @Nullable byte[] pinnedServerCert,
+        boolean acceptOnlySelfSignedServerCertificate,
+        @NonNull CBLTrustManagerListener listener) {
+        this.pinnedServerCertificate = (pinnedServerCert != null ? pinnedServerCert.clone() : null);
+        this.acceptOnlySelfSignedServerCertificate = acceptOnlySelfSignedServerCertificate;
+        this.listener = listener;
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        throw new UnsupportedOperationException("Checking Client Trust is a server operation");
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        try { doCheckServerTrusted(chain, authType); }
+        finally {
+            listener.onReceivedServerCertificate(Collections.unmodifiableList(Arrays.asList(chain)));
+        }
+    }
+
+    private void doCheckServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        // Use default trust manager if the pinned server certificate
+        // and acceptOnlySelfSignedServerCertificate are not used:
+        if (useDefaultTrustManager()) {
+            getDefaultTrustManager().checkServerTrusted(chain, authType);
+            return;
+        }
+
+        // Check chain and authType precondition and throws IllegalArgumentException according to
+        // https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/X509TrustManager.html:
+        if (chain == null || chain.length == 0) {
+            throw new IllegalArgumentException("No server certificates");
+        }
+        if (authType == null || authType.length() == 0) {
+            throw new IllegalArgumentException("Invalid auth type: " + authType);
+        }
+
+        // Validate certificate:
+        final X509Certificate cert = chain[0];
+        cert.checkValidity();
+
+        // pinnedServerCertificate takes precedence over acceptOnlySelfSignedServerCertificate
+        if (pinnedServerCertificate != null) {
+            // Compare pinnedServerCertificate and the received cert:
+            if (!Arrays.equals(pinnedServerCertificate, cert.getEncoded())) {
+                throw new CertificateException("Server certificate does not match pinned certificate");
+            }
+        } else {
+            // Accept only self-signed certificate:
+            if (chain.length > 0 || !isSelfSignedCertificate(cert)) {
+                throw new CertificateException("Server certificate is not self-signed");
+            }
+        }
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+        if (useDefaultTrustManager()) { return getDefaultTrustManager().getAcceptedIssuers(); }
+        return new X509Certificate[0];
+    }
+
+    /**
+     * Check if the default trust manager should be used.
+     * When the pinned server certificate and acceptOnlySelfSignedServerCertificate
+     * are not used, the default trust manager will be used.
+     */
+    private boolean useDefaultTrustManager() {
+        return pinnedServerCertificate == null && !acceptOnlySelfSignedServerCertificate;
+    }
+
+    /**
+     * Get the default trust manager.
+     */
+    private X509TrustManager getDefaultTrustManager() {
+        final X509TrustManager trustManager = defaultTrustManager.get();
+        if (trustManager != null) { return trustManager; }
+
+        final TrustManager[] trustManagers;
+        try {
+            final TrustManagerFactory trustManagerFactory
+                = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init((KeyStore) null);
+            trustManagers = trustManagerFactory.getTrustManagers();
+        }
+        catch (NoSuchAlgorithmException | KeyStoreException e) {
+            throw new IllegalStateException("Cannot find the default trust manager", e);
+        }
+
+        if (trustManagers == null || trustManagers.length == 0) {
+            throw new IllegalStateException("Cannot find the default trust manager");
+        }
+
+        defaultTrustManager.compareAndSet(null, (X509TrustManager) trustManagers[0]);
+        return defaultTrustManager.get();
+    }
+
+    /**
+     * Check if the certificate is a self-signed certificate.
+     */
+    private boolean isSelfSignedCertificate(X509Certificate cert) {
+        if (!cert.getSubjectDN().equals(cert.getIssuerDN())) { return false; }
+
+        try {
+            cert.verify(cert.getPublicKey());
+            return true;
+        } catch (CertificateException | NoSuchAlgorithmException |
+                 InvalidKeyException | NoSuchProviderException |
+                 SignatureException e) {
+            return false;
+        }
+    }
+}

--- a/java/main/java/com/couchbase/lite/internal/replicator/CBLWebSocket.java
+++ b/java/main/java/com/couchbase/lite/internal/replicator/CBLWebSocket.java
@@ -19,7 +19,12 @@ import android.support.annotation.NonNull;
 
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
+import java.security.cert.Certificate;
+import java.util.List;
 import java.util.Map;
+
+import com.couchbase.lite.internal.utils.Fn;
+
 
 public class CBLWebSocket extends AbstractCBLWebSocket {
     protected CBLWebSocket(
@@ -29,8 +34,8 @@ public class CBLWebSocket extends AbstractCBLWebSocket {
         int port,
         String path,
         Map<String, Object> options,
-        @NonNull CBLTrustManager.CBLTrustManagerListener trustManagerListener)
+        @NonNull Fn.Consumer<List<Certificate>> serverCertsListener)
         throws GeneralSecurityException, URISyntaxException {
-        super(handle, scheme, hostname, port, path, options, trustManagerListener);
+        super(handle, scheme, hostname, port, path, options, serverCertsListener);
     }
 }

--- a/java/main/java/com/couchbase/lite/internal/replicator/CBLWebSocket.java
+++ b/java/main/java/com/couchbase/lite/internal/replicator/CBLWebSocket.java
@@ -15,6 +15,8 @@
 //
 package com.couchbase.lite.internal.replicator;
 
+import android.support.annotation.NonNull;
+
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import java.util.Map;
@@ -26,7 +28,9 @@ public class CBLWebSocket extends AbstractCBLWebSocket {
         String hostname,
         int port,
         String path,
-        Map<String, Object> options) throws GeneralSecurityException, URISyntaxException {
-        super(handle, scheme, hostname, port, path, options);
+        Map<String, Object> options,
+        @NonNull CBLTrustManager.CBLTrustManagerListener trustManagerListener)
+        throws GeneralSecurityException, URISyntaxException {
+        super(handle, scheme, hostname, port, path, options, trustManagerListener);
     }
 }


### PR DESCRIPTION
* Implemented CBLTrustManager to support listening to server certs received, pinned cert, and accept only self-signed cert feature.

* Updated AbstractCBLWebSocket to use CBLTrustManager.

* Wired up from Replicator -> SocketFactor -> CBLWebSocket -> CBLTrustManager to listen to get server certificates available in the Replicator.

* Reference: CBL-1167 and CBL-1168