### PR TITLE
Make ListenerToken abstract

### DIFF
--- a/common/main/java/com/couchbase/lite/ListenerToken.java
+++ b/common/main/java/com/couchbase/lite/ListenerToken.java
@@ -30,13 +30,13 @@ import com.couchbase.lite.internal.utils.Preconditions;
 /**
  * Base class for a removable subscription to an observable.
  */
-public class ListenerToken extends AtomicBoolean implements AutoCloseable {
+public abstract class ListenerToken implements AutoCloseable {
     @Nullable
     private final Executor executor;
     private final Fn.Consumer<ListenerToken> onRemove;
+    private final AtomicBoolean active = new AtomicBoolean(true);
 
     protected ListenerToken(@Nullable Executor executor, @NonNull Fn.Consumer<ListenerToken> onRemove) {
-        super(true);
         this.executor = executor;
         this.onRemove = Preconditions.assertNotNull(onRemove, "onRemove task");
     }
@@ -49,7 +49,7 @@ public class ListenerToken extends AtomicBoolean implements AutoCloseable {
     public void close() { remove(); }
 
     public void remove() {
-        if (getAndSet(false)) { onRemove.accept(this); }
+        if (active.getAndSet(false)) { onRemove.accept(this); }
     }
 
     protected void send(@NonNull Runnable notification) { getExecutor().execute(notification); }

--- a/common/main/java/com/couchbase/lite/QueryChange.java
+++ b/common/main/java/com/couchbase/lite/QueryChange.java
@@ -63,4 +63,8 @@ public final class QueryChange {
      */
     @Nullable
     public Throwable getError() { return error; }
+
+    @NonNull
+    @Override
+    public String toString() { return "QueryChange{" + error + ", " + query + ", " + rs + "}"; }
 }


### PR DESCRIPTION
A couple of small tweaks to production code, suggested by work on tests.

Notably, ListenerToken is now an abstract class

These are all of the changes that affect production code