### PR TITLE
Fix QueryTest.testWhereValued()

### DIFF
--- a/common/test/java/com/couchbase/lite/QueryTest.java
+++ b/common/test/java/com/couchbase/lite/QueryTest.java
@@ -338,7 +338,7 @@ public class QueryTest extends BaseQueryTest {
             int numRows = verifyQuery(
                 QueryBuilder.select(SR_DOCID).from(DataSource.database(baseTestDb)).where(testCase.expr),
                 (n, result) -> {
-                    if (n < testCase.docIds.size()) {
+                    if (n <= testCase.docIds.size()) {
                         assertEquals(testCase.docIds.get(n - 1), result.getString(0));
                     }
                 });
@@ -368,7 +368,7 @@ public class QueryTest extends BaseQueryTest {
             new TestCase(name.isNotValued()),
             new TestCase(name.isValued(), 1, 2),
             new TestCase(address.isNotValued(), 1),
-            new TestCase(address.isNotValued(), 2),
+            new TestCase(address.isValued(), 2),
             new TestCase(age.isNotValued(), 1),
             new TestCase(age.isValued(), 2),
             new TestCase(work.isNotValued(), 1, 2),
@@ -379,7 +379,7 @@ public class QueryTest extends BaseQueryTest {
             int numRows = verifyQuery(
                 QueryBuilder.select(SR_DOCID).from(DataSource.database(baseTestDb)).where(testCase.expr),
                 (n, result) -> {
-                    if (n < testCase.docIds.size()) {
+                    if (n <= testCase.docIds.size()) {
                         assertEquals(testCase.docIds.get(n - 1), result.getString(0));
                     }
                 });


### PR DESCRIPTION
I noticed the `QueryTest.testWhereNullOrMissing()` test case `TestCase(address.notNullOrMissing(), 2)` became `TestCase(address.isNotValued(), 2)` in `testWhereValued()` which should be incorrect, but the test was still passing. Correcting it as `TestCase(address.isValued(), 2)` passed as well. On further inspection, the `<` should actually be `<=`, which properly causes the current state to fail and the corrected to pass.