### PR TITLE
Fix artifacts packaging

### DIFF
--- a/tools/extract_libs.sh
+++ b/tools/extract_libs.sh
@@ -22,6 +22,8 @@ if [ -z "${ZIP_URL}" ]; then
 fi
 
 ZIP_FILE="$2"
+ARTIFACT_NAME="${ZIP_FILE%-*}"
+
 if [ -z "${ZIP_FILE}" ]; then
     usage
 fi
@@ -45,7 +47,7 @@ curl -f -L "${ZIP_URL}/${ZIP_FILE}" -o "${ZIP_FILE}" || exit 1
 unzip "${ZIP_FILE}"
 rm -rf "${ZIP_FILE}"
 
-jar -xf `find . -name 'couchbase-lite-java*.jar' -print` libs
+jar -xf "${ARTIFACT_NAME}/lib/${ARTIFACT_NAME}.jar" libs
 
 cp -R "libs/"* "${OUTPUT_DIR}"
 


### PR DESCRIPTION
Similar to 3.0, the hydrogen Linux build also has an issue pulling windows and macOS artifacts. Backport fix from 3.0 to java hydrogen.