### PR TITLE
Separate test functions from cleanup functions

### DIFF
--- a/common/test/java/com/couchbase/lite/BaseDbTest.java
+++ b/common/test/java/com/couchbase/lite/BaseDbTest.java
@@ -82,7 +82,7 @@ public abstract class BaseDbTest extends BaseTest {
 
     @After
     public final void tearDownBaseDbTest() {
-        deleteDb(baseTestDb);
+        eraseDb(baseTestDb);
         Report.log("Deleted baseTestDb: " + baseTestDb);
     }
 
@@ -1697,11 +1697,11 @@ public abstract class BaseDbTest extends BaseTest {
             return db;
         }
         catch (IOException e) {
-            deleteDb(db);
+            eraseDb(db);
             throw new AssertionError("Unable to get db path", e);
         }
         catch (AssertionError e) {
-            deleteDb(db);
+            eraseDb(db);
             throw e;
         }
     }

--- a/common/test/java/com/couchbase/lite/BaseReplicatorTest.java
+++ b/common/test/java/com/couchbase/lite/BaseReplicatorTest.java
@@ -83,7 +83,7 @@ public abstract class BaseReplicatorTest extends BaseCollectionTest {
     public final void setUpBaseReplicatorTest() throws CouchbaseLiteException { otherDB = createDb("replicator_db"); }
 
     @After
-    public final void tearDownBaseReplicatorTest() { deleteDb(otherDB); }
+    public final void tearDownBaseReplicatorTest() { eraseDb(otherDB); }
 
     protected final URLEndpoint getRemoteTargetEndpoint() throws URISyntaxException {
         return new URLEndpoint(new URI("ws://foo.couchbase.com/db"));

--- a/common/test/java/com/couchbase/lite/CollectionCrossDbTest.kt
+++ b/common/test/java/com/couchbase/lite/CollectionCrossDbTest.kt
@@ -39,11 +39,11 @@ class CollectionCrossDbTest : BaseTest() {
     @After
     fun tearDownBaseReplicatorTest() {
         try {
-            closeDb(dbA)
-            closeDb(dbB)
+            discardDb(dbA)
+            discardDb(dbB)
         } finally {
-            deleteDb(dbA)
-            deleteDb(dbB)
+            eraseDb(dbA)
+            eraseDb(dbB)
         }
     }
 

--- a/common/test/java/com/couchbase/lite/CollectionListenerTest.kt
+++ b/common/test/java/com/couchbase/lite/CollectionListenerTest.kt
@@ -107,7 +107,7 @@ class CollectionListenerTest : BaseCollectionTest() {
         } finally {
             token.remove()
 
-            deleteDb(otherDb)
+            eraseDb(otherDb)
         }
     }
 
@@ -140,14 +140,14 @@ class CollectionListenerTest : BaseCollectionTest() {
         } finally {
             token.remove()
 
-            deleteDb(otherDb)
+            eraseDb(otherDb)
         }
     }
 
     // Test that adding a change listener to a collection in a closed database doesn't throw an exception
     @Test
     fun testAddChangeListenerToCollectionInClosedDatabase() {
-        closeDb(baseTestDb)
+        discardDb(baseTestDb)
         testCollection.addChangeListener(null) {}
     }
 
@@ -157,7 +157,7 @@ class CollectionListenerTest : BaseCollectionTest() {
         val docID = "testDoc"
         testCollection.save(MutableDocument(docID))
 
-        closeDb(baseTestDb)
+        discardDb(baseTestDb)
 
         testCollection.addDocumentChangeListener(docID, null) {}
     }
@@ -167,7 +167,7 @@ class CollectionListenerTest : BaseCollectionTest() {
     fun testRemoveChangeListenerFromCollectionInClosedDatabase() {
         val token = testCollection.addChangeListener {}
         try {
-            closeDb(baseTestDb)
+            discardDb(baseTestDb)
         } finally {
             token.remove()
         }
@@ -176,14 +176,14 @@ class CollectionListenerTest : BaseCollectionTest() {
     // Test that addChangeListener to a collection in a deleted database doesn't throw an exception
     @Test
     fun testAddChangeListenerToCollectionInDeletedDatabase() {
-        deleteDb(baseTestDb)
+        eraseDb(baseTestDb)
         testCollection.addChangeListener(null) {}
     }
 
     // Test that addDocumentChangeListener to a collection in a deleted database doesn't throw an exception
     @Test
     fun testAddDocumentChangeListenerToCollectionInDeletedDatabase() {
-        deleteDb(baseTestDb)
+        eraseDb(baseTestDb)
         testCollection.addDocumentChangeListener("doc_id", null) {}
     }
 
@@ -192,7 +192,7 @@ class CollectionListenerTest : BaseCollectionTest() {
     fun testRemoveChangeListenerFromCollectionInDeletedDatabase() {
         val token = testCollection.addChangeListener { }
         try {
-            deleteDb(baseTestDb)
+            eraseDb(baseTestDb)
         } finally {
             token.remove()
         }

--- a/common/test/java/com/couchbase/lite/CollectionTest.kt
+++ b/common/test/java/com/couchbase/lite/CollectionTest.kt
@@ -24,6 +24,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 
 class CollectionTest : BaseCollectionTest() {
@@ -60,7 +61,7 @@ class CollectionTest : BaseCollectionTest() {
                 assertEquals(1, coll2.count)
             }
         } finally {
-            closeDb(otherDatabase)
+            discardDb(otherDatabase)
         }
     }
 
@@ -96,7 +97,7 @@ class CollectionTest : BaseCollectionTest() {
     @Test(expected = CouchbaseLiteException::class)
     fun testGetDocFromCollectionInClosedDB() {
         createSingleDocInTestCollectionWithId("doc_id")
-        closeDb(baseTestDb)
+        discardDb(baseTestDb)
         testCollection.getDocument("doc_id")
     }
 
@@ -104,7 +105,7 @@ class CollectionTest : BaseCollectionTest() {
     @Test(expected = CouchbaseLiteException::class)
     fun testGetDocFromCollectionInDeletedDB() {
         createSingleDocInTestCollectionWithId("doc_id")
-        deleteDb(baseTestDb)
+        eraseDb(baseTestDb)
         testCollection.getDocument("doc_id")
     }
 
@@ -125,7 +126,7 @@ class CollectionTest : BaseCollectionTest() {
     fun testGetDocCountFromCollectionInDeletedDatabase() {
         saveNewDocInCollectionWithIDTest()
         assertEquals(1, testCollection.count)
-        deleteDb(baseTestDb)
+        eraseDb(baseTestDb)
         assertEquals(0, testCollection.count)
     }
 
@@ -149,7 +150,7 @@ class CollectionTest : BaseCollectionTest() {
         val doc = MutableDocument(docID)
         saveDocInTestCollection(doc)
         assertEquals(1, testCollection.count)
-        closeDb(baseTestDb)
+        discardDb(baseTestDb)
         assertEquals(0, testCollection.count)
     }
     //---------------------------------------------
@@ -199,7 +200,7 @@ class CollectionTest : BaseCollectionTest() {
                 collection.save(doc)
             }
         } finally {
-            closeDb(otherDB)
+            discardDb(otherDB)
         }
     }
 
@@ -247,14 +248,14 @@ class CollectionTest : BaseCollectionTest() {
     // Test saving document in a collection of a closed database causes CBLException
     @Test(expected = CouchbaseLiteException::class)
     fun testSaveDocToCollectionInClosedDB() {
-        closeDb(baseTestDb)
+        discardDb(baseTestDb)
         saveDocInTestCollection(MutableDocument("invalid"))
     }
 
     // Test saving document in a collection of a deleted database causes CBLException
     @Test(expected = CouchbaseLiteException::class)
     fun testSaveDocToCollectionInDeletedDB() {
-        deleteDb(baseTestDb)
+        eraseDb(baseTestDb)
         saveDocInTestCollection(MutableDocument("invalid"))
     }
 
@@ -388,7 +389,7 @@ class CollectionTest : BaseCollectionTest() {
                 collection.delete(doc)
             }
         } finally {
-            closeDb(otherDb)
+            discardDb(otherDb)
         }
     }
 
@@ -443,7 +444,7 @@ class CollectionTest : BaseCollectionTest() {
     @Test(expected = CouchbaseLiteException::class)
     fun testDeleteDocOnCollectionInClosedDB() {
         val doc = createSingleDocInTestCollectionWithId("doc_id")
-        closeDb(baseTestDb)
+        discardDb(baseTestDb)
         testCollection.delete(doc)
     }
 
@@ -451,7 +452,7 @@ class CollectionTest : BaseCollectionTest() {
     @Test(expected = CouchbaseLiteException::class)
     fun testDeleteDocOnCollectionInDeletedDB() {
         val doc = createSingleDocInTestCollectionWithId("doc_id")
-        deleteDb(baseTestDb)
+        eraseDb(baseTestDb)
         testCollection.delete(doc)
     }
 
@@ -578,7 +579,7 @@ class CollectionTest : BaseCollectionTest() {
             //purge document against collection in the other db:
             TestUtils.assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { collection.purge(doc) }
         } finally {
-            closeDb(otherDB)
+            discardDb(otherDB)
         }
     }
 
@@ -628,7 +629,7 @@ class CollectionTest : BaseCollectionTest() {
     @Test(expected = CouchbaseLiteException::class)
     fun testPurgeDocFromCollectionInClosedDB() {
         val doc = createSingleDocInTestCollectionWithId("doc_id")
-        closeDb(baseTestDb)
+        discardDb(baseTestDb)
         testCollection.purge(doc)
     }
 
@@ -636,7 +637,7 @@ class CollectionTest : BaseCollectionTest() {
     @Test(expected = CouchbaseLiteException::class)
     fun testPurgeDocFromCollectionInDeletedDB() {
         val doc = createSingleDocInTestCollectionWithId("doc_id")
-        deleteDb(baseTestDb)
+        eraseDb(baseTestDb)
         testCollection.purge(doc)
     }
 
@@ -718,10 +719,11 @@ class CollectionTest : BaseCollectionTest() {
     }
 
     // Test getting index from a collection deleted from another DB instance causes CBL exception
+    @Ignore("CBL-3824")
     @Test(expected = CouchbaseLiteException::class)
     fun testGetIndexFromCollectionDeletedFromADifferentDBInstance() {
         testCreateIndexInCollection()
-        duplicateBaseTestDb().use {
+        duplicateDb(baseTestDb).use {
             assertNotNull(it.getCollection(testCollection.name, testCollection.scope.name))
             // Delete collection
             it.deleteCollection(testCollection.name, testCollection.scope.name)
@@ -777,7 +779,7 @@ class CollectionTest : BaseCollectionTest() {
     fun testGetIndexesFromCollectionInClosedDatabase() {
         testCollection.createIndex("test_index", ValueIndexConfiguration("firstName", "lastName"))
         assertEquals(1, testCollection.indexes.size)
-        closeDb(baseTestDb)
+        discardDb(baseTestDb)
         testCollection.indexes
     }
 
@@ -786,21 +788,21 @@ class CollectionTest : BaseCollectionTest() {
     fun testGetIndexesFromCollectionInDeletedDatabase() {
         testCollection.createIndex("test_index", ValueIndexConfiguration("firstName", "lastName"))
         assertEquals(1, testCollection.indexes.size)
-        deleteDb(baseTestDb)
+        eraseDb(baseTestDb)
         testCollection.indexes
     }
 
     // Test that createIndex in collection in closed database causes CBLException
     @Test(expected = CouchbaseLiteException::class)
     fun testCreateIndexInCollectionInClosedDatabase() {
-        closeDb(baseTestDb)
+        discardDb(baseTestDb)
         testCollection.createIndex("test_index", ValueIndexConfiguration("firstName", "lastName"))
     }
 
     // Test that createIndex in collection in deleted database causes CBLException
     @Test(expected = CouchbaseLiteException::class)
     fun testCreateIndexInCollectionInDeletedDatabase() {
-        deleteDb(baseTestDb)
+        eraseDb(baseTestDb)
         testCollection.createIndex("test_index", ValueIndexConfiguration("firstName", "lastName"))
     }
 
@@ -810,7 +812,7 @@ class CollectionTest : BaseCollectionTest() {
         val name = "test_index"
         testCollection.createIndex(name, ValueIndexConfiguration("firstName", "lastName"))
         assertEquals(1, testCollection.indexes.size)
-        closeDb(baseTestDb)
+        discardDb(baseTestDb)
         testCollection.deleteIndex(name)
     }
 
@@ -820,7 +822,7 @@ class CollectionTest : BaseCollectionTest() {
         val name = "test_index"
         testCollection.createIndex(name, ValueIndexConfiguration("firstName", "lastName"))
         assertEquals(1, testCollection.indexes.size)
-        deleteDb(baseTestDb)
+        eraseDb(baseTestDb)
         testCollection.deleteIndex(name)
     }
 

--- a/common/test/java/com/couchbase/lite/DatabaseTest.kt
+++ b/common/test/java/com/couchbase/lite/DatabaseTest.kt
@@ -72,7 +72,7 @@ class DatabaseTest : BaseDbTest() {
             assertEquals(1, otherDb.count)
             verifyGetDocument(otherDb, docID, 1)
         } finally {
-            closeDb(otherDb)
+            discardDb(otherDb)
         }
     }
 
@@ -165,7 +165,7 @@ class DatabaseTest : BaseDbTest() {
             doc.setValue("key", 2)
             TestUtils.assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherDb.save(doc) }
         } finally {
-            closeDb(otherDb)
+            discardDb(otherDb)
         }
     }
 
@@ -186,7 +186,7 @@ class DatabaseTest : BaseDbTest() {
             TestUtils.assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherDb.save(doc) }
         } finally {
             // delete otherDb
-            deleteDb(otherDb)
+            eraseDb(otherDb)
         }
     }
 
@@ -259,7 +259,7 @@ class DatabaseTest : BaseDbTest() {
             // Delete from the different db instance:
             TestUtils.assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherDb.delete(doc) }
         } finally {
-            closeDb(otherDb)
+            discardDb(otherDb)
         }
     }
 
@@ -277,7 +277,7 @@ class DatabaseTest : BaseDbTest() {
             // Delete from the different db:
             TestUtils.assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherDb.delete(doc) }
         } finally {
-            deleteDb(otherDb)
+            eraseDb(otherDb)
         }
     }
 
@@ -357,7 +357,7 @@ class DatabaseTest : BaseDbTest() {
             // purge document against other db instance:
             TestUtils.assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherDb.purge(doc) }
         } finally {
-            closeDb(otherDb)
+            discardDb(otherDb)
         }
     }
 
@@ -376,7 +376,7 @@ class DatabaseTest : BaseDbTest() {
             // Purge document against other db:
             TestUtils.assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherDb.purge(doc) }
         } finally {
-            deleteDb(otherDb)
+            eraseDb(otherDb)
         }
     }
 
