### PR TITLE
Fix/cbl 2344

### DIFF
--- a/android/androidTest/java/com/couchbase/lite/PlatformBaseTest.java
+++ b/android/androidTest/java/com/couchbase/lite/PlatformBaseTest.java
@@ -19,6 +19,7 @@ import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.test.InstrumentationRegistry;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,6 +31,7 @@ import com.couchbase.lite.internal.CouchbaseLiteInternal;
 import com.couchbase.lite.internal.exec.AbstractExecutionService;
 import com.couchbase.lite.internal.exec.ExecutionService;
 import com.couchbase.lite.internal.support.Log;
+import com.couchbase.lite.internal.utils.FileUtils;
 
 
 /**
@@ -37,6 +39,7 @@ import com.couchbase.lite.internal.support.Log;
  */
 public abstract class PlatformBaseTest implements PlatformTest {
     public static final String PRODUCT = "Android";
+    public static final String SCRATCH_DIR_NAME = "cbl_test_scratch";
 
     public static final String LEGAL_FILE_NAME_CHARS = "`~@#$%^&()_+{}][=-.,;'12345ABCDEabcde";
 
@@ -55,21 +58,25 @@ public abstract class PlatformBaseTest implements PlatformTest {
             android.util.Log.w("TEST", "Failed adding to chatty whitelist");
         }
     }
-
     @Override
