### PR TITLE
CBL-2416: Comply with new API from N1QL spec

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractFunction.java
+++ b/common/main/java/com/couchbase/lite/AbstractFunction.java
@@ -138,7 +138,7 @@ abstract class AbstractFunction {
      * to the point (x, y) in Cartesian coordinates.
      */
     @NonNull
-    public static Expression atan2(@NonNull Expression x, @NonNull Expression y) {
+    public static Expression atan2(@NonNull Expression y, @NonNull Expression x) {
         return expr("ATAN2()", Preconditions.assertNotNull(y, "y"), Preconditions.assertNotNull(x, "x"));
     }
 

--- a/common/main/java/com/couchbase/lite/Expression.java
+++ b/common/main/java/com/couchbase/lite/Expression.java
@@ -276,7 +276,7 @@ public abstract class Expression {
     //---------------------------------------------
     static final class UnaryExpression extends Expression {
         @SuppressWarnings("PMD.FieldNamingConventions")
-        private enum OpType {Missing, NotMissing, NotNull, Null}
+        private enum OpType {Missing, NotMissing, NotNull, Null, Valued}
 
         @NonNull
         private final Expression operand;
@@ -310,6 +310,9 @@ public abstract class Expression {
 
                 case NotNull:
                     return Arrays.asList("IS NOT", opd, null);
+
+                case Valued:
+                    return Arrays.asList("IS VALUED", opd);
 
                 default:
                     Log.i(LogDomain.QUERY, "Unexpected unary type: " + type);
@@ -792,7 +795,9 @@ public abstract class Expression {
      * expression is null or missing.
      *
      * @return An IS NULL expression.
+     * @deprecated use Expression.isValued
      */
+    @Deprecated
     @SuppressWarnings("PMD.LinguisticNaming")
     @NonNull
     public Expression isNullOrMissing() {
@@ -805,9 +810,33 @@ public abstract class Expression {
      * expression is NOT null or missing.
      *
      * @return An IS NOT NULL expression.
+     * @deprecated use Expression.isValued
      */
+    @Deprecated
     @NonNull
     public Expression notNullOrMissing() { return negated(isNullOrMissing()); }
+
+    /**
+     * Creates an IS VALUED expression that returns true if the current
+     * expression is valued.
+     *
+     * @return An IS VALUED expression.
+     */
+    @SuppressWarnings("PMD.LinguisticNaming")
+    @NonNull
+    public Expression isValued() {
+        return new UnaryExpression(this, UnaryExpression.OpType.Valued);
+    }
+
+    /**
+     * Creates an NOT IS VALUED expression that returns true if the current
+     * expression is NOT VALUED.
+     *
+     * @return An IS NOT VALUED expression.
+     */
+    @SuppressWarnings("PMD.LinguisticNaming")
+    @NonNull
+    public Expression isNotValued() { return negated(isValued()); }
 
     /**
      * Creates a Collate expression with the given Collation specification. Commonly

--- a/common/main/java/com/couchbase/lite/FullTextExpression.java
+++ b/common/main/java/com/couchbase/lite/FullTextExpression.java
@@ -24,7 +24,10 @@ import com.couchbase.lite.internal.utils.Preconditions;
 
 /**
  * Full-text expression
+ *
+ * @deprecated Use FullTextFunction.match()
  */
+@Deprecated
 public final class FullTextExpression {
     static final class FullTextMatchExpression extends Expression {
         //---------------------------------------------
@@ -57,7 +60,9 @@ public final class FullTextExpression {
      *
      * @param name The full-text index name.
      * @return The full-text expression.
+     * @deprecated Use FullTextFunction.match()
      */
+    @Deprecated
     @NonNull
     public static FullTextExpression index(@NonNull String name) {
         Preconditions.assertNotNull(name, "name");
@@ -80,7 +85,9 @@ public final class FullTextExpression {
      *
      * @param query The search text
      * @return The full-text match expression
+     * @deprecated Use FullTextFunction.match()
      */
+    @Deprecated
     @NonNull
     public Expression match(@NonNull String query) {
         Preconditions.assertNotNull(query, "query");

--- a/common/main/java/com/couchbase/lite/FullTextFunction.java
+++ b/common/main/java/com/couchbase/lite/FullTextFunction.java
@@ -33,6 +33,21 @@ public final class FullTextFunction {
     private FullTextFunction() { }
 
     /**
+     * Creates a full-text expression with the given full-text index name and search text.
+     *
+     * @param indexName The full-text index name.
+     * @param text The search text
+     * @return The full-text match expression
+     */
+    @NonNull
+    public static Expression match(@NonNull String indexName, @NonNull String text) {
+        Preconditions.assertNotNull(indexName, "indexName");
+        return new Expression.FunctionExpression(
+            "MATCH()",
+            Arrays.asList(Expression.string(indexName), Expression.string(text)));
+    }
+
+    /**
      * Creates a full-text rank function with the given full-text index name.
      * The rank function indicates how well the current query result matches
      * the full-text query when performing the match comparison.


### PR DESCRIPTION
These changes, mandated by the N1QL spec, were totally left out.  They are part of the Lithium release.

Deprecate FullTextExpression and its methods
Add FullTextFunction.match
Re-order args to atan2
Deprecate isNullOrMissing and notNullOrMissing
Add isValued() and isNotValued() expressions
Add tests for all of the above