### PR TITLE
Fix QueryTest.testOrderBy()

### DIFF
--- a/common/test/java/com/couchbase/lite/QueryTest.java
+++ b/common/test/java/com/couchbase/lite/QueryTest.java
@@ -3305,8 +3305,8 @@ public class QueryTest extends BaseQueryTest {
 
         List<String> sorted = new ArrayList<>(firstNames);
         Collections.sort(sorted, cmp);
-        String[] array1 = firstNames.toArray(new String[0]);
-        String[] array2 = sorted.toArray(new String[0]);
+        String[] array1 = sorted.toArray(new String[0]);
+        String[] array2 = firstNames.toArray(new String[0]);
         assertArrayEquals(array1, array2);
     }
 }

--- a/common/test/java/com/couchbase/lite/QueryTest.java
+++ b/common/test/java/com/couchbase/lite/QueryTest.java
@@ -606,9 +606,9 @@ public class QueryTest extends BaseQueryTest {
 
         // Don't replace this with Comparator.naturalOrder.
         // it doesn't exist on older versions of Android
-        //noinspection Convert2MethodRef,ComparatorCombinators
-        testOrdered(order.ascending(), (c1, c2) -> c1.compareTo(c2));
-        testOrdered(order.descending(), String::compareTo);
+        testOrdered(order.ascending(), String::compareTo);
+        //noinspection ComparatorCombinators
+        testOrdered(order.descending(), (c1, c2) -> c2.compareTo(c1));
     }
 
     // https://github.com/couchbase/couchbase-lite-ios/issues/1669
@@ -3292,6 +3292,7 @@ public class QueryTest extends BaseQueryTest {
         final List<String> firstNames = new ArrayList<>();
         int numRows = verifyQuery(
             QueryBuilder.select(SR_DOCID).from(DataSource.database(baseTestDb)).orderBy(ordering),
+            false,
             (n, result) -> {
                 String docID = result.getString(0);
                 Document doc = baseTestDb.getDocument(docID);
@@ -3300,11 +3301,12 @@ public class QueryTest extends BaseQueryTest {
                 firstNames.add(firstName);
             });
         assertEquals(100, numRows);
+        assertEquals(100, firstNames.size());
 
         List<String> sorted = new ArrayList<>(firstNames);
         Collections.sort(sorted, cmp);
         String[] array1 = firstNames.toArray(new String[0]);
-        String[] array2 = firstNames.toArray(new String[sorted.size()]);
+        String[] array2 = sorted.toArray(new String[0]);
         assertArrayEquals(array1, array2);
     }
 }


### PR DESCRIPTION
I noticed in `QueryTest.testOrdered()` that `array1` and `array2` being compared were both created from the same `firstNames` list. So the `assertArrayEquals()` check was actually comparing the original list to itself, rather than the `sorted` version.

After correctly using `sorted` as the expected array in the comparison, `testOrderBy()` was failing for a couple reasons. `verifyQuery()` was running the query twice as both `Enumerator` and `Iterable`, resulting in `firstNames` being 200 long, the same sorted list twice, one after the other (which doesn't match its sorted version with double names in a row).

After passing `false` for `runBoth` in `verifyQuery()`, I also found that the `Comparator`s were reversed for `ascending()` and `descending()`. After fixing this, the test is now passing with confidence!