### PR TITLE
CBL-3023: correctly handle SocketTimeoutException

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/core/C4Constants.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Constants.java
@@ -222,5 +222,6 @@ public final class C4Constants {
         public static final int TLS_CLIENT_CERT_REJECTED = 10;  // 10
         public static final int TLS_CERT_UNKNOWN_ROOT = 11;     // Self-signed cert, or unknown anchor cert
         public static final int INVALID_REDIRECT = 12;          // Attempted redirect to invalid replication endpoint
+        public static final int HOST_UNREACHABLE = 24;          // There is no network path to the host [EHOSTUNREACH, retryable]
     }
 }

--- a/common/main/java/com/couchbase/lite/internal/core/C4Constants.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Constants.java
@@ -222,6 +222,5 @@ public final class C4Constants {
         public static final int TLS_CLIENT_CERT_REJECTED = 10;  // 10
         public static final int TLS_CERT_UNKNOWN_ROOT = 11;     // Self-signed cert, or unknown anchor cert
         public static final int INVALID_REDIRECT = 12;          // Attempted redirect to invalid replication endpoint
-        public static final int HOST_UNREACHABLE = 24;          // There is no network path to the host [EHOSTUNREACH, retryable]
     }
 }

--- a/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
+++ b/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
@@ -21,7 +21,10 @@ import android.support.annotation.VisibleForTesting;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.NoRouteToHostException;
+import java.net.PortUnreachableException;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
@@ -600,6 +603,13 @@ public class AbstractCBLWebSocket extends C4Socket {
         }
 
         if (handleClose(error)) { return; }
+
+        if ((error instanceof NoRouteToHostException)
+            || (error instanceof PortUnreachableException)
+            || (error instanceof SocketTimeoutException)) {
+            closed(C4Constants.ErrorDomain.NETWORK, C4Constants.NetworkError.HOST_UNREACHABLE, null);
+            return;
+        }
 
         // TLS Certificate error
         if (error.getCause() instanceof java.security.cert.CertificateException) {

--- a/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
+++ b/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
@@ -604,10 +604,13 @@ public class AbstractCBLWebSocket extends C4Socket {
 
         if (handleClose(error)) { return; }
 
-        if ((error instanceof NoRouteToHostException)
-            || (error instanceof PortUnreachableException)
-            || (error instanceof SocketTimeoutException)) {
-            closed(C4Constants.ErrorDomain.NETWORK, C4Constants.NetworkError.HOST_UNREACHABLE, null);
+        if (error instanceof SocketTimeoutException) {
+            closed(C4Constants.ErrorDomain.NETWORK, C4Constants.NetworkError.TIMEOUT, "Socket timeout");
+            return;
+        }
+
+        if ((error instanceof NoRouteToHostException) || (error instanceof PortUnreachableException)) {
+            closed(C4Constants.ErrorDomain.NETWORK, C4Constants.NetworkError.UNKNOWN_HOST, "Host unreachable");
             return;
         }
 


### PR DESCRIPTION
Correct handling of SocketTimeoutException.  Similar treatment of PortUnreachableException and NoRouteToHostException

@borrrden : will the use of domain `C4Constants.ErrorDomain.NETWORK` and code `C4Constants.NetworkError.HOST_UNREACHABLE` work in Hydrogen LiteCore?