### PR TITLE
CBL-3084: Make SSLExceptions recoverable

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
+++ b/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
@@ -47,7 +47,9 @@ import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLKeyException;
 import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLProtocolException;
 import javax.net.ssl.TrustManager;
 
 import okhttp3.Authenticator;
@@ -556,13 +558,17 @@ public abstract class AbstractCBLWebSocket extends C4Socket {
             code = C4Constants.NetworkError.TLS_HANDSHAKE_FAILED;
         }
 
-        else if (error instanceof SSLPeerUnverifiedException) {
+        else if ((error instanceof SSLKeyException) || (error instanceof SSLPeerUnverifiedException)) {
             code = C4Constants.NetworkError.TLS_CERT_UNTRUSTED;
         }
 
-        else if (error instanceof SSLException) {
+        else if (error instanceof SSLProtocolException) {
             domain = C4Constants.ErrorDomain.WEB_SOCKET;
-            code = C4Constants.WebSocketError.TLS_FAILURE;
+            code = C4Constants.WebSocketError.PROTOCOL_ERROR;
+        }
+
+        else if (error instanceof SSLException) {
+            code = C4Constants.NetworkError.NETWORK_RESET;
         }
 
         // default: no idea what happened.

--- a/tools/extract_libs.sh
+++ b/tools/extract_libs.sh
@@ -22,8 +22,6 @@ if [ -z "${ZIP_URL}" ]; then
 fi
 
 ZIP_FILE="$2"
-ARTIFACT_NAME="${ZIP_FILE%-*}"
-
 if [ -z "${ZIP_FILE}" ]; then
     usage
 fi
@@ -47,8 +45,8 @@ curl -f -L "${ZIP_URL}/${ZIP_FILE}" -o "${ZIP_FILE}" || exit 1
 unzip "${ZIP_FILE}"
 rm -rf "${ZIP_FILE}"
 
+ARTIFACT_NAME="${ZIP_FILE%-*}"
 jar -xf "${ARTIFACT_NAME}/lib/${ARTIFACT_NAME}.jar" libs
-
 
 cp -R libs/* "${OUTPUT_DIR}"
 


### PR DESCRIPTION
CBSE-11861: report generic SSLExceptions to LiteCore as recoverable.