### PR TITLE
CBL-2417: Session cookies replace header cookies

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractReplicator.java
+++ b/common/main/java/com/couchbase/lite/AbstractReplicator.java
@@ -28,7 +28,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -654,12 +653,7 @@ public abstract class AbstractReplicator extends BaseReplicator {
 
     @Nullable
     private byte[] getFleeceOptions() {
-        final Map<String, Object> options = new HashMap<>();
-
-        final Authenticator authenticator = config.getAuthenticator();
-        if (authenticator != null) { authenticator.authenticate(options); }
-
-        config.addConnectionOptions(options);
+        final Map<String, Object> options = config.getConnectionOptions();
 
         byte[] optionsFleece = null;
         if (!options.isEmpty()) {

--- a/common/main/java/com/couchbase/lite/BasicAuthenticator.java
+++ b/common/main/java/com/couchbase/lite/BasicAuthenticator.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.couchbase.lite.internal.BaseAuthenticator;
 import com.couchbase.lite.internal.core.C4Replicator;
 import com.couchbase.lite.internal.utils.Preconditions;
 
@@ -30,7 +31,7 @@ import com.couchbase.lite.internal.utils.Preconditions;
  * auth with the given username and password. This should only be used over an SSL/TLS connection,
  * as otherwise it's very easy for anyone sniffing network traffic to read the password.
  */
-public final class BasicAuthenticator extends Authenticator {
+public final class BasicAuthenticator extends BaseAuthenticator {
 
     //---------------------------------------------
     // member variables
@@ -96,7 +97,7 @@ public final class BasicAuthenticator extends Authenticator {
     //---------------------------------------------
 
     @Override
-    void authenticate(@NonNull Map<String, Object> options) {
+    protected void authenticate(@NonNull Map<String, Object> options) {
         final Map<String, Object> auth = new HashMap<>();
         auth.put(C4Replicator.REPLICATOR_AUTH_TYPE, C4Replicator.AUTH_TYPE_BASIC);
         auth.put(C4Replicator.REPLICATOR_AUTH_USER_NAME, username);

--- a/common/main/java/com/couchbase/lite/SessionAuthenticator.java
+++ b/common/main/java/com/couchbase/lite/SessionAuthenticator.java
@@ -21,6 +21,7 @@ import android.support.annotation.Nullable;
 import java.util.Locale;
 import java.util.Map;
 
+import com.couchbase.lite.internal.BaseAuthenticator;
 import com.couchbase.lite.internal.core.C4Replicator;
 import com.couchbase.lite.internal.utils.Preconditions;
 
@@ -29,7 +30,7 @@ import com.couchbase.lite.internal.utils.Preconditions;
  * SessionAuthenticator class is an authenticator that will authenticate by using the session ID of
  * the session created by a Sync Gateway
  */
-public final class SessionAuthenticator extends Authenticator {
+public final class SessionAuthenticator  extends BaseAuthenticator {
 
     private static final String DEFAULT_SYNC_GATEWAY_SESSION_ID_NAME = "SyncGatewaySession";
 
@@ -94,7 +95,7 @@ public final class SessionAuthenticator extends Authenticator {
     //---------------------------------------------
 
     @Override
-    void authenticate(@NonNull Map<String, Object> options) {
+    protected void authenticate(@NonNull Map<String, Object> options) {
         final String current = (String) options.get(C4Replicator.REPLICATOR_OPTION_COOKIES);
         final StringBuffer cookieStr = current != null ? new StringBuffer(current) : new StringBuffer();
 

--- a/common/main/java/com/couchbase/lite/internal/BaseAuthenticator.java
+++ b/common/main/java/com/couchbase/lite/internal/BaseAuthenticator.java
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020, 2017 Couchbase, Inc All rights reserved.
+// Copyright (c) 2022 Couchbase, Inc All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,9 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-package com.couchbase.lite;
+package com.couchbase.lite.internal;
 
-/**
- * Authenticator is an opaque interface.
- */
-public interface Authenticator { }
+import java.util.Map;
+
+import com.couchbase.lite.Authenticator;
+
+public abstract class BaseAuthenticator implements Authenticator {
+    protected abstract void authenticate(Map<String, Object> options);
+}

--- a/common/test/java/com/couchbase/lite/ReplicatorMiscTest.java
+++ b/common/test/java/com/couchbase/lite/ReplicatorMiscTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 import com.couchbase.lite.internal.CouchbaseLiteInternal;
+import com.couchbase.lite.internal.ImmutableReplicatorConfiguration;
 import com.couchbase.lite.internal.core.C4Constants;
 import com.couchbase.lite.internal.core.C4Replicator;
 import com.couchbase.lite.internal.core.C4ReplicatorStatus;
@@ -34,6 +35,7 @@ import com.couchbase.lite.internal.replicator.AbstractCBLWebSocket;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -316,6 +318,80 @@ public class ReplicatorMiscTest extends BaseReplicatorTest {
         assertEquals(
             ReplicatorActivityLevel.BUSY,
             getActivityLevelFor(C4ReplicatorStatus.ActivityLevel.BUSY + 1));
+    }
+
+    /**
+     * The 4 tests below test replicator cookies option when specifying replicator configuration
+     **/
+
+    @Test
+    public void testReplicatorWithBothAuthenticationAndHeaderCookies() throws URISyntaxException {
+        Authenticator authenticator = new SessionAuthenticator("mysessionid");
+        HashMap<String, String> header = new HashMap<>();
+        header.put(AbstractCBLWebSocket.HEADER_COOKIES, "region=nw; city=sf");
+        ReplicatorConfiguration configuration = new ReplicatorConfiguration(baseTestDb, getRemoteTargetEndpoint())
+            .setAuthenticator(authenticator)
+            .setHeaders(header);
+
+        ImmutableReplicatorConfiguration immutableConfiguration = new ImmutableReplicatorConfiguration(configuration);
+        HashMap<String, Object> options = (HashMap<String, Object>) immutableConfiguration.getConnectionOptions();
+
+        // cookie option contains both sgw cookie and user specified cookie
+        String cookies = (String) options.get(C4Replicator.REPLICATOR_OPTION_COOKIES);
+        assertNotNull(cookies);
+        assertTrue(cookies.contains("SyncGatewaySession=mysessionid"));
+        assertTrue(cookies.contains("region=nw; city=sf"));
+
+        // user specified cookie should be removed from extra header
+        HashMap<String, Object> httpHeaders = (HashMap<String, Object>) options
+            .get(C4Replicator.REPLICATOR_OPTION_EXTRA_HEADERS);
+        assertNotNull(httpHeaders); //httpHeaders must at least include a mapping for User-Agent
+        assertFalse(httpHeaders.containsKey(AbstractCBLWebSocket.HEADER_COOKIES));
+    }
+
+    @Test
+    public void testReplicatorWithNoCookie() throws URISyntaxException {
+        ImmutableReplicatorConfiguration immutableConfiguration =
+            new ImmutableReplicatorConfiguration(new ReplicatorConfiguration(
+                baseTestDb,
+                getRemoteTargetEndpoint()));
+        HashMap<String, Object> options = (HashMap<String, Object>) immutableConfiguration.getConnectionOptions();
+        assertFalse(options.containsKey(C4Replicator.REPLICATOR_OPTION_COOKIES));
+    }
+
+    @Test
+    public void testReplicatorWithOnlyAuthenticationCookie() throws URISyntaxException {
+        Authenticator authenticator = new SessionAuthenticator("mysessionid");
+        ReplicatorConfiguration configuration = new ReplicatorConfiguration(baseTestDb, getRemoteTargetEndpoint())
+            .setAuthenticator(authenticator);
+
+        ImmutableReplicatorConfiguration immutableConfiguration = new ImmutableReplicatorConfiguration(configuration);
+        HashMap<String, Object> options = (HashMap<String, Object>) immutableConfiguration.getConnectionOptions();
+
+        assertEquals(
+            "SyncGatewaySession=mysessionid",
+            options.get(C4Replicator.REPLICATOR_OPTION_COOKIES));
+    }
+
+    @Test
+    public void testReplicatorWithOnlyHeaderCookie() throws URISyntaxException {
+        HashMap<String, String> header = new HashMap<>();
+        header.put(AbstractCBLWebSocket.HEADER_COOKIES, "region=nw; city=sf");
+        ReplicatorConfiguration configuration = new ReplicatorConfiguration(baseTestDb, getRemoteTargetEndpoint())
+            .setHeaders(header);
+
+        ImmutableReplicatorConfiguration immutableConfiguration = new ImmutableReplicatorConfiguration(configuration);
+        HashMap<String, Object> options = (HashMap<String, Object>) immutableConfiguration.getConnectionOptions();
+
+        assertEquals(
+            "region=nw; city=sf",
+            options.get(C4Replicator.REPLICATOR_OPTION_COOKIES));
+
+        HashMap<String, Object> httpHeaders = (HashMap<String, Object>) options
+            .get(C4Replicator.REPLICATOR_OPTION_EXTRA_HEADERS);
+
+        assertNotNull(httpHeaders);  // httpHeaders must at least include a mapping for User-Agent
+        assertFalse(httpHeaders.containsKey(AbstractCBLWebSocket.HEADER_COOKIES));
     }
 
     private ReplicatorActivityLevel getActivityLevelFor(int activityLevel) {


### PR DESCRIPTION
Correctly handle cookies provide in client supplied custom headers.
Backport to 3.0.2