### PR TITLE
Check heartbeat bounds

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractReplicatorConfiguration.java
+++ b/common/main/java/com/couchbase/lite/AbstractReplicatorConfiguration.java
@@ -21,6 +21,9 @@ import android.support.annotation.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.internal.Util;
 
 import com.couchbase.lite.internal.core.C4Replicator;
 import com.couchbase.lite.internal.core.CBLVersion;
@@ -258,7 +261,8 @@ public abstract class AbstractReplicatorConfiguration {
      * Set the heartbeat interval, in seconds.
      */
     public final ReplicatorConfiguration setHeartbeat(long heartbeat) {
-        this.heartbeat = Preconditions.assertPositive(heartbeat, "heartbeat");
+        Util.checkDuration("heartbeat", heartbeat, TimeUnit.SECONDS);
+        this.heartbeat = heartbeat;
         return getReplicatorConfiguration();
     }
 


### PR DESCRIPTION
OkHttp explodes trying to set a ping interval > MAX_INT.  The explosion doesn't happen until the replicator actually tries to connect.

This code uses the same check that OkHttp uses, guaranteeing that if you can set the heartbeat in the config, it will work when the replicator connects.