@@ -650,7 +650,7 @@ class DatabaseTest : BaseDbTest() {
             // delete db
             TestUtils.assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.BUSY) { baseTestDb.delete() }
         } finally {
-            closeDb(otherDb)
+            discardDb(otherDb)
         }
     }
 
@@ -699,7 +699,7 @@ class DatabaseTest : BaseDbTest() {
             Database.delete(dbName, File(dbDirPath))
             assertFalse(dbPath.exists())
         } finally {
-            deleteDb(db)
+            eraseDb(db)
         }
     }
 
@@ -712,7 +712,7 @@ class DatabaseTest : BaseDbTest() {
         try {
             TestUtils.assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.BUSY) { Database.delete(dbName, dbDir) }
         } finally {
-            closeDb(db)
+            discardDb(db)
         }
     }
 
@@ -749,7 +749,7 @@ class DatabaseTest : BaseDbTest() {
             assertFalse(Database.exists(dirName, dbDir))
             assertFalse(File(dbPath).exists())
         } finally {
-            deleteDb(db)
+            eraseDb(db)
         }
     }
 
@@ -775,7 +775,7 @@ class DatabaseTest : BaseDbTest() {
         baseTestDb.createCollection("bobblehead", "horo")
         val scope = baseTestDb.getScope("horo")
         assertNotNull(scope)
-        closeDb(baseTestDb)
+        discardDb(baseTestDb)
         TestUtils.assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { scope!!.collections }
     }
 