-    public void setupPlatform() {
+    public final void setupPlatform() {
         final ConsoleLogger console = Database.log.getConsole();
         console.setLevel(LogLevel.DEBUG);
         console.setDomains(LogDomain.ALL_DOMAINS);
     }
 
     @Override
-    public void reloadStandardErrorMessages() {
+    public final File getTmpDir() {
+        return FileUtils.verifyDir(InstrumentationRegistry.getTargetContext().getExternalFilesDir(SCRATCH_DIR_NAME));
+    }
+
+    @Override
+    public final void reloadStandardErrorMessages() {
         Log.initLogging(CouchbaseLiteInternal.loadErrorMessages(InstrumentationRegistry.getTargetContext()));
     }
 
     @Override
-    public AbstractExecutionService getExecutionService(ThreadPoolExecutor executor) {
+    public final AbstractExecutionService getExecutionService(ThreadPoolExecutor executor) {
         return new AndroidExecutionService(executor);
     }
 

--- a/android/main/java/com/couchbase/lite/CouchbaseLite.java
+++ b/android/main/java/com/couchbase/lite/CouchbaseLite.java
@@ -24,16 +24,45 @@ import com.couchbase.lite.internal.CouchbaseLiteInternal;
 
 
 public final class CouchbaseLite {
-    // Singleton
+    // Utility class
     private CouchbaseLite() {}
 
     /**
      * Initialize CouchbaseLite library. This method MUST be called before using CouchbaseLite.
+     * <p>
+     * This method expects <code>Context.getExternalFilesDir(...)</code> to return a non-null value
+     * and will throw an <code>IllegalStateException</code> if it does not.
+     * On the rare device on which that occurs, you may want to do something like this:
+     * <code>
+     * try { init(); }
+     * catch (IllegalStateException e) {
+     *     final File rootDir = ctxt.getFilesDir();
+     *     init(false, rootDIr, new File(rootDir, "cbl_scratch"));
+     * }
+     * </code>
+     *
+     * @param ctxt the ApplicationContext.
+     * @throws IllegalStateException on initialization failure
      */
     public static void init(@NonNull Context ctxt) { init(ctxt, BuildConfig.CBL_DEBUG); }
 
     /**
      * Initialize CouchbaseLite library. This method MUST be called before using CouchbaseLite.
+     * <p>
+     * This method expects <code>Context.getExternalFilesDir(...)</code> to return a non-null value
+     * and will throw an <code>IllegalStateException</code> if it does not.
+     * On the rare device on which that occurs, you may want to do something like this:
+     * <code>
+     * try { init(); }
+     * catch (IllegalStateException e) {
+     *     final File rootDir = ctxt.getFilesDir();
+     *     init(false, rootDIr, new File(rootDir, "cbl_scratch"));
+     * }
+     * </code>
+     *
+     * @param ctxt the ApplicationContext.
+     * @param debug true to enable debugging
+     * @throws IllegalStateException on initialization failure
      */
     public static void init(@NonNull Context ctxt, boolean debug) {
         init(ctxt, debug, ctxt.getFilesDir(), ctxt.getExternalFilesDir(CouchbaseLiteInternal.SCRATCH_DIR_NAME));
@@ -45,11 +74,12 @@ public final class CouchbaseLite {
      * Use this version with great caution.
      *
      * @param ctxt       Application context
-     * @param debug      true if debugging
-     * @param rootDbDir  default directory for databases
+     * @param debug      to enable debugging
+     * @param rootDir    default directory for databases
      * @param scratchDir scratch directory for SQLite
+     * @throws IllegalStateException on initialization failure
      */
-    public static void init(@NonNull Context ctxt, boolean debug, @NonNull File rootDbDir, @NonNull File scratchDir) {
-        CouchbaseLiteInternal.init(new MValueDelegate(), debug, rootDbDir, scratchDir, ctxt);
+    public static void init(@NonNull Context ctxt, boolean debug, @NonNull File rootDir, @NonNull File scratchDir) {
+        CouchbaseLiteInternal.init(new MValueDelegate(), debug, rootDir, scratchDir, ctxt);
     }
 }

--- a/android/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
+++ b/android/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
@@ -72,7 +72,6 @@ public final class CouchbaseLiteInternal {
     private static volatile boolean debugging;
 
     private static volatile File rootDir;
-    private static volatile File scratchDir;
 
     /**
      * Initialize CouchbaseLite library. This method MUST be called before using CouchbaseLite.
@@ -92,8 +91,7 @@ public final class CouchbaseLiteInternal {
 
         Preconditions.assertNotNull(mValueDelegate, "mValueDelegate");
 
-        CouchbaseLiteInternal.rootDir = Preconditions.assertNotNull(FileUtils.verifyDir(rootDir), "rootDir");
-        CouchbaseLiteInternal.scratchDir = Preconditions.assertNotNull(FileUtils.verifyDir(scratchDir), "scratchDir");
+        CouchbaseLiteInternal.rootDir = FileUtils.verifyDir(rootDir);
 
         System.loadLibrary(LITECORE_JNI_LIBRARY);
 
@@ -101,7 +99,7 @@ public final class CouchbaseLiteInternal {
 
         Log.initLogging(loadErrorMessages(ctxt));
 
-        setC4TmpDirPath(scratchDir);
+        setC4TmpDirPath(FileUtils.verifyDir(scratchDir));
 
         MValue.registerDelegate(mValueDelegate);
     }
@@ -149,15 +147,6 @@ public final class CouchbaseLiteInternal {
 
     @NonNull
     public static String getRootDirPath() { return rootDir.getAbsolutePath(); }
-
-    @NonNull
-    public static File getScratchDir() {
-        requireInit("Can't create Scratch path");
-        return scratchDir;
-    }
-
-    @NonNull
-    public static String getScratchDirPath() { return scratchDir.getAbsolutePath(); }
 
     @VisibleForTesting
     public static void reset(boolean state) { INITIALIZED.set(state); }

--- a/common/main/cpp/com_couchbase_lite_internal_core_C4BlobReadStream.h
+++ b/common/main/cpp/com_couchbase_lite_internal_core_C4BlobReadStream.h
@@ -7,13 +7,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-/*
- * Class:     com_couchbase_lite_internal_core_C4BlobReadStream
- * Method:    read
- * Signature: (JJ)[B
- */
-JNIEXPORT jbyteArray JNICALL Java_com_couchbase_lite_internal_core_C4BlobReadStream_read__JJ
-  (JNIEnv *, jclass, jlong, jlong);
 
 /*
  * Class:     com_couchbase_lite_internal_core_C4BlobReadStream

--- a/common/main/cpp/native_c4blobstore.cc
+++ b/common/main/cpp/native_c4blobstore.cc
@@ -269,27 +269,6 @@ Java_com_couchbase_lite_internal_core_C4BlobStore_freeStore(JNIEnv *env, jclass 
 /*
  * Class:     com_couchbase_lite_internal_core_C4BlobReadStream
  * Method:    read
- * Signature: (JJ)[B
- */
-JNIEXPORT jbyteArray JNICALL
-Java_com_couchbase_lite_internal_core_C4BlobReadStream_read__JJ(
-        JNIEnv *env,
-        jclass ignore,
-        jlong jstream,
-        jlong jsize) {
-    C4Error error = {};
-    char *buff = new char[(size_t) jsize];
-    size_t read = c4stream_read((C4ReadStream *) jstream,
-                                buff,
-                                (size_t) jsize,
-                                &error);
-    C4Slice s = {buff, read};
-    return toJByteArray(env, s);
-}
-
-/*
- * Class:     com_couchbase_lite_internal_core_C4BlobReadStream
- * Method:    read
  * Signature: (J[BIJ)I
  */
 JNIEXPORT jint JNICALL
@@ -308,10 +287,7 @@ Java_com_couchbase_lite_internal_core_C4BlobReadStream_read__J_3BIJ(
 
     jbyte *buff = env->GetByteArrayElements(buffer, nullptr);
 
-    size_t read = c4stream_read((C4ReadStream *) jstream,
-                                buff + offset,
-                                (size_t) jsize,
-                                &error);
+    size_t read = c4stream_read((C4ReadStream *) jstream, buff + offset, (size_t) jsize, &error);
 
     env->ReleaseByteArrayElements(buffer, buff, 0);
 

--- a/common/main/java/com/couchbase/lite/Blob.java
+++ b/common/main/java/com/couchbase/lite/Blob.java
@@ -144,10 +144,15 @@ public final class Blob implements FLEncodable {
         public int read() throws IOException {
             if (key == null) { throw new IOException("Stream is closed"); }
 
+            // Jens says:
+            // LiteCore’s stream API is blocking.
+            // It always returns one or more bytes, until you hit EOF.
+            // (It’s always reading from the filesystem, so the latency should be pretty low.)
             if (read(buf, 0, buf.length) <= 0) { return -1; }
 
             final int b = (((int) buf[0]) & 0xff);
             buf[0] = 0;
+
             return b;
         }
 

--- a/common/main/java/com/couchbase/lite/ChangeListenerToken.java
+++ b/common/main/java/com/couchbase/lite/ChangeListenerToken.java
@@ -42,7 +42,11 @@ class ChangeListenerToken<T> implements ListenerToken {
 
     public void setKey(@Nullable Object key) { this.key = key; }
 
-    void postChange(@Nullable T change) {
+    @NonNull
+    @Override
+    public String toString() { return "ChangeListenerToken{" + key + ", " + listener + ", " + executor + "}"; }
+
+    void postChange(@NonNull T change) {
         final Executor exec = (executor != null)
             ? executor
             : CouchbaseLiteInternal.getExecutionService().getDefaultExecutor();

--- a/common/main/java/com/couchbase/lite/ChangeNotifier.java
+++ b/common/main/java/com/couchbase/lite/ChangeNotifier.java
@@ -34,7 +34,6 @@ class ChangeNotifier<T> {
     @NonNull
     ChangeListenerToken<T> addChangeListener(@Nullable Executor executor, @NonNull ChangeListener<T> listener) {
         Preconditions.assertNotNull(listener, "listener");
-
         synchronized (lock) {
             final ChangeListenerToken<T> token = new ChangeListenerToken<>(executor, listener);
             listenerTokens.add(token);
@@ -45,18 +44,16 @@ class ChangeNotifier<T> {
     @SuppressWarnings("SuspiciousMethodCalls")
     int removeChangeListener(@NonNull ListenerToken token) {
         Preconditions.assertNotNull(token, "token");
-
         synchronized (lock) {
             listenerTokens.remove(token);
             return listenerTokens.size();
         }
     }
 
-    void postChange(T change) {
-        if (change == null) { throw new IllegalArgumentException("change is null"); }
-
+    void postChange(@NonNull T change) {
+        Preconditions.assertNotNull(change, "change");
         synchronized (lock) {
-            for (ChangeListenerToken<T> token : listenerTokens) { token.postChange(change); }
+            for (ChangeListenerToken<T> token: listenerTokens) { token.postChange(change); }
         }
     }
 }

--- a/common/main/java/com/couchbase/lite/DataSource.java
+++ b/common/main/java/com/couchbase/lite/DataSource.java
@@ -91,13 +91,6 @@ public class DataSource {
     @NonNull
     Object getSource() { return this.source; }
 
-    @Nullable
-    String getColumnName() {
-        if (alias != null) { return alias; }
-
-        return (!(source instanceof Database)) ? null : ((Database) source).getName();
-    }
-
     @NonNull
     Map<String, Object> asJSON() {
         final Map<String, Object> json = new HashMap<>();

--- a/common/main/java/com/couchbase/lite/LiveQuery.java
+++ b/common/main/java/com/couchbase/lite/LiveQuery.java
@@ -43,7 +43,7 @@ final class LiveQuery implements DatabaseChangeListener {
     private static final LogDomain DOMAIN = LogDomain.QUERY;
 
     @VisibleForTesting
-    static final long LIVE_QUERY_UPDATE_INTERVAL_MS = 200; // 0.2sec (200ms)
+    static final long UPDATE_INTERVAL_MS = 200; // 0.2sec (200ms)
 
     @VisibleForTesting
     enum State {STOPPED, STARTED, SCHEDULED}
@@ -94,7 +94,7 @@ final class LiveQuery implements DatabaseChangeListener {
     //---------------------------------------------
 
     @Override
-    public void changed(@NonNull DatabaseChange change) { update(LIVE_QUERY_UPDATE_INTERVAL_MS); }
+    public void changed(@NonNull DatabaseChange change) { update(UPDATE_INTERVAL_MS); }
 
     //---------------------------------------------
     // package

--- a/common/main/java/com/couchbase/lite/LiveQuery.java
+++ b/common/main/java/com/couchbase/lite/LiveQuery.java
@@ -87,7 +87,7 @@ final class LiveQuery implements DatabaseChangeListener {
 
     @NonNull
     @Override
-    public String toString() { return "LiveQuery{" + ClassUtils.objId(this) + "," + query.toString() + "}"; }
+    public String toString() { return "LiveQuery{" + ClassUtils.objId(this) + "," + query + "}"; }
 
     //---------------------------------------------
     // Implementation of DatabaseChangeListener
@@ -120,51 +120,43 @@ final class LiveQuery implements DatabaseChangeListener {
      * Starts observing database changes and reports changes in the query result.
      */
     void start(boolean shouldClearResults) {
-        final AbstractDatabase db = Preconditions.assertNotNull(query.getDatabase(), "Live query database");
+        final boolean started;
 
-        // can't have the db closing while a query is starting.
+        final AbstractDatabase db = Preconditions.assertNotNull(query.getDatabase(), "Live query database");
         synchronized (db.getDbLock()) {
+            // can't have the db closing while a query is starting.
             db.mustBeOpen();
 
-            if (state.compareAndSet(State.STOPPED, State.STARTED)) {
+            started = state.compareAndSet(State.STOPPED, State.STARTED);
+
+            if (started) {
                 synchronized (lock) { dbListenerToken = db.addActiveLiveQuery(this); }
             }
-            else {
-                // Here if the live query was already running.  This can happen in two ways:
-                // 1) when adding another listener
-                // 2) when the query parameters have changed.
-                // In either case we probably want to kick off a new query.
-                // In the latter case the current query results are irrelevant and need to be cleared.
-                if (shouldClearResults) {
-                    synchronized (lock) { closePrevResults(); }
-                }
-            }
         }
+
+        // There are two ways that the query might already be running:
+        // 1) when adding another listener
+        // 2) when the query parameters have changed.
+        // In either case we should kick off a new query.
+        // In the latter case, though, the current query results are irrelevant and need to be cleared.
+        if ((!started) && (shouldClearResults)) { closePrevResults(); }
+
         update(0);
     }
 
     void stop() {
         final AbstractDatabase db = query.getDatabase();
         if (db == null) {
-            if (State.STOPPED != state.get()) {
-                Log.w(LogDomain.DATABASE, "Null db when stopping LiveQuery");
-            }
+            if (State.STOPPED != state.get()) { Log.w(LogDomain.DATABASE, "Null db when stopping LiveQuery"); }
             return;
         }
 
         synchronized (db.getDbLock()) {
             if (State.STOPPED == state.getAndSet(State.STOPPED)) { return; }
-
-            synchronized (lock) {
-                closePrevResults();
-
-                final ListenerToken token = dbListenerToken;
-                dbListenerToken = null;
-                if (token == null) { return; }
-
-                db.removeActiveLiveQuery(this, token);
-            }
+            closeDbListener(db);
         }
+
+        closePrevResults();
     }
 
     @NonNull
@@ -181,50 +173,67 @@ final class LiveQuery implements DatabaseChangeListener {
         db.scheduleOnQueryExecutor(this::refreshResults, delay);
     }
 
-    // Runs on the query.database.queryExecutor
-    // Assumes that call to `previousResults.refresh` is safe, even if previousResults has been freed.
+    // Runs on the query.database.queryExecutor which is single threaded
+    // CAUTION: This is very sensitive code!
+    // Several bugs have been discovered in this method.
     @SuppressWarnings("PMD.CloseResource")
     private void refreshResults() {
-        try {
-            final ResultSet prevResults;
-            synchronized (lock) {
-                if (!state.compareAndSet(State.SCHEDULED, State.STARTED)) { return; }
-                prevResults = previousResults;
-            }
+        final ResultSet prevResults;
+        synchronized (lock) { prevResults = previousResults; }
 
-            final ResultSet newResults;
-            if (prevResults == null) { newResults = query.execute(); }
-            else {
-                newResults = prevResults.refresh();
-                previousResults.forceClose();
-            }
-            Log.i(DOMAIN, "LiveQuery refresh: %s > %s", prevResults, newResults);
+        if (!state.compareAndSet(State.SCHEDULED, State.STARTED)) { return; }
 
-            if (newResults == null) { return; }
-
-            newResults.retain();
-
-            boolean update = false;
-            synchronized (lock) {
-                if (state.get() != State.STOPPED) {
-                    previousResults = newResults;
-                    update = true;
-                }
-            }
-
-            // Listeners may be notified even after the LiveQuery has been stopped.
-            if (update) { changeNotifier.postChange(new QueryChange(query, newResults, null)); }
-        }
+        // Assumes that call to `prevResults.refresh` is safe, even if it has been closed/freed.
+        final ResultSet newResults;
+        try { newResults = (prevResults == null) ? query.execute() : prevResults.refresh(); }
         catch (CouchbaseLiteException err) {
             changeNotifier.postChange(new QueryChange(query, null, err));
+            return;
         }
+
+        Log.i(DOMAIN, "LiveQuery refresh: %s ==> %s", prevResults, newResults);
+
+        // Refresh returns null if there have been no changes
+        if (newResults == null) { return; }
+
+        if (prevResults != null) { prevResults.release(); }
+
+        // There is a race here: if client code stops
+        // the live query between this line and the next
+        // we will leak a result set.  Since the LiveQuery
+        // itself is likely to be GCed soon, perhaps that
+        // isn't such a big deal.
+        if (state.get() == State.STOPPED) { return; }
+
+        // We need this result set.  Don't let the user close it.
+        newResults.retain();
+        synchronized (lock) { previousResults = newResults; }
+
+        // Listeners may be notified even after the LiveQuery has been stopped.
+        // This call to postChange will cause a call to LiveQuery.changed,
+        // if there is anybody still listening to the query.
+        changeNotifier.postChange(new QueryChange(query, newResults, null));
     }
 
-    @GuardedBy("lock")
+    @SuppressWarnings("PMD.CloseResource")
     private void closePrevResults() {
-        if (previousResults == null) { return; }
-        previousResults.forceClose();
-        previousResults = null;
+        final ResultSet prevResults;
+        synchronized (lock) {
+            prevResults = previousResults;
+            previousResults = null;
+        }
+
+        if (prevResults != null) { prevResults.release(); }
+    }
+
+    private void closeDbListener(AbstractDatabase db) {
+        final ListenerToken token;
+        synchronized (lock) {
+            token = dbListenerToken;
+            dbListenerToken = null;
+        }
+        if (token == null) { return; }
+        db.removeActiveLiveQuery(this, token);
     }
 }
 

--- a/common/main/java/com/couchbase/lite/internal/core/C4Base.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Base.java
@@ -16,6 +16,7 @@
 package com.couchbase.lite.internal.core;
 
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.couchbase.lite.LiteCoreException;
@@ -30,7 +31,7 @@ public final class C4Base {
 
     public static native void debug(boolean debugging);
 
-    public static native void setTempDir(String tempDir) throws LiteCoreException;
+    public static native void setTempDir(@NonNull String tempDir) throws LiteCoreException;
 
     @Nullable
     public static native String getMessage(int domain, int code, int internalInfo);

--- a/common/main/java/com/couchbase/lite/internal/core/C4BlobReadStream.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4BlobReadStream.java
@@ -16,7 +16,6 @@
 package com.couchbase.lite.internal.core;
 
 import android.support.annotation.CallSuper;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.couchbase.lite.LiteCoreException;
@@ -43,9 +42,6 @@ public class C4BlobReadStream extends C4NativePeer {
      *
      * @param maxBytesToRead The maximum number of bytes to read to the buffer
      */
-    @NonNull
-    public byte[] read(long maxBytesToRead) throws LiteCoreException { return read(getPeer(), maxBytesToRead); }
-
     public int read(byte[] b, int offset, long maxBytesToRead) throws LiteCoreException {
         return read(getPeer(), b, offset, maxBytesToRead);
     }
@@ -87,9 +83,6 @@ public class C4BlobReadStream extends C4NativePeer {
     //-------------------------------------------------------------------------
     // native methods
     //-------------------------------------------------------------------------
-    @NonNull
-    private static native byte[] read(long peer, long maxBytesToRead) throws LiteCoreException;
-
     private static native int read(long peer, byte[] b, int offset, long maxBytesToRead) throws LiteCoreException;
 
     private static native long getLength(long peer) throws LiteCoreException;

--- a/common/main/java/com/couchbase/lite/internal/utils/FileUtils.java
+++ b/common/main/java/com/couchbase/lite/internal/utils/FileUtils.java
@@ -16,6 +16,7 @@
 package com.couchbase.lite.internal.utils;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,18 +33,15 @@ public final class FileUtils {
     private FileUtils() { }
 
     @NonNull
-    public static File verifyDir(@NonNull String dirPath) {
-        Preconditions.assertNotNull(dirPath, "dirPath");
-        return verifyDir(new File(dirPath));
+    public static File verifyDir(@Nullable String dirPath) {
+        return verifyDir(new File(Preconditions.assertNotNull(dirPath, "directory path")));
     }
 
     @NonNull
-    public static File verifyDir(@NonNull File dir) {
-        Preconditions.assertNotNull(dir, "directory");
-
+    public static File verifyDir(@Nullable File dir) {
         IOException err = null;
         try {
-            dir = dir.getCanonicalFile();
+            dir = Preconditions.assertNotNull(dir, "directory").getCanonicalFile();
             if ((dir.exists() && dir.isDirectory()) || dir.mkdirs()) { return dir; }
         }
         catch (IOException e) { err = e; }
@@ -97,6 +95,12 @@ public final class FileUtils {
             }
         }
         return fileOrDirectory.setReadable(readable) && fileOrDirectory.setWritable(writable);
+    }
+
+    @NonNull
+    public static File getCurrentDirectory() {
+        try { return new File("").getCanonicalFile(); }
+        catch (IOException e) { throw new IllegalStateException("Can't open current directory", e); }
     }
 
     private static boolean deleteRecursive(File fileOrDirectory) {

--- a/common/test/java/com/couchbase/lite/BaseTest.java
+++ b/common/test/java/com/couchbase/lite/BaseTest.java
@@ -127,8 +127,7 @@ public abstract class BaseTest extends PlatformBaseTest {
 
     protected final String getScratchDirectoryPath(@NonNull String name) {
         try {
-            String path = FileUtils.verifyDir(new File(CouchbaseLiteInternal.getScratchDir().getCanonicalFile(), name))
-                .getCanonicalPath();
+            String path = FileUtils.verifyDir(new File(getTmpDir(), name)).getCanonicalPath();
             SCRATCH_DIRS.add(path);
             return path;
         }

--- a/common/test/java/com/couchbase/lite/BlobTest.java
+++ b/common/test/java/com/couchbase/lite/BlobTest.java
@@ -441,6 +441,23 @@ public class BlobTest extends BaseDbTest {
         assertNull(baseTestDb.getBlob(props));
     }
 
+    // https://issues.couchbase.com/browse/CBL-2320
+    @Test
+    public void testBlobStreamReadNotNegative() throws CouchbaseLiteException, IOException {
+        MutableDocument mDoc = new MutableDocument("blobDoc");
+        mDoc.setBlob(
+            "blob",
+            new Blob("application/octet-stream", new byte[] {-1, (byte) 255, (byte) 0xf0, (byte) 0xa0}));
+        saveDocInBaseTestDb(mDoc);
+
+        InputStream blobStream = baseTestDb.getDocument("blobDoc").getBlob("blob").getContentStream();
+
+        assertEquals(255, blobStream.read());
+        assertEquals(255, blobStream.read());
+        assertEquals(0xf0, blobStream.read());
+        assertEquals(0xa0, blobStream.read());
+    }
+
     private Map<String, Object> getPropsForSavedBlob() {
         Blob blob = makeBlob();
         baseTestDb.saveBlob(blob);

--- a/common/test/java/com/couchbase/lite/DatabaseTest.java
+++ b/common/test/java/com/couchbase/lite/DatabaseTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/common/test/java/com/couchbase/lite/PlatformTest.java
+++ b/common/test/java/com/couchbase/lite/PlatformTest.java
@@ -18,6 +18,7 @@ package com.couchbase.lite;
 
 import android.support.annotation.NonNull;
 
+import java.io.File;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import com.couchbase.lite.internal.exec.AbstractExecutionService;
@@ -40,6 +41,9 @@ public interface PlatformTest {
 
     /* initialize the platform */
     void setupPlatform();
+
+    /* get a scratch directory */
+    File getTmpDir();
 
     /* Reload the cross-platform error messages. */
     void reloadStandardErrorMessages();

--- a/common/test/java/com/couchbase/lite/internal/core/C4BlobStoreTest.java
+++ b/common/test/java/com/couchbase/lite/internal/core/C4BlobStoreTest.java
@@ -179,6 +179,7 @@ public class C4BlobStoreTest extends C4BaseTest {
     @Test
     public void testReadBlobWithStream() throws LiteCoreException {
         String blob = "This is a blob to store in the store!";
+        byte[] buf = new byte[6];
 
         // Add blob to the store:
         try (C4BlobKey key = blobStore.create(blob.getBytes(StandardCharsets.UTF_8))) {
@@ -191,19 +192,17 @@ public class C4BlobStoreTest extends C4BaseTest {
 
                 // Read it back, 6 bytes at a time:
                 StringBuilder readBack = new StringBuilder();
-                byte[] bytes;
-                do {
-                    bytes = stream.read(6);
-                    readBack.append(new String(bytes));
+
+                int n;
+                while ((n = stream.read(buf, 0, buf.length)) > 0) {
+                    readBack.append(new String(buf, 0, n, StandardCharsets.UTF_8));
                 }
-                while (bytes.length == 6);
                 assertEquals(blob, readBack.toString());
 
                 // Try seeking:
                 stream.seek(10);
-                bytes = stream.read(4);
-                assertEquals(4, bytes.length);
-                assertEquals("blob", new String(bytes));
+                assertEquals(4, stream.read(buf, 0, 4));
+                assertEquals("blob", new String(buf, 0, 4, StandardCharsets.UTF_8));
             }
         }
     }
@@ -241,7 +240,8 @@ public class C4BlobStoreTest extends C4BaseTest {
                         Report.log(LogLevel.VERBOSE, "Reading line " + line + " at offset " + (18 * line));
                         String buf = String.format(Locale.ENGLISH, "This is line %03d.\n", line);
                         reader.seek(18 * line);
-                        byte[] readBuf = reader.read(18);
+                        byte[] readBuf = new byte[18];
+                        reader.read(readBuf, 0, 18);
                         assertNotNull(readBuf);
                         assertEquals(18, readBuf.length);
                         assertArrayEquals(readBuf, buf.getBytes(StandardCharsets.UTF_8));

--- a/java/main/java/com/couchbase/lite/CouchbaseLite.java
+++ b/java/main/java/com/couchbase/lite/CouchbaseLite.java
@@ -18,27 +18,38 @@ package com.couchbase.lite;
 import android.support.annotation.NonNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import com.couchbase.lite.internal.CouchbaseLiteInternal;
+import com.couchbase.lite.internal.utils.FileUtils;
 
 
 public final class CouchbaseLite {
-    // Singleton
-    private CouchbaseLite() {}
+    // Utility class
+    private CouchbaseLite() { }
 
     /**
      * Initialize CouchbaseLite library. This method MUST be called before using CouchbaseLite.
+     * <p>
+     * This method expects the current directory to be writeable
+     * and will throw an <code>IllegalStateException</code> if it is not.
+     * Use <code>init(boolean, File, File)</code> to specify alternative root and scratch directories.
+     *
+     * @throws IllegalStateException on initialization failure
      */
     public static void init() { init(false); }
 
     /**
      * Initialize CouchbaseLite library. This method MUST be called before using CouchbaseLite.
+     * <p>
+     * This method expects the current directory to be writeable
+     * and will throw an <code>IllegalStateException</code> if it is not.
+     * Use <code>init(boolean, File, File)</code> to specify alternative root and scratch directories.
+     *
+     * @param debug true if debugging
+     * @throws IllegalStateException on initialization failure
      */
     public static void init(boolean debug) {
-        final File curDir;
-        try { curDir = new File("").getCanonicalFile(); }
-        catch (IOException e) { throw new IllegalStateException("cannot find current directory", e); }
+        final File curDir = FileUtils.getCurrentDirectory();
         init(debug, curDir, new File(curDir, CouchbaseLiteInternal.SCRATCH_DIR_NAME));
     }
 
@@ -47,10 +58,11 @@ public final class CouchbaseLite {
      * This method allows specifying a root directory for CBL files.
      *
      * @param debug      true if debugging
-     * @param rootDbDir  default directory for databases
+     * @param rootDir    default directory for databases
      * @param scratchDir scratch directory for SQLite
+     * @throws IllegalStateException on initialization failure
      */
-    public static void init(boolean debug, @NonNull File rootDbDir, @NonNull File scratchDir) {
-        CouchbaseLiteInternal.init(new MValueDelegate(), debug, rootDbDir, scratchDir);
+    public static void init(boolean debug, @NonNull File rootDir, @NonNull File scratchDir) {
+        CouchbaseLiteInternal.init(new MValueDelegate(), debug, rootDir, scratchDir);
     }
 }

--- a/java/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
+++ b/java/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
@@ -60,7 +60,6 @@ public final class CouchbaseLiteInternal {
     private static volatile boolean debugging;
 
     private static volatile File rootDir;
-    private static volatile File scratchDir;
 
     public static void init(
         @NonNull MValue.Delegate mValueDelegate,
@@ -74,16 +73,16 @@ public final class CouchbaseLiteInternal {
 
         Preconditions.assertNotNull(mValueDelegate, "mValueDelegate");
 
-        CouchbaseLiteInternal.rootDir = Preconditions.assertNotNull(FileUtils.verifyDir(rootDir), "rootDir");
-        CouchbaseLiteInternal.scratchDir = Preconditions.assertNotNull(FileUtils.verifyDir(scratchDir), "scratchDir");
+        CouchbaseLiteInternal.rootDir = FileUtils.verifyDir(rootDir);
+        final File tmpDir = FileUtils.verifyDir(scratchDir);
 
-        NativeLibrary.load(scratchDir);
+        NativeLibrary.load(tmpDir);
 
         C4Base.debug(debugging);
 
         Log.initLogging(loadErrorMessages());
 
-        setC4TmpDirPath(scratchDir);
+        setC4TmpDirPath(tmpDir);
 
         MValue.registerDelegate(mValueDelegate);
     }
@@ -115,15 +114,6 @@ public final class CouchbaseLiteInternal {
 
     @NonNull
     public static String getRootDirPath() { return rootDir.getAbsolutePath(); }
-
-    @NonNull
-    public static File getScratchDir() {
-        requireInit("Can't create Scratch path");
-        return scratchDir;
-    }
-
-    @NonNull
-    public static String getScratchDirPath() { return scratchDir.getAbsolutePath(); }
 
     @VisibleForTesting
     public static void reset(boolean state) { INITIALIZED.set(state); }

--- a/java/test/java/com/couchbase/lite/PlatformBaseTest.java
+++ b/java/test/java/com/couchbase/lite/PlatformBaseTest.java
@@ -34,6 +34,7 @@ import com.couchbase.lite.internal.utils.FileUtils;
  */
 public abstract class PlatformBaseTest implements PlatformTest {
     public static final String PRODUCT = "Java";
+    public static final String SCRATCH_DIR_NAME = "cbl_test_scratch";
 
     public static final String LEGAL_FILE_NAME_CHARS = "`~@#$%&'()_+{}][=-.,;'ABCDEabcde";
 
@@ -43,10 +44,7 @@ public abstract class PlatformBaseTest implements PlatformTest {
     private static final int MAX_LOG_FILES = Integer.MAX_VALUE; // lots
 
     private static LogFileConfiguration logConfig;
-
     static { CouchbaseLite.init(true); }
-
-
     // set up the file logger...
     @Override
     public final void setupPlatform() {
@@ -72,6 +70,11 @@ public abstract class PlatformBaseTest implements PlatformTest {
         final ConsoleLogger consoleLogger = logger.getConsole();
         consoleLogger.setLevel(LogLevel.DEBUG);
         consoleLogger.setDomains(LogDomain.ALL_DOMAINS);
+    }
+
+    @Override
+    public final File getTmpDir() {
+        return FileUtils.verifyDir(new File(FileUtils.getCurrentDirectory(), SCRATCH_DIR_NAME));
     }
 
     @Override


### PR DESCRIPTION
CBL-2344: Live query only requeries once
CBL-2320: BlobInputStream returns negative values
Rework scratch directory handling (CBL-2346)
Fix BlobStream reader to use pre-allocated buffer.
Remove redundant JNI read method
Remove one more column-name remnant
Improve ResultSet release logic
Add some comments
    
