### PR TITLE
8.5.2 Test use collection API on collection deleted in a different database instance...

### DIFF
--- a/common/test/java/com/couchbase/lite/CollectionListenerTest.kt
+++ b/common/test/java/com/couchbase/lite/CollectionListenerTest.kt
@@ -55,8 +55,8 @@ class CollectionListenerTest : BaseCollectionTest() {
         testCollectionChangeListener(testSerialExecutor)
     }
 
-    // Test that addChangeListener to a deleted collection get a warning message and doesn't throw exception
-    @Ignore("Native crash")
+    // Test that addChangeListener to a deleted collection gets a warning message and doesn't throw exception
+    @Ignore("CBL-3582")
     @Test
     fun testAddChangeListenerToDeletedCollection() {
         baseTestDb.deleteCollection(testColName, testScopeName)
@@ -64,8 +64,8 @@ class CollectionListenerTest : BaseCollectionTest() {
     }
 
 
-    // Test that addChangeListener to a collection deleted from a different db instance get a warning message and doesn't throw exception
-    @Ignore("Native crash")
+    // Test that addChangeListener to a collection deleted from a different db instance gets a warning message and doesn't throw exception
+    @Ignore("CBL-3582")
     @Test
     fun testAddChangeListenerToCollectionDeletedInDifferentDBInstance() {
         val otherDb = duplicateBaseTestDb()
@@ -73,8 +73,8 @@ class CollectionListenerTest : BaseCollectionTest() {
         testCollection.addChangeListener(testSerialExecutor) {}
     }
 
-    // Test addDocumentChangeListener from a deleted collection get warning message and doesn't throw exception
-    @Ignore("Throw exception instead of warning message")
+    // Test that addDocumentChangeListener to a deleted collection gets warning message and doesn't throw exception
+    @Ignore("CBL-3583")
     @Test
     fun testAddDocumentChangeListenerToDeletedCollection() {
         val docID = "testDoc"
@@ -84,8 +84,8 @@ class CollectionListenerTest : BaseCollectionTest() {
         testCollection.addDocumentChangeListener(docID, testSerialExecutor) {}
     }
 
-    // Test addDocumentChangeListener from a deleted collection get warning message and doesn't throw exception
-    @Ignore("Throw exception instead of warning message")
+    // Test that addDocumentChangeListener to a deleted collection gets warning message and doesn't throw exception
+    @Ignore("CBL-3583")
     @Test
     fun testAddDocumentChangeListenerToCollectionDeletedInADifferentDBInstance() {
         val docID = "testDoc"
@@ -97,8 +97,8 @@ class CollectionListenerTest : BaseCollectionTest() {
         testCollection.addDocumentChangeListener(docID, testSerialExecutor) {}
     }
 
-    // Test removeChangeListener from a deleted collection doesn't throw exception
-    @Ignore("Native crash")
+    // Test that removeChangeListener from a deleted collection gets a warning message and doesn't throw exception
+    @Ignore("CBL-3584")
     @Test
     fun testRemoveChangeListenerToDeletedCollection() {
         val doc1Id = "doc_1"
@@ -130,7 +130,7 @@ class CollectionListenerTest : BaseCollectionTest() {
     }
 
     // Test removeChangeListener from a collection deleted in a different db doesn't throw exception
-    @Ignore("Native crash")
+    @Ignore("CBL-3584")
     @Test
     fun testRemoveChangeListenerToCollectionDeletedInADifferentDBInstance() {
         val otherDb = duplicateBaseTestDb()

--- a/common/test/java/com/couchbase/lite/CollectionTest.kt
+++ b/common/test/java/com/couchbase/lite/CollectionTest.kt
@@ -66,7 +66,7 @@ class CollectionTest : BaseCollectionTest() {
         }
     }
 
-    // Test get doc from collection that is deleted in a different database instance
+    // Test getting doc from collection that is deleted in a different database instance causes CBL exception
     @Test(expected = CouchbaseLiteException::class)
     fun testGetDocFromCollectionDeletedInDifferentDBInstance() {
         val otherDatabase = duplicateDb(baseTestDb)
@@ -80,7 +80,7 @@ class CollectionTest : BaseCollectionTest() {
 
     }
 
-    // Test get doc from deleted collection
+    // Test getting doc from deleted collection causes CBL exception
     @Test(expected = CouchbaseLiteException::class)
     fun testGetDocFromDeletedCollection() {
         //store doc
@@ -94,7 +94,7 @@ class CollectionTest : BaseCollectionTest() {
         testCollection.getDocument("doc1")
     }
 
-    // Test get doc count from deleted collection
+    // Test getting doc count from deleted collection returns 0
     @Test
     fun testGetDocCountFromDeletedCollection() {
         // store doc
@@ -106,7 +106,7 @@ class CollectionTest : BaseCollectionTest() {
         assertEquals(0, testCollection.count)
     }
 
-    // Test get doc count from a collection deleted in a different database instance
+    // Test getting doc count from a collection deleted in a different database instance returns 0
     @Test
     fun testGetDocFromCollectionDeletedInADifferentDBInstance() {
         val otherDatabase = duplicateDb(baseTestDb)
@@ -381,6 +381,7 @@ class CollectionTest : BaseCollectionTest() {
         assertEquals(0, collection4.count)
     }
 
+    // Test deleting doc on a deleted collection causes CBL exception
     @Test(expected = CouchbaseLiteException::class)
     fun testDeleteDocOnDeletedCollection() {
         val doc = createSingleDocInCollectionWithId("doc1")
@@ -388,7 +389,7 @@ class CollectionTest : BaseCollectionTest() {
         testCollection.delete(doc)
     }
 
-    // test delete doc on a collection that is deleted from a different db instance
+    // Test deleting doc on a collection that is deleted from a different db instance causes CBL exception
     @Test(expected = CouchbaseLiteException::class)
     fun testDeleteDocOnCollectionDeletedInDifferentDBInstance() {
         val otherDb = duplicateDb(baseTestDb)
@@ -558,6 +559,7 @@ class CollectionTest : BaseCollectionTest() {
         assertEquals(0, collection4.count)
     }
 
+    // Test purging doc on a deleted collection causes CBL exception
     @Test(expected = CouchbaseLiteException::class)
     fun testPurgeDocOnDeletedCollection() {
         //store doc
@@ -641,7 +643,7 @@ class CollectionTest : BaseCollectionTest() {
         testCollection.deleteIndex("index1")
     }
 
-    // Test get index from a deleted collection
+    // Test getting index from a deleted collection causes CBL exception
     @Test(expected = CouchbaseLiteException::class)
     fun testGetIndexFromDeletedCollection() {
         testCreateIndexInCollection()
@@ -651,7 +653,7 @@ class CollectionTest : BaseCollectionTest() {
         testCollection.indexes
     }
 
-    // Test get index from a collection deleted from another DB instance
+    // Test getting index from a collection deleted from another DB instance causes CBL exception
     @Test(expected = CouchbaseLiteException::class)
     fun testGetIndexFromCollectionDeletedFromADifferentDBInstance() {
         testCreateIndexInCollection()

--- a/common/test/java/com/couchbase/lite/DbCollectionsTest.kt
+++ b/common/test/java/com/couchbase/lite/DbCollectionsTest.kt
@@ -335,5 +335,19 @@ class DbCollectionsTest : BaseCollectionTest() {
         assertEquals(testColName, testCollection.name)
     }
 
+    // Test get scope from a collection that is deleted from a different database instance
+    @Test
+    fun testGetScopeAndNameFromCollectionFromDifferentDBInstance() {
+        val otherDb = duplicateDb(baseTestDb)
+        val collection = otherDb.getCollection(testColName, testScopeName)
+        assertNotNull(collection)
+
+        otherDb.deleteCollection(testColName, testScopeName)
+        assertNull(otherDb.getCollection(testColName, testScopeName))
+
+        //get from original collection
+        assertNotNull(testCollection.scope)
+        assertEquals(testColName, testCollection.name)
+    }
 }
 

--- a/common/test/java/com/couchbase/lite/DocumentTest.java
+++ b/common/test/java/com/couchbase/lite/DocumentTest.java
@@ -1843,6 +1843,49 @@ public class DocumentTest extends BaseCollectionTest {
         }
     }
 
+    @Ignore("CBL-3575")
+    @Test
+    public void testSetExpirationDocInCollectionDeletedInDifferentDBInstance() {
+        Date expiration = new Date(System.currentTimeMillis() + 30000L);
+        try {
+            // add doc in collection
+            String id = "test_doc";
+            MutableDocument document = new MutableDocument(id);
+            saveDocInBaseCollectionTest(document);
+
+            Database otherDb = duplicateBaseTestDb();
+            otherDb.deleteCollection(testColName, testScopeName);
+            testCollection.setDocumentExpiration(id, expiration);
+
+            fail("Expect CouchbaseLiteException"); // fail test if no exception is caught
+        }
+        catch (CouchbaseLiteException e) {
+            assertEquals(CBLError.Code.NOT_OPEN, e.getCode());
+        }
+    }
+
+    @Ignore("CBL-3575")
+    @Test
+    public void testGetExpirationOnDocInCollectionDeletedInDifferentDBInstance() throws CouchbaseLiteException {
+        Date expiration = new Date(System.currentTimeMillis() + 30000L);
+        // add doc in collection
+        String id = "test_doc";
+        MutableDocument document = new MutableDocument(id);
+        saveDocInBaseCollectionTest(document);
+        testCollection.setDocumentExpiration(id, expiration);
+
+        Database otherDb = duplicateBaseTestDb();
+        otherDb.deleteCollection(testColName, testScopeName);
+
+        try {
+            testCollection.getDocumentExpiration(id);
+            fail("Expect CouchbaseLiteException");
+        }
+        catch (CouchbaseLiteException e) {
+            assertEquals(CBLError.Code.NOT_OPEN, e.getCode());
+        }
+    }
+
     @Test
     public void testLongExpiration() throws Exception {
         Date now = new Date(System.currentTimeMillis());


### PR DESCRIPTION
.. and fix the issue that’s causing several filter tests with docIds and channels to fail (ignored tests tagged with this ticket [CBL-3424](https://issues.couchbase.com/browse/CBL-3424)) because option was not handled correctly in native_c4Replicator. The solution is to retain collection options until c4replicator is created.