@@ -784,7 +784,7 @@ class DatabaseTest : BaseDbTest() {
         baseTestDb.createCollection("bobblehead", "horo")
         val scope = baseTestDb.getScope("horo")
         assertNotNull(scope)
-        closeDb(baseTestDb)
+        discardDb(baseTestDb)
         TestUtils.assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) {
             scope!!.getCollection("bobblehead")
         }
@@ -797,7 +797,7 @@ class DatabaseTest : BaseDbTest() {
         baseTestDb.createCollection("bobblehead", "horo")
         val scope = baseTestDb.getScope("horo")
         assertNotNull(scope)
-        closeDb(baseTestDb)
+        discardDb(baseTestDb)
         TestUtils.assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { scope!!.collections }
     }
 
@@ -806,7 +806,7 @@ class DatabaseTest : BaseDbTest() {
         baseTestDb.createCollection("bobblehead", "horo")
         val scope = baseTestDb.getScope("horo")
         assertNotNull(scope)
-        closeDb(baseTestDb)
+        discardDb(baseTestDb)
         TestUtils.assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) {
             scope!!.getCollection("bobblehead")
         }
@@ -824,7 +824,7 @@ class DatabaseTest : BaseDbTest() {
 
         assertNotNull(baseTestDb.getScope("horo"))
 
-        closeDb(baseTestDb)
+        discardDb(baseTestDb)
 
         TestUtils.assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) {
             baseTestDb.getScope("horo")
@@ -837,7 +837,7 @@ class DatabaseTest : BaseDbTest() {
 
         assertNotNull(baseTestDb.getCollection("bobblehead", "horo"))
 
-        closeDb(baseTestDb)
+        discardDb(baseTestDb)
 
         TestUtils.assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) {
             baseTestDb.getCollection("bobblehead", "horo")
@@ -852,7 +852,7 @@ class DatabaseTest : BaseDbTest() {
 
         assertNotNull(baseTestDb.getScope("horo"))
 
-        deleteDb(baseTestDb)
+        eraseDb(baseTestDb)
 
         TestUtils.assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) {
             baseTestDb.getScope("horo")
@@ -865,7 +865,7 @@ class DatabaseTest : BaseDbTest() {
 
         assertNotNull(baseTestDb.getCollection("bobblehead", "horo"))
 
-        deleteDb(baseTestDb)
+        eraseDb(baseTestDb)
 
         TestUtils.assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) {
             baseTestDb.getCollection("bobblehead", "horo")
@@ -959,19 +959,19 @@ class DatabaseTest : BaseDbTest() {
     @Test(expected = IllegalStateException::class)
     fun testUseDatabaseAddChangeListenerWhenDefaultCollectionIsDeleted() {
         baseTestDb.deleteCollection(Collection.DEFAULT_NAME)
-        baseTestDb.addChangeListener() { c -> fail("Unexpected call to change listener") }
+        baseTestDb.addChangeListener { fail("Unexpected call to change listener") }
     }
 
     @Test(expected = IllegalStateException::class)
     fun testUseDatabaseAddDocumentChangeListenerWhenDefaultCollectionIsDeleted() {
         baseTestDb.save(MutableDocument("BobaFet"))
         baseTestDb.deleteCollection(Collection.DEFAULT_NAME)
-        baseTestDb.addDocumentChangeListener("BobaFet") { c -> fail("Unexpected call to change listener") }
+        baseTestDb.addDocumentChangeListener("BobaFet") { fail("Unexpected call to change listener") }
     }
 
     @Test(expected = IllegalStateException::class)
     fun testUseDatabaseRemoveChangeListenerWhenDefaultCollectionIsDeleted() {
-        val token = baseTestDb.addChangeListener() { c -> fail("Unexpected call to change listener") }
+        val token = baseTestDb.addChangeListener { fail("Unexpected call to change listener") }
         baseTestDb.deleteCollection(Collection.DEFAULT_NAME)
         baseTestDb.removeChangeListener(token)
     }
@@ -1155,7 +1155,7 @@ class DatabaseTest : BaseDbTest() {
                     }
                 }
         } finally {
-            deleteDb(newDb)
+            eraseDb(newDb)
         }
     }
 
@@ -1325,8 +1325,8 @@ class DatabaseTest : BaseDbTest() {
             // close db again
             database2.close()
         } finally {
-            deleteDb(database1)
-            deleteDb(database2)
+            eraseDb(database1)
+            eraseDb(database2)
         }
     }
 
@@ -1472,7 +1472,7 @@ class DatabaseTest : BaseDbTest() {
             val doc = db.getDocument(mDoc.id)
             assertEquals("bar", doc!!.getString("foo"))
         } finally {
-            deleteDb(db)
+            eraseDb(db)
         }
     }
 
