### PR TITLE
Fix test databases not deleted

### DIFF
--- a/common/main/java/com/couchbase/lite/Fleece.java
+++ b/common/main/java/com/couchbase/lite/Fleece.java
@@ -71,7 +71,7 @@ final class Fleece {
 
         throw new IllegalArgumentException(
             Log.formatStandardMessage(
-                "InvalidValueToBeDeserialized",
+                "InvalidCouchbaseObjType",
                 value.getClass().getSimpleName(),
                 SUPPORTED_TYPES));
     }

--- a/common/test/java/com/couchbase/lite/DatabaseTest.java
+++ b/common/test/java/com/couchbase/lite/DatabaseTest.java
@@ -959,7 +959,7 @@ public class DatabaseTest extends BaseDbTest {
             }
         }
         finally {
-            closeDb(newDb);
+            deleteDb(newDb);
         }
     }
 

--- a/common/test/java/com/couchbase/lite/DbCollectionsTest.kt
+++ b/common/test/java/com/couchbase/lite/DbCollectionsTest.kt
@@ -408,20 +408,23 @@ class DbCollectionsTest : BaseCollectionTest() {
     @Test
     fun testCreateThenGetCollectionFromDifferentDatabaseInstance(){
         val otherDb = duplicateDb(baseTestDb)
-        baseTestDb.createCollection("testColl")
-        val collection = otherDb.getCollection("testColl")
-        assertNotNull(collection)
+        try {
+            baseTestDb.createCollection("testColl")
+            val collection = otherDb.getCollection("testColl")
+            assertNotNull(collection)
 
-        //delete coll from a db
-        baseTestDb.deleteCollection("testColl")
-        assertNull(baseTestDb.getCollection("testColl"))
-        assertNull(otherDb.getCollection("testColl"))
+            //delete coll from a db
+            baseTestDb.deleteCollection("testColl")
+            assertNull(baseTestDb.getCollection("testColl"))
+            assertNull(otherDb.getCollection("testColl"))
 
-        //recreate collection
-        baseTestDb.createCollection("testColl")
-        val collectionRecreated = otherDb.getCollection("testColl")
-        assertNotSame(collectionRecreated, collection)
-
+            //recreate collection
+            baseTestDb.createCollection("testColl")
+            val collectionRecreated = otherDb.getCollection("testColl")
+            assertNotSame(collectionRecreated, collection)
+        } finally {
+            closeDb(otherDb);
+        }
     }
 
 }

--- a/common/test/java/com/couchbase/lite/DocumentTest.java
+++ b/common/test/java/com/couchbase/lite/DocumentTest.java
@@ -1536,8 +1536,8 @@ public class DocumentTest extends BaseDbTest {
         saveDocInBaseTestDb(mDoc);
 
         Map<String, Object> newProps = new HashMap<>();
-        props.put("PropName3", "Val3");
-        props.put("PropName4", 84);
+        newProps.put("PropName3", "Val3");
+        newProps.put("PropName4", 84);
 
         MutableDocument existingDoc = baseTestDb.getDocument("docName").toMutable();
         existingDoc.setData(newProps);

--- a/common/test/java/com/couchbase/lite/DocumentTest.java
+++ b/common/test/java/com/couchbase/lite/DocumentTest.java
@@ -2137,7 +2137,7 @@ public class DocumentTest extends BaseDbTest {
         }
         finally {
             closeDb(sameDB);
-            closeDb(otherDB);
+            deleteDb(otherDB);
         }
     }
 

--- a/common/test/java/com/couchbase/lite/NotificationTest.java
+++ b/common/test/java/com/couchbase/lite/NotificationTest.java
@@ -279,26 +279,30 @@ public class NotificationTest extends BaseDbTest {
     @Test
     public void testDatabaseChangeNotifier() throws CouchbaseLiteException {
         Database db = createDb("default_config_db");
-        CollectionChangeNotifier changeNotifier = new CollectionChangeNotifier(db.getDefaultCollection());
-        assertEquals(0, changeNotifier.getListenerCount());
-        ListenerToken t1 = changeNotifier.addChangeListener(
-            null,
-            c -> { },
-            t -> assertTrue(changeNotifier.removeChangeListener(t)));
-        assertEquals(1, changeNotifier.getListenerCount());
-        ListenerToken t2 = changeNotifier.addChangeListener(
-            null,
-            c -> { },
-            t -> assertFalse(changeNotifier.removeChangeListener(t)));
-        assertEquals(2, changeNotifier.getListenerCount());
-        t2.remove();
-        assertEquals(1, changeNotifier.getListenerCount());
-        t1.remove();
-        assertEquals(0, changeNotifier.getListenerCount());
-        t1.remove();
-        assertEquals(0, changeNotifier.getListenerCount());
-        t2.remove();
-        assertEquals(0, changeNotifier.getListenerCount());
+        try {
+            CollectionChangeNotifier changeNotifier = new CollectionChangeNotifier(db.getDefaultCollection());
+            assertEquals(0, changeNotifier.getListenerCount());
+            ListenerToken t1 = changeNotifier.addChangeListener(
+                    null,
+                    c -> { },
+                    t -> assertTrue(changeNotifier.removeChangeListener(t)));
+            assertEquals(1, changeNotifier.getListenerCount());
+            ListenerToken t2 = changeNotifier.addChangeListener(
+                    null,
+                    c -> { },
+                    t -> assertFalse(changeNotifier.removeChangeListener(t)));
+            assertEquals(2, changeNotifier.getListenerCount());
+            t2.remove();
+            assertEquals(1, changeNotifier.getListenerCount());
+            t1.remove();
+            assertEquals(0, changeNotifier.getListenerCount());
+            t1.remove();
+            assertEquals(0, changeNotifier.getListenerCount());
+            t2.remove();
+            assertEquals(0, changeNotifier.getListenerCount());
+        } finally {
+            deleteDb(db);
+        }
     }
 
     @Test


### PR DESCRIPTION
There are 4 databases that aren't cleaned up after being created in tests. After running tests repeatedly, these 4 databases will continue to duplicate. This properly handles deleting these databases, or in one instance, the base test DB fails to be deleted because a handle isn't closed.

Fixes https://github.com/couchbase/couchbase-lite-java-ce-root/issues/19.

Also fix a `Map` variable, writing to the wrong map and an incorrect error message.