### PR TITLE
CBL-2974: Check entire server chain for pinned cert

### DIFF
--- a/android/main/java/com/couchbase/lite/internal/replicator/CBLTrustManager.java
+++ b/android/main/java/com/couchbase/lite/internal/replicator/CBLTrustManager.java
@@ -31,7 +31,7 @@ import com.couchbase.lite.internal.utils.Fn;
 
 public final class CBLTrustManager extends AbstractCBLTrustManager {
     public CBLTrustManager(
-        @Nullable byte[] pinnedServerCert,
+        @Nullable X509Certificate pinnedServerCert,
         boolean acceptOnlySelfSignedServerCertificate,
         @NonNull Fn.Consumer<List<Certificate>> serverCertsListener) {
         super(pinnedServerCert, acceptOnlySelfSignedServerCertificate, serverCertsListener);

--- a/java/main/java/com/couchbase/lite/internal/replicator/CBLTrustManager.java
+++ b/java/main/java/com/couchbase/lite/internal/replicator/CBLTrustManager.java
@@ -20,6 +20,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 import java.util.List;
 
 import com.couchbase.lite.internal.utils.Fn;
@@ -27,7 +28,7 @@ import com.couchbase.lite.internal.utils.Fn;
 /** Just delegate everything to the base class */
 public class CBLTrustManager extends AbstractCBLTrustManager {
     public CBLTrustManager(
-        @Nullable byte[] pinnedServerCert,
+        @Nullable X509Certificate pinnedServerCert,
         boolean acceptOnlySelfSignedServerCertificate,
         @NonNull Fn.Consumer<List<Certificate>> serverCertsListener) {
         super(pinnedServerCert, acceptOnlySelfSignedServerCertificate, serverCertsListener);


### PR DESCRIPTION
Check all certs provided by the server, for a match with a pinned cert, instead of just the leaf.
Backport to 3.0.2