### PR TITLE
CBL-3666: Connectivity Manager can be registered multiple times.

### DIFF
--- a/android/main/java/com/couchbase/lite/internal/AndroidConnectivityManager.java
+++ b/android/main/java/com/couchbase/lite/internal/AndroidConnectivityManager.java
@@ -114,10 +114,15 @@ public class AndroidConnectivityManager implements NetworkConnectivityManager {
 
         @Override
         public void start() {
-            CouchbaseLiteInternal.getContext().registerReceiver(
-                connectivityReceiver,
-                new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
-            Log.v(LogDomain.NETWORK, getLogMessage("Started"));
+            try {
+                CouchbaseLiteInternal.getContext().registerReceiver(
+                    connectivityReceiver,
+                    new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
+                Log.v(LogDomain.NETWORK, getLogMessage("Started"));
+            }
+            catch (RuntimeException e) {
+                Log.w(LogDomain.NETWORK, "Start failed", e);
+            }
         }
 
         @Override
@@ -164,13 +169,13 @@ public class AndroidConnectivityManager implements NetworkConnectivityManager {
             if (connectivityMgr == null) { return; }
 
             final String msg = name + " network listener for " + getCblMgr() + ": " + this;
-            try { connectivityMgr.unregisterNetworkCallback(connectivityCallback); }
-            catch (RuntimeException e) {
-                Log.e(LogDomain.NETWORK, "Failed stopping " + msg, e);
-                return;
+            try {
+                connectivityMgr.unregisterNetworkCallback(connectivityCallback);
+                Log.v(LogDomain.NETWORK, "Stopped " + msg);
             }
-
-            Log.v(LogDomain.NETWORK, "Stopped " + msg);
+            catch (RuntimeException e) {
+                Log.w(LogDomain.NETWORK, "Failed stopping " + msg, e);
+            }
         }
     }
 
@@ -186,8 +191,13 @@ public class AndroidConnectivityManager implements NetworkConnectivityManager {
             final ConnectivityManager connectivityMgr = getSysMgr();
             if (connectivityMgr == null) { return; }
 
-            connectivityMgr.registerNetworkCallback(new NetworkRequest.Builder().build(), connectivityCallback);
-            Log.v(LogDomain.NETWORK, getLogMessage("Started"));
+            try {
+                connectivityMgr.registerNetworkCallback(new NetworkRequest.Builder().build(), connectivityCallback);
+                Log.v(LogDomain.NETWORK, getLogMessage("Started"));
+            }
+            catch (RuntimeException e) {
+                Log.w(LogDomain.NETWORK, "Start failed", e);
+            }
         }
 
         @Override
@@ -213,8 +223,13 @@ public class AndroidConnectivityManager implements NetworkConnectivityManager {
             final ConnectivityManager connectivityMgr = getSysMgr();
             if (connectivityMgr == null) { return; }
 
-            connectivityMgr.registerDefaultNetworkCallback(connectivityCallback);
-            Log.v(LogDomain.NETWORK, getLogMessage("Started"));
+            try {
+                connectivityMgr.registerDefaultNetworkCallback(connectivityCallback);
+                Log.v(LogDomain.NETWORK, getLogMessage("Started"));
+            }
+            catch (RuntimeException e) {
+                Log.w(LogDomain.NETWORK, "Start failed", e);
+            }
         }
 
         @Override
@@ -295,7 +310,7 @@ public class AndroidConnectivityManager implements NetworkConnectivityManager {
 
     @Override
     public void registerObserver(@NonNull Observer observer) {
-        synchronized (observers) { observers.put(observer, Boolean.TRUE); }
+        if (Boolean.TRUE.equals(observers.put(observer, Boolean.TRUE))) { return; }
         start();
     }
 

--- a/android/main/java/com/couchbase/lite/internal/AndroidConnectivityManager.java
+++ b/android/main/java/com/couchbase/lite/internal/AndroidConnectivityManager.java
@@ -310,8 +310,12 @@ public class AndroidConnectivityManager implements NetworkConnectivityManager {
 
     @Override
     public void registerObserver(@NonNull Observer observer) {
-        if (Boolean.TRUE.equals(observers.put(observer, Boolean.TRUE))) { return; }
-        start();
+        final boolean shouldStart;
+        synchronized (observers) {
+            shouldStart = observers.isEmpty();
+            observers.put(observer, Boolean.TRUE);
+        }
+        if (shouldStart) { start(); }
     }
 
     @Override


### PR DESCRIPTION
Hotfix for CBSE-12499

When a continuous replication goes offline, it registers an observer to watch for changes in connectivity. The code used to allow a single observer to be registered multiple times. If this happened often enough, the system would throw an uncheck exception: TooManyRequestsException, which will cause the thread to fail.

The heart of the fix is line 313, checking to see if the observer is already in the map.  The try-catch blocks are just bullet-proofing.