@@ -1499,7 +1499,7 @@ class DatabaseTest : BaseDbTest() {
         } finally {
 
             FileUtils.eraseFileOrDir(twoDot8DotOhDirPath)
-            deleteDb(db)
+            eraseDb(db)
         }
     }
 
@@ -1534,7 +1534,7 @@ class DatabaseTest : BaseDbTest() {
             assertFalse(C4Database.getDatabaseFile(CouchbaseLiteInternal.getDefaultDbDir(), dbName).exists())
         } finally {
             FileUtils.eraseFileOrDir(twoDot8DotOhDirPath)
-            deleteDb(db)
+            eraseDb(db)
         }
     }
 
@@ -1566,7 +1566,7 @@ class DatabaseTest : BaseDbTest() {
             assertEquals("bar", doc!!.getString("foo"))
         } finally {
             FileUtils.eraseFileOrDir(twoDot8DotOhDirPath)
-            deleteDb(db)
+            eraseDb(db)
         }
     }
 

--- a/common/test/java/com/couchbase/lite/DbCollectionsTest.kt
+++ b/common/test/java/com/couchbase/lite/DbCollectionsTest.kt
@@ -283,7 +283,7 @@ class DbCollectionsTest : BaseCollectionTest() {
             val collectionRecreated = otherDb.getCollection("testColl")
             assertNotSame(collectionRecreated, collection)
         } finally {
-            deleteDb(otherDb)
+            eraseDb(otherDb)
         }
     }
 
