### PR TITLE
Fix for CBL-1406 Java

### DIFF
--- a/common/test/java/com/couchbase/lite/BaseTest.java
+++ b/common/test/java/com/couchbase/lite/BaseTest.java
@@ -49,13 +49,11 @@ public abstract class BaseTest extends PlatformBaseTest {
 
     @AfterClass
     public static void tearDownBaseTestClass() {
-        String path = CouchbaseLiteInternal.getDbDirectoryPath();
-        Report.log(LogLevel.INFO, "Deleting db directory: " + path);
-        FileUtils.deleteContents(new File(path));
-        path = CouchbaseLiteInternal.getTmpDirectoryPath();
-        Report.log(LogLevel.INFO, "Deleting tmp directory: " + path);
-        FileUtils.deleteContents(new File(CouchbaseLiteInternal.getTmpDirectoryPath()));
-        Report.log(LogLevel.INFO, "Directories deleted");
+        File tmpDir = new File(CouchbaseLiteInternal.getTmpDirectoryPath()).getAbsoluteFile();
+        if (!tmpDir.exists()) { return; }
+
+        Report.log(LogLevel.INFO, "Deleting tmp directory contents: " + tmpDir);
+        FileUtils.deleteContents(tmpDir);
     }
 
     @Before

--- a/common/test/java/com/couchbase/lite/DatabaseTest.java
+++ b/common/test/java/com/couchbase/lite/DatabaseTest.java
@@ -1270,6 +1270,10 @@ public class DatabaseTest extends BaseDbTest {
     public void testReOpenExistingDb() throws CouchbaseLiteException {
         final String dbName = getUniqueName("test-db");
 
+        // verify that the db directory is no longer in the misguided 2.8.0 subdirectory
+        final String dbDirectory = AbstractDatabaseConfiguration.getDbDirectory(null);
+        assertFalse(dbDirectory.endsWith(".couchbase"));
+
         Database db = null;
         try {
             db = new Database(dbName);

--- a/java/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
+++ b/java/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
@@ -49,7 +49,7 @@ public final class CouchbaseLiteInternal {
 
     private static final String ERRORS_PROPERTIES_PATH = "/errors.properties";
     private static final String TEMP_DIR_NAME = "CouchbaseLiteTemp";
-    private static final String DEFAULT_ROOT_DIR_NAME = ".couchbase";
+    private static final String DEFAULT_ROOT_DIR_NAME = "";
 
     private static final AtomicReference<ExecutionService> EXECUTION_SERVICE = new AtomicReference<>();
 
@@ -156,18 +156,18 @@ public final class CouchbaseLiteInternal {
 
     @NonNull
     private static String verifyDir(@NonNull File dir) {
-        String path = dir.getAbsolutePath();
         try {
-            path = dir.getCanonicalPath();
+            final File canonicalDir = dir.getCanonicalFile();
+            final String path = canonicalDir.getPath();
 
-            if (!((dir.exists() || dir.mkdirs()) && dir.isDirectory())) {
+            if (!((canonicalDir.exists() || canonicalDir.mkdirs()) && canonicalDir.isDirectory())) {
                 throw new IOException("Cannot create directory: " + path);
             }
 
             return path;
         }
         catch (IOException e) {
-            throw new IllegalStateException("Cannot create or access temp directory at " + path, e);
+            throw new IllegalStateException("Cannot create or access temp directory at " + dir.getAbsolutePath(), e);
         }
     }
 


### PR DESCRIPTION
Fix for the Java side of the 2.8.0 bug.

I confirm that my tests were passing because the "real" root directory was still .../.couchbase.  The code that fixes the (Android) problem, then, looks for the directory .../.couchbase/.couchbase.  Since it will never find such a directory, I do not believe that the problem has gotten any worse.

Changes are as follows:

- **CouchbaseLiteInternal.java: DEFAULT_ROOT_DIR_NAME is empty:**  This is the main issue.  Changing this effectively fixes the problem.  Everything else is a consequence of changing this.

- **CouchbaseLiteInternal.java: verifyDir:** "".exists() always returns `false`.  Have to get the canonical file before checking for existence.

- **DatabaseTest.java: testReOpenExistingDb:** verify that the default database path no longer ends with ".couchbase"

- **BaseTest.java: tearDownBaseTestClass:** One of the main reasons for adding the .couchbase namespace was so that it was possible to clean up after running automated tests.  Since they now run in the current directory, there's now way to do that safely, anymore.