### PR TITLE
CBL-2593: Replicator delete sometimes fails.

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
+++ b/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
@@ -435,7 +435,7 @@ public abstract class AbstractCBLWebSocket extends C4Socket {
     protected final void requestClose(int code, String message) {
         Log.d(TAG, "%s#Core request close: %d", this, code);
         synchronized (getPeerLock()) {
-            if (!state.setState(State.CLOSE_REQUESTED)) { return; }
+            if (!state.setState(State.CLOSING)) { return; }
 
             if (webSocket != null) {
                 closeWebSocket(code, message);


### PR DESCRIPTION
The actual failure documented in the ticket is due to a replicator that doesn't stop.
I *believe* that the replicator doesn't stop because the attempt by
core to close a connection on which the remote already requested a close,
is ignored.  I believe this will fix it.