@@ -295,7 +295,7 @@ class DbCollectionsTest : BaseCollectionTest() {
             assertNull(newDB.getCollection(testCollection.name, testCollection.scope.name))
         } finally {
             // delete otherDb
-            deleteDb(newDB)
+            eraseDb(newDB)
         }
     }
 
@@ -336,7 +336,7 @@ class DbCollectionsTest : BaseCollectionTest() {
     @Test
     fun testGetScopeAndCollectionNameFromAClosedDatabase() {
         val collectionName = testCollection.name
-        closeDb(baseTestDb)
+        discardDb(baseTestDb)
         assertNotNull(testCollection.scope)
         assertEquals(collectionName, testCollection.name)
     }

--- a/common/test/java/com/couchbase/lite/DocumentTest.java
+++ b/common/test/java/com/couchbase/lite/DocumentTest.java
@@ -1879,7 +1879,7 @@ public class DocumentTest extends BaseCollectionTest {
         try {
             String id = "doc_id";
             MutableDocument document = new MutableDocument(id);
-            closeDb(baseTestDb);
+            discardDb(baseTestDb);
             testCollection.setDocumentExpiration(id, expiration);
             fail("Expect CouchbaseLiteException");
         }
@@ -1915,7 +1915,7 @@ public class DocumentTest extends BaseCollectionTest {
         String id = "doc_id";
         MutableDocument document = new MutableDocument(id);
         saveDocInTestCollection(document);
-        deleteDb(baseTestDb);
+        eraseDb(baseTestDb);
         try {
             testCollection.setDocumentExpiration(id, expiration);
             fail("Expect CouchbaseLiteException");
@@ -1934,7 +1934,7 @@ public class DocumentTest extends BaseCollectionTest {
         MutableDocument document = new MutableDocument(id);
         saveDocInTestCollection(document);
         testCollection.setDocumentExpiration(id, expiration);
-        deleteDb(baseTestDb);
+        eraseDb(baseTestDb);
         try {
             testCollection.getDocumentExpiration(id);
             fail("Expect CouchbaseLiteException");
@@ -2284,8 +2284,8 @@ public class DocumentTest extends BaseCollectionTest {
             assertEquals(sDoc1a, anotherDoc1a);
         }
         finally {
-            deleteDb(sameDB);
-            deleteDb(otherDB);
+            eraseDb(sameDB);
+            eraseDb(otherDB);
         }
     }
 

--- a/common/test/java/com/couchbase/lite/MigrationTest.java
+++ b/common/test/java/com/couchbase/lite/MigrationTest.java
@@ -48,7 +48,7 @@ public class MigrationTest extends BaseTest {
 
     @After
     public final void tearDownMigrationTest() {
-        deleteDb(migrationTestDb);
+        eraseDb(migrationTestDb);
         FileUtils.eraseFileOrDir(dbDir);
     }
 

--- a/common/test/java/com/couchbase/lite/NotificationTest.java
+++ b/common/test/java/com/couchbase/lite/NotificationTest.java
@@ -302,7 +302,7 @@ public class NotificationTest extends BaseDbTest {
             assertEquals(0, changeNotifier.getListenerCount());
         }
         finally {
-            deleteDb(db);
+            eraseDb(db);
         }
     }
 

--- a/common/test/java/com/couchbase/lite/ReplicatorMiscTest.java
+++ b/common/test/java/com/couchbase/lite/ReplicatorMiscTest.java
@@ -24,7 +24,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.couchbase.lite.internal.CouchbaseLiteInternal;
@@ -290,7 +289,7 @@ public class ReplicatorMiscTest extends BaseReplicatorTest {
             null,
             null));
 
-        closeDb(baseTestDb);
+        discardDb(baseTestDb);
 
         replicator.start(false);
     }
@@ -306,7 +305,7 @@ public class ReplicatorMiscTest extends BaseReplicatorTest {
             null,
             null));
 
-        closeDb(baseTestDb);
+        discardDb(baseTestDb);
 
         replicator.getPendingDocumentIds();
     }
@@ -326,7 +325,7 @@ public class ReplicatorMiscTest extends BaseReplicatorTest {
                 null,
                 null));
 
