### PR TITLE
CBL-3274: Make IndexConfiguration visible as an opaque type

### DIFF
--- a/common/main/java/com/couchbase/lite/IndexConfiguration.java
+++ b/common/main/java/com/couchbase/lite/IndexConfiguration.java
@@ -25,7 +25,7 @@ import com.couchbase.lite.internal.utils.Preconditions;
 import com.couchbase.lite.internal.utils.StringUtils;
 
 
-class IndexConfiguration extends AbstractIndex {
+public class IndexConfiguration extends AbstractIndex {
     @NonNull
     private final List<String> expressions;
 


### PR DESCRIPTION
According to Pasin, making this type package protected is a violation of the API spec.

It should be visible as an opaque type.