### PR TITLE
Fixes couchbase/couchbase-lite-java-ce-root#17

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/common/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -1430,7 +1430,13 @@ abstract class AbstractDatabase {
         try {
             // Unless the remote revision is being used as-is, we need a new revision:
             if (resolvedDoc != remoteDoc) {
-                if ((resolvedDoc != null) && !resolvedDoc.isDeleted()) { mergedBody = resolvedDoc.encode(); }
+                if ((resolvedDoc != null) && !resolvedDoc.isDeleted())
+                {
+                    mergedBody = resolvedDoc.encode();
+                    if (C4Document.dictContainsBlobs(mergedBody, sharedKeys.getFLSharedKeys())) {
+                        mergedFlags |= C4Constants.RevisionFlags.HAS_ATTACHMENTS;
+                    }
+                }
                 else {
                     mergedFlags |= C4Constants.RevisionFlags.DELETED;
                     final FLEncoder enc = getSharedFleeceEncoder();


### PR DESCRIPTION
add HAS_ATTACHMENTS flags in saveResolvedDocument.
Without it, the current revision lost attachment.

Fixes couchbase/couchbase-lite-java-ce-root#17