### PR TITLE
Lithium fix for CBL-2389 and CBL-2395

### DIFF
--- a/common/main/java/com/couchbase/lite/FullTextIndexConfiguration.java
+++ b/common/main/java/com/couchbase/lite/FullTextIndexConfiguration.java
@@ -20,6 +20,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 
 
@@ -30,6 +31,8 @@ public class FullTextIndexConfiguration extends IndexConfiguration {
     public FullTextIndexConfiguration(@NonNull String... expressions) {
         super(IndexType.FULL_TEXT, Arrays.asList(expressions));
     }
+
+    FullTextIndexConfiguration(@NonNull List<String> expressions) { super(IndexType.FULL_TEXT, expressions); }
 
     /**
      * The language code which is an ISO-639 language such as "en", "fr", etc.

--- a/common/main/kotlin/com/couchbase/lite/CommonConfigurationFactories.kt
+++ b/common/main/kotlin/com/couchbase/lite/CommonConfigurationFactories.kt
@@ -18,9 +18,10 @@ package com.couchbase.lite
 
 val FullTextIndexConfigurationFactory: FullTextIndexConfiguration? = null
 fun FullTextIndexConfiguration?.create(
-    expression: String? = null
+    vararg expressions: String = emptyArray()
 ) = FullTextIndexConfiguration(
-    expression ?: this?.expressions?.get(0) ?: error("Must specify an expression")
+    if (!expressions.isEmpty()) expressions.asList() else this?.expressions
+        ?: error("Must specify an expression")
 )
 
 val ValueIndexConfigurationFactory: ValueIndexConfiguration? = null


### PR DESCRIPTION
This is fixes for:
CBL-2389 | Confirm LiteCore request for close, before connection is opened.
CBL-2395 | Kotlin FullTextIndexConfiguration?.create extension function does not support multiple expressions