### PR TITLE
CBL-3301: FullTextIndex.setLanguage should accept a null parameter

### DIFF
--- a/common/main/java/com/couchbase/lite/FullTextIndex.java
+++ b/common/main/java/com/couchbase/lite/FullTextIndex.java
@@ -16,11 +16,14 @@
 package com.couchbase.lite;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+
+import com.couchbase.lite.internal.utils.StringUtils;
 
 
 /**
@@ -29,7 +32,7 @@ import java.util.Locale;
 public class FullTextIndex extends Index {
     @NonNull
     private final List<FullTextIndexItem> indexItems;
-    @NonNull
+    @Nullable
     private String language = Locale.getDefault().getLanguage();
     private boolean ignoreDiacritics;
 
@@ -41,17 +44,17 @@ public class FullTextIndex extends Index {
     /**
      * The language code which is an ISO-639 language such as "en", "fr", etc.
      * Setting the language code affects how word breaks and word stems are parsed.
-     * Without setting the value, the current locale's language will be used. Setting
-     * a nil or "" value to disable the language features.
+     * If not explicitly set, the current locale's language will be used. Setting
+     * a null, empty, or unrecognized value will disable the language features.
      */
     @NonNull
-    public FullTextIndex setLanguage(@NonNull String language) {
-        this.language = language;
+    public FullTextIndex setLanguage(@Nullable String language) {
+        this.language = (StringUtils.isEmpty(language)) ? null : language;
         return this;
     }
 
     /**
-     * Set the true value to ignore accents/diacritical marks. The default value is false.
+     * Set true to ignore accents/diacritical marks. The default is false.
      */
     @NonNull
     public FullTextIndex ignoreAccents(boolean ignoreAccents) {
@@ -59,7 +62,7 @@ public class FullTextIndex extends Index {
         return this;
     }
 
-    @NonNull
+    @Nullable
     @Override
     String getLanguage() { return language; }
 

--- a/common/main/java/com/couchbase/lite/FullTextIndexConfiguration.java
+++ b/common/main/java/com/couchbase/lite/FullTextIndexConfiguration.java
@@ -15,7 +15,6 @@
 //
 package com.couchbase.lite;
 
-
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -23,8 +22,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
+import com.couchbase.lite.internal.utils.StringUtils;
+
 
 public class FullTextIndexConfiguration extends IndexConfiguration {
+    @Nullable
     private String textLanguage = Locale.getDefault().getLanguage();
     private boolean ignoreDiacritics;
 
@@ -37,12 +39,12 @@ public class FullTextIndexConfiguration extends IndexConfiguration {
     /**
      * The language code which is an ISO-639 language such as "en", "fr", etc.
      * Setting the language code affects how word breaks and word stems are parsed.
-     * Without setting the value, the current locale's language will be used. Setting
-     * a null or "" value to disable the language features.
+     * If not explicitly set, the current locale's language will be used. Setting
+     * a null, empty, or unrecognized value will disable the language features.
      */
     @NonNull
     public FullTextIndexConfiguration setLanguage(@Nullable String language) {
-        this.textLanguage = language;
+        this.textLanguage = (StringUtils.isEmpty(language)) ? null : language;
         return this;
     }
 
@@ -55,7 +57,7 @@ public class FullTextIndexConfiguration extends IndexConfiguration {
         return this;
     }
 
-    @NonNull
+    @Nullable
     @Override
     String getLanguage() { return textLanguage; }
 

--- a/common/main/java/com/couchbase/lite/internal/core/C4Query.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Query.java
@@ -162,11 +162,11 @@ public class C4Query extends C4NativePeer {
 
     private static native boolean createIndex(
         long db,
-        String name,
-        String queryExpressions,
+        @NonNull String name,
+        @NonNull String queryExpressions,
         int queryLanguage,
         int indexType,
-        String language,
+        @Nullable String language,
         boolean ignoreDiacritics)
         throws LiteCoreException;
 


### PR DESCRIPTION
From the forums: the parameter for FullTextIndex.setLanguage is marked @NonNull.  As described in the documentation immediately above, a null, empty, or unrecognized should disable stemming.