### PR TITLE
CBL-2344: A Live Query can stop updating

### DIFF
--- a/common/main/java/com/couchbase/lite/LiveQuery.java
+++ b/common/main/java/com/couchbase/lite/LiveQuery.java
@@ -194,19 +194,19 @@ final class LiveQuery implements DatabaseChangeListener {
 
             final ResultSet newResults;
             if (prevResults == null) { newResults = query.execute(); }
-            else {
-                newResults = prevResults.refresh();
-                previousResults.forceClose();
-            }
+            else { newResults = prevResults.refresh(); }
             Log.i(DOMAIN, "LiveQuery refresh: %s > %s", prevResults, newResults);
 
             if (newResults == null) { return; }
 
-            newResults.retain();
+            // ??? This could close a result set to which
+            // client code still has a reference.
+            if (prevResults != null) { prevResults.forceClose(); }
 
             boolean update = false;
             synchronized (lock) {
                 if (state.get() != State.STOPPED) {
+                    newResults.retain();
                     previousResults = newResults;
                     update = true;
                 }

--- a/common/main/java/com/couchbase/lite/ResultSet.java
+++ b/common/main/java/com/couchbase/lite/ResultSet.java
@@ -161,6 +161,19 @@ public class ResultSet implements Iterable<Result>, AutoCloseable {
     }
 
     //---------------------------------------------
+    // Protected access
+    //---------------------------------------------
+
+    @Override
+    protected void finalize() throws Throwable {
+        try {
+            // ??? Hail Mary: no lock, no synchronization...
+            if (c4enum != null) { c4enum.close(); }
+        }
+        finally { super.finalize(); }
+    }
+
+    //---------------------------------------------
     // Package level access
     //---------------------------------------------
 


### PR DESCRIPTION
If a live query runs and none of the changes in the database match the query, the query will never updated again.

This is the fix and a test for the fix.  Test fails before the change and succeeds after.

Also necessary re-implementation of a finalizer for ResultSet, in case client code does not properly close it.

Note that this change will be cherry-picked to both the android/release/lithium and the java/release/lithium branches.