### PR TITLE
Only call setC4TmpDirPath once

### DIFF
--- a/android/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
+++ b/android/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
@@ -156,16 +156,7 @@ public final class CouchbaseLiteInternal {
 
     public static void setupDirectories(@Nullable String rootDirPath) {
         requireInit("Can't set root directory");
-
-        synchronized (LOCK) {
-            // remember the current tmp dir
-            final String tmpPath = tmpDirPath;
-
-            initDirectories(rootDirPath);
-
-            // if the temp dir has changed, tell C4Base
-            if (!Objects.equals(tmpPath, tmpDirPath)) { setC4TmpDirPath(); }
-        }
+        synchronized (LOCK) { initDirectories(rootDirPath); }
     }
 
     @NonNull

--- a/common/test/java/com/couchbase/lite/DatabaseTest.java
+++ b/common/test/java/com/couchbase/lite/DatabaseTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.couchbase.lite.internal.CouchbaseLiteInternal;
 import com.couchbase.lite.internal.utils.FileUtils;
 import com.couchbase.lite.internal.utils.Report;
 import com.couchbase.lite.internal.utils.TestUtils;
@@ -1260,6 +1261,14 @@ public class DatabaseTest extends BaseDbTest {
         // 3. delete by previously retrieved document
         baseTestDb.delete(doc);
         assertNull(baseTestDb.getDocument("doc"));
+    }
+
+    // At one point, setupDirectories called c4_setTmpDir.
+    // That function will now throw, if called twice.
+    // Verify that the call does not throw.
+    @Test
+    public void testSetupDirectories() {
+        CouchbaseLiteInternal.setupDirectories(CouchbaseLiteInternal.getTmpDirectoryPath() + "/foo");
     }
 
     // The following four tests verify, explicitly, the code that


### PR DESCRIPTION
The new version of c4_setTmpDir should (by my request!) only be called once.

This fix has the platform code calling it only at initialization.