### PR TITLE
v2.8.6: Android API 30 compatibility

### DIFF
--- a/android/debug/AndroidManifest.xml
+++ b/android/debug/AndroidManifest.xml
@@ -17,7 +17,7 @@ limitations under the License.
 -->
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.couchbase.lite.test"
+    package="com.couchbase.lite"
     >
 
     <uses-permission android:name="android.permission.INTERNET" />

--- a/android/main/AndroidManifest.xml
+++ b/android/main/AndroidManifest.xml
@@ -15,14 +15,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.couchbase.lite">
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.couchbase.lite"
+    >
 
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
-    <application android:label="@string/app_name"></application>
+    <application
+        android:label="@string/app_name"
+        />
 </manifest>

--- a/android/main/java/com/couchbase/lite/internal/AndroidExecutionService.java
+++ b/android/main/java/com/couchbase/lite/internal/AndroidExecutionService.java
@@ -15,16 +15,15 @@
 //
 package com.couchbase.lite.internal;
 
-import android.os.AsyncTask;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ThreadPoolExecutor;
 
 import com.couchbase.lite.LogDomain;
+import com.couchbase.lite.internal.exec.CBLExecutor;
 import com.couchbase.lite.internal.support.Log;
 import com.couchbase.lite.internal.utils.Preconditions;
 
@@ -63,7 +62,7 @@ public final class AndroidExecutionService extends AbstractExecutionService {
     // Constructor
     //---------------------------------------------
     public AndroidExecutionService() {
-        super((ThreadPoolExecutor) AsyncTask.THREAD_POOL_EXECUTOR);
+        super(new CBLExecutor());
         mainHandler = new Handler(Looper.getMainLooper());
         mainThreadExecutor = mainHandler::post;
     }

--- a/common/main/java/com/couchbase/lite/internal/exec/CBLExecutor.java
+++ b/common/main/java/com/couchbase/lite/internal/exec/CBLExecutor.java
@@ -1,0 +1,66 @@
+//
+// Copyright (c) 2021 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package com.couchbase.lite.internal.exec;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.couchbase.lite.LogDomain;
+import com.couchbase.lite.internal.AbstractExecutionService;
+import com.couchbase.lite.internal.support.Log;
+
+
+// ??? Kludge to keep changes minimal, until v 3.x
+public class CBLExecutor extends ThreadPoolExecutor {
+    private final String name;
+
+    public CBLExecutor() {
+        this("CBL Worker", 2, 6, new LinkedBlockingQueue<>(AbstractExecutionService.MIN_CAPACITY * 2));
+    }
+
+    @VisibleForTesting
+    public CBLExecutor(@NonNull String name, int min, int max, @NonNull BlockingQueue<Runnable> workQueue) {
+        super(min, max,
+            30, TimeUnit.SECONDS,        // unused threads die after 30 sec
+            workQueue,
+            new ThreadFactory() {        // thread factory that gives our threads nice recognizable names
+                private final String threadName = name + " #";
+                private final AtomicInteger threadId = new AtomicInteger(0);
+
+                public Thread newThread(@NonNull Runnable r) {
+                    final Thread thread = new Thread(r, threadName + threadId.incrementAndGet());
+                    thread.setUncaughtExceptionHandler((t, e) ->
+                        Log.w(LogDomain.DATABASE, "Uncaught exception on thread" + thread.getName(), e));
+                    return thread;
+                }
+            });
+
+        allowCoreThreadTimeOut(true);
+
+        this.name = name;
+    }
+
+    @NonNull
+    @Override
+    public String toString() { return "CBLExecutor(" + name + "}"; }
+}


### PR DESCRIPTION
The Android cert verification process calls, by reflection, a completely non-standard method.

I've added that method and refactored the standard method, so that both use the same code to either defer to the default, or to use the CBL checks.

Also, AsyncTasks have been deprecated in v30.  The Executor that powered them is no longer useful for CBL.  I've replaced it with a small, internal execution service.

Any other changes are just things to get the test code to run