-        closeDb(baseTestDb);
+        discardDb(baseTestDb);
 
         replicator.isDocumentPending(doc.getId());
     }

--- a/common/test/java/com/couchbase/lite/SaveConflictResolutionTest.kt
+++ b/common/test/java/com/couchbase/lite/SaveConflictResolutionTest.kt
@@ -18,7 +18,6 @@ package com.couchbase.lite
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
@@ -227,9 +226,9 @@ class SaveConflictResolutionTests : BaseDbTest() {
 
         assertNull(baseTestDb.getDocument(docID))
 
-        val c4doc = baseTestDb.getDefaultCollection()?.getC4Document(docID)
+        val c4doc = baseTestDb.defaultCollection?.getC4Document(docID)
         assertNotNull(c4doc)
-        assertTrue(c4doc!!.isRevDeleted())
+        assertTrue(c4doc!!.isRevDeleted)
     }
 
     /**

--- a/common/test/java/com/couchbase/lite/SimpleDatabaseTest.java
+++ b/common/test/java/com/couchbase/lite/SimpleDatabaseTest.java
@@ -56,7 +56,7 @@ public class SimpleDatabaseTest extends BaseTest {
             assertNotNull(newConfig);
             assertEquals(config.getDirectory(), newConfig.getDirectory());
         }
-        finally { deleteDb(db); }
+        finally { eraseDb(db); }
     }
 
     @Test
@@ -69,7 +69,7 @@ public class SimpleDatabaseTest extends BaseTest {
             assertNotNull(db.getConfig());
             assertNotSame(db.getConfig(), config);
         }
-        finally { deleteDb(db); }
+        finally { eraseDb(db); }
     }
 
     @Test
@@ -91,7 +91,7 @@ public class SimpleDatabaseTest extends BaseTest {
             assertNotNull(db);
             assertEquals(0, db.getCount());
         }
-        finally { deleteDb(db); }
+        finally { eraseDb(db); }
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -101,7 +101,7 @@ public class SimpleDatabaseTest extends BaseTest {
     public void testCreateWithSpecialCharacterDBNames() throws CouchbaseLiteException {
         Database db = new Database(LEGAL_FILE_NAME_CHARS);
         try { assertEquals(LEGAL_FILE_NAME_CHARS, db.getName()); }
-        finally { deleteDb(db); }
+        finally { eraseDb(db); }
     }
 
     @Test
@@ -127,7 +127,7 @@ public class SimpleDatabaseTest extends BaseTest {
             assertEquals(0, db.getCount());
         }
         finally {
-            deleteDb(db);
+            eraseDb(db);
         }
     }
 }


### PR DESCRIPTION
These test functions have always confused test. 

There are many tests that assume these functions will complete.  Especially when the a test passes only if a CBL exception, we are in danger of false positives, because one of these methods throws the exception before the test actually executes the code that should cause the error.

