### PR TITLE
Another attempt at fixing the final packaging

### DIFF
--- a/tools/extract_libs.sh
+++ b/tools/extract_libs.sh
@@ -22,7 +22,7 @@ if [ -z "${ZIP_URL}" ]; then
 fi
 
 ZIP_FILE="$2"
-ARTIFACT_NAME="${ZIP_FILE%.*}"
+ARTIFACT_NAME="${ZIP_FILE%-*}"
 
 if [ -z "${ZIP_FILE}" ]; then
     usage


### PR DESCRIPTION
Need to exclude both platform names ( "-macos", "-windows") and ".zip" to get the correct artifacts folder. 