### PR TITLE
Hotfix/2.8.1

### DIFF
--- a/android/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
+++ b/android/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
@@ -59,8 +59,6 @@ public final class CouchbaseLiteInternal {
     private static final String LITECORE_JNI_LIBRARY = "LiteCoreJNI";
 
     private static final String TEMP_DIR_NAME = "CouchbaseLiteTemp";
-    private static final String DB_DIR_NAME = ".couchbase";
-
 
     private static final AtomicReference<SoftReference<Context>> CONTEXT = new AtomicReference<>();
     private static final AtomicReference<ExecutionService> EXECUTION_SERVICE = new AtomicReference<>();
@@ -143,7 +141,7 @@ public final class CouchbaseLiteInternal {
     @NonNull
     public static String makeDbPath(@Nullable String rootDir) {
         requireInit("Can't create DB path");
-        return verifyDir((rootDir != null) ? new File(rootDir) : new File(getContext().getFilesDir(), DB_DIR_NAME));
+        return verifyDir((rootDir != null) ? new File(rootDir) : getContext().getFilesDir());
     }
 
     @NonNull

--- a/common/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/common/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -1734,17 +1734,17 @@ abstract class AbstractDatabase {
     // The fix is to use the original "real" default dir (the one used by all pre 2.8.0 code)
     // and to copy a database from the "2.8" default directory into the "real" default
     // directory as long as it won't overwrite anything that is already there.
-    private void fixHydrogenBug(@NonNull String rootDirPath, @NonNull String dbName) throws CouchbaseLiteException {
+    private void fixHydrogenBug(@Nullable String rootDirPath, @NonNull String dbName) throws CouchbaseLiteException {
         final String defaultDirPath = AbstractDatabaseConfiguration.getDbDirectory(null);
 
         // Both rootDir and defaultDir are canonical, so string comparison should work.
         // If this is not about a database located in the default directory, none of this is relevant.
-        if (defaultDirPath.equals(rootDirPath)) { return; }
+        if (!defaultDirPath.equals(AbstractDatabaseConfiguration.getDbDirectory(rootDirPath))) { return; }
         final File defaultDir = new File(defaultDirPath);
 
         // If this database doesn't exist in the 2.8 default dir, were'r done here.
         final File twoDotEightDefaultDir = new File(defaultDir, ".couchbase");
-        if (Database.exists(dbName, twoDotEightDefaultDir)) { return; }
+        if (!Database.exists(dbName, twoDotEightDefaultDir)) { return; }
 
         // If this database already exists in the real default directory,
         // we can't risk trashing it. We just use the database in the real default

--- a/common/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/common/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -1735,26 +1735,28 @@ abstract class AbstractDatabase {
     // and to copy a database from the "2.8" default directory into the "real" default
     // directory as long as it won't overwrite anything that is already there.
     private void fixHydrogenBug(@Nullable String rootDirPath, @NonNull String dbName) throws CouchbaseLiteException {
+        // This is the real default directory
         final String defaultDirPath = AbstractDatabaseConfiguration.getDbDirectory(null);
 
+        // Check to see if the rootDirPath refers to the default directory.  If not, none of this is relevant.
         // Both rootDir and defaultDir are canonical, so string comparison should work.
-        // If this is not about a database located in the default directory, none of this is relevant.
         if (!defaultDirPath.equals(AbstractDatabaseConfiguration.getDbDirectory(rootDirPath))) { return; }
+
         final File defaultDir = new File(defaultDirPath);
 
         // If this database doesn't exist in the 2.8 default dir, were'r done here.
         final File twoDotEightDefaultDir = new File(defaultDir, ".couchbase");
-        if (!Database.exists(dbName, twoDotEightDefaultDir)) { return; }
+        if (!exists(dbName, twoDotEightDefaultDir)) { return; }
 
         // If this database already exists in the real default directory,
         // we can't risk trashing it. We just use the database in the real default
         // directory and leave well enough alone.
         // It is *always* possible to use 2.8 database, by specifying
         // its directory explicitly.
-        if (Database.exists(dbName, defaultDir)) { return; }
+        if (exists(dbName, defaultDir)) { return; }
 
         // This database is in the 2.8 default dir but not in the real
         // default dir.  Copy it to where it belongs.
-        Database.copy(twoDotEightDefaultDir, dbName, new DatabaseConfiguration());
+        Database.copy(getDatabaseFile(twoDotEightDefaultDir, dbName), dbName, new DatabaseConfiguration());
     }
 }

--- a/common/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/common/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -245,7 +245,8 @@ abstract class AbstractDatabase {
         logger.setLevel(level);
     }
 
-    private static File getDatabaseFile(File dir, String name) {
+    @VisibleForTesting
+    static File getDatabaseFile(File dir, String name) {
         return new File(dir, name.replaceAll("/", ":") + DB_EXTENSION);
     }
 

--- a/common/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/common/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -1757,6 +1757,15 @@ abstract class AbstractDatabase {
 
         // This database is in the 2.8 default dir but not in the real
         // default dir.  Copy it to where it belongs.
-        Database.copy(getDatabaseFile(twoDotEightDefaultDir, dbName), dbName, new DatabaseConfiguration());
+        final File twoDotEightDb = getDatabaseFile(twoDotEightDefaultDir, dbName);
+        try { Database.copy(twoDotEightDb, dbName, new DatabaseConfiguration()); }
+        catch (CouchbaseLiteException e) {
+            // Per review: If the copy fails, delete the partial DB
+            // and throw an exception.  This is a poison pill.
+            // The db can only be opened by explicitly specifying 2.8.0 directory.
+            try { FileUtils.eraseFileOrDir(twoDotEightDb); }
+            catch (Exception ignore) { }
+            throw e;
+        }
     }
 }

--- a/tools/fetch_litecore.sh
+++ b/tools/fetch_litecore.sh
@@ -121,12 +121,19 @@ case "${OS}" in
       mv -f lib/libLiteCore.so "${LIBLITECORE_DIR}"
 
       SUPPORT_DIR=support/linux/x86_64
-      mkdir -p "${SUPPORT_DIR}" && rm -rf "${SUPPORT_DIR}/"*
-      mv -f lib/libgcc*.* "${SUPPORT_DIR}"
-      mv -f lib/libicu*.* "${SUPPORT_DIR}"
-      mv -f lib/libstdc*.* "${SUPPORT_DIR}"
-      mv -f lib/libz*.* "${SUPPORT_DIR}"
-      rm -f "${SUPPORT_DIR}/"libicutest*.*
+      rm -rf "${SUPPORT_DIR}" || true
+      mkdir -p "${SUPPORT_DIR}" 
+
+      mkdir "${SUPPORT_DIR}/libc++" 
+      mv -f lib/libgcc* "${SUPPORT_DIR}/libc++"
+      mv -f lib/libstdc* "${SUPPORT_DIR}/libc++"
+
+      mkdir "${SUPPORT_DIR}/libicu" 
+      mv -f lib/libicu* "${SUPPORT_DIR}/libicu"
+      rm -f "${SUPPORT_DIR}/libicu/"libicutest*
+
+      mkdir "${SUPPORT_DIR}/libz" 
+      mv -f lib/libz*.so* "${SUPPORT_DIR}/libz" || true # Only on CentOS6
 
       rm -f "${LIB}.tar.gz"
       ;;


### PR DESCRIPTION
There are two commits here:
1) This is the change that is driving 2.8.1: backward compatible default db directory.  This is the only code change in the product.
2) Fix the packaging for Java.  We had to do this by hand, in the 2.8.0 release.  This puts the support libraries into separate directories, by category