### PR TITLE
CBL-2589: stop building mbedtls tests

### DIFF
--- a/tools/build_litecore.bat
+++ b/tools/build_litecore.bat
@@ -55,7 +55,7 @@ if "%lib%" == "LiteCore" (
 
 rem Works
 if "%lib%" == "mbedcrypto" (
-    "C:\Program Files\CMake\bin\cmake.exe" -G %VS_GEN% -DCMAKE_BUILD_TYPE=RelWithDebInfo ..\..\vendor\mbedtls || goto :error
+    "C:\Program Files\CMake\bin\cmake.exe" -G %VS_GEN% -DENABLE_TESTING=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo ..\..\vendor\mbedtls || goto :error
  
     "C:\Program Files\CMake\bin\cmake.exe" --build . --config RelWithDebInfo --target mbedcrypto || goto :error
 	   copy /y %liteCoreBuildDir%\windows\library\RelWithDebInfo\mbedcrypto.lib %outputDir%

--- a/tools/build_litecore.sh
+++ b/tools/build_litecore.sh
@@ -103,7 +103,7 @@ pushd $OS > /dev/null
 case $LIB in
    # works on centos6 and several version of OSX
    mbedcrypto)
-      cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_POSITION_INDEPENDENT_CODE=1 ../../$MBEDTLS_DIR
+      cmake -DENABLE_TESTING=OFF -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_POSITION_INDEPENDENT_CODE=1 ../../$MBEDTLS_DIR
       make -j $JOBS mbedx509 mbedcrypto mbedtls
       cp -f $MBEDTLS_LIB $OUTPUT_DIR
       ;;
@@ -124,7 +124,7 @@ case $LIB in
          # works on several OSX versions
          macos)
             echo "OSX: -DBUILD_ENTERPRISE=$ENT -DCMAKE_BUILD_TYPE=$BUILD_TYPE"
-            cmake -DBUILD_ENTERPRISE=$ENT -DCMAKE_BUILD_TYPE=$BUILD_TYPE ../..
+            cmake -DENABLE_TESTING=OFF -DBUILD_ENTERPRISE=$ENT -DCMAKE_BUILD_TYPE=$BUILD_TYPE ../..
 
             make -j $JOBS LiteCore
             strip -x libLiteCore.dylib


### PR DESCRIPTION
Add flags to cmake build to prevent it from creating the mbedtls test suite.