### PR TITLE
CBL-2456: Database.createQuery should throw on bad n1ql query

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/common/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -649,10 +649,12 @@ abstract class AbstractDatabase extends BaseDatabase {
     // Queries:
 
     @NonNull
-    public Query createQuery(@NonNull String query) {
+    public Query createQuery(@NonNull String query) throws CouchbaseLiteException {
         synchronized (getDbLock()) {
             mustBeOpen();
-            return new N1qlQuery(this, query);
+            final N1qlQuery n1qlQuery = new N1qlQuery(this, query);
+            n1qlQuery.compile();
+            return n1qlQuery;
         }
     }
 

--- a/common/main/java/com/couchbase/lite/AbstractQuery.java
+++ b/common/main/java/com/couchbase/lite/AbstractQuery.java
@@ -204,7 +204,7 @@ abstract class AbstractQuery implements Query {
 
     @GuardedBy("lock")
     @NonNull
-    private C4Query getC4QueryLocked() throws CouchbaseLiteException {
+    C4Query getC4QueryLocked() throws CouchbaseLiteException {
         if (c4query != null) { return c4query; }
 
         final AbstractDatabase db = getDatabase();

--- a/common/main/java/com/couchbase/lite/N1qlQuery.java
+++ b/common/main/java/com/couchbase/lite/N1qlQuery.java
@@ -21,6 +21,7 @@ import com.couchbase.lite.internal.core.C4Query;
 import com.couchbase.lite.internal.support.Log;
 import com.couchbase.lite.internal.utils.ClassUtils;
 import com.couchbase.lite.internal.utils.Preconditions;
+import com.couchbase.lite.internal.utils.StringUtils;
 
 
 public final class N1qlQuery extends AbstractQuery {
@@ -46,9 +47,10 @@ public final class N1qlQuery extends AbstractQuery {
     @Override
     protected C4Query prepQueryLocked(@NonNull AbstractDatabase db) throws CouchbaseLiteException {
         Log.d(DOMAIN, "N1QL query: %s", n1ql);
-        if (n1ql == null) { throw new CouchbaseLiteException("Failed to generate JSON query."); }
-
+        if (StringUtils.isEmpty(n1ql)) { throw new CouchbaseLiteException("Query is null or empty."); }
         try { return db.createN1qlQuery(n1ql); }
         catch (LiteCoreException e) { throw CouchbaseLiteException.convertException(e); }
     }
+
+    void compile() throws CouchbaseLiteException { getC4QueryLocked(); }
 }


### PR DESCRIPTION
As agreed, for Lithium Beta 3

Minimal implementation