### PR TITLE
Remove use of deprecated APIs from most CE tests

### DIFF
--- a/common/test/java/com/couchbase/lite/ArrayTest.java
+++ b/common/test/java/com/couchbase/lite/ArrayTest.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 
-@SuppressWarnings("ConstantConditions")
+@SuppressWarnings({"ConstantConditions", "SameParameterValue"})
 public class ArrayTest extends BaseDbTest {
 
     @Test
@@ -1073,7 +1073,7 @@ public class ArrayTest extends BaseDbTest {
 
     @SuppressWarnings("AssertBetweenInconvertibleTypes")
     @Test
-    public void testEquals() throws CouchbaseLiteException {
+    public void testEquals() {
 
         // mArray1 and mArray2 have exactly same data
         // mArray3 is different

--- a/common/test/java/com/couchbase/lite/BaseDbTest.kt
+++ b/common/test/java/com/couchbase/lite/BaseDbTest.kt
@@ -44,7 +44,13 @@ val Database.getC4Db
 val Scope.collectionCount
     get() = this.collections.size
 
-fun CountDownLatch.stdWait() = this.await(BaseTest.STD_TIMEOUT_SEC, TimeUnit.SECONDS)
+fun CountDownLatch.stdWait(): Boolean {
+    try {
+        return await(BaseTest.STD_TIMEOUT_SEC, TimeUnit.SECONDS)
+    } catch (e: InterruptedException) {
+        return false
+    }
+}
 
 fun Database.createTestCollection(name: String = "coll_", scope: String = "scope_"): Collection {
     val uname = BaseTest.getUniqueName(name)
@@ -129,6 +135,7 @@ fun readJSONResource(name: String?): String {
     return buf.toString()
 }
 
+@Suppress("SameParameterValue")
 abstract class BaseDbTest : BaseTest() {
     protected lateinit var testDatabase: Database
     protected lateinit var testCollection: Collection

--- a/common/test/java/com/couchbase/lite/BaseQueryTest.java
+++ b/common/test/java/com/couchbase/lite/BaseQueryTest.java
@@ -28,25 +28,6 @@ public abstract class BaseQueryTest extends BaseDbTest {
         void check(int n, Result result) throws CouchbaseLiteException;
     }
 
-    private class DocumentCreator implements UnitOfWork<Exception> {
-        private final int first;
-        private final int n;
-        private final Collection collection;
-        public List<MutableDocument> docs;
-
-        public DocumentCreator(int first, int n, Collection collection) {
-            this.first = first;
-            this.n = n;
-            this. collection = collection;
-        }
-
-        @Override
-        public void run() throws Exception {
-            docs = createTestDocs(first, n);
-            for (MutableDocument doc: docs) { saveDocInCollection(doc, collection, null); }
-        }
-    }
-
     protected final List<MutableDocument> loadDocuments(int n) {
         return loadDocuments(n, testCollection);
     }
@@ -60,10 +41,9 @@ public abstract class BaseQueryTest extends BaseDbTest {
     }
 
     protected final List<MutableDocument> loadDocuments(int first, int n, Collection collection) {
-        DocumentCreator createDocs = new DocumentCreator(first, n, collection);
-        try { testDatabase.inBatch(createDocs); }
-        catch (Exception e) { throw new AssertionError("Failed loading numbered docs", e); }
-        return createDocs.docs;
+        final List<MutableDocument> docs = createTestDocs(first, n);
+        saveDocsInCollection(docs, collection, null);
+        return docs;
     }
 
     protected final void verifyQuery(@NonNull Query query, int expected, @NonNull ResultVerifier verifier) {

--- a/common/test/java/com/couchbase/lite/BlobTest.java
+++ b/common/test/java/com/couchbase/lite/BlobTest.java
@@ -68,7 +68,7 @@ public class BlobTest extends BaseDbTest {
     public void testBlobCtorsWithNullStream() { new Blob("image/png", (InputStream) null); }
 
     @Test
-    public void testEquals() throws CouchbaseLiteException {
+    public void testEquals() {
         byte[] content1a = BLOB_CONTENT.getBytes(StandardCharsets.UTF_8);
         byte[] content1b = BLOB_CONTENT.getBytes(StandardCharsets.UTF_8);
         byte[] content2a = localBlobContent.getBytes(StandardCharsets.UTF_8);
@@ -279,7 +279,9 @@ public class BlobTest extends BaseDbTest {
         try (InputStream is = PlatformUtils.getAsset("iTunesMusicLibrary.json")) { data = IOUtils.toByteArray(is); }
 
         byte[] blobContent = new byte[data.length];
-        new Blob("application/json", data).getContentStream().read(blobContent, 0, data.length);
+        assertEquals(
+            data.length,
+            new Blob("application/json", data).getContentStream().read(blobContent, 0, data.length));
         assertArrayEquals(blobContent, data);
     }
 
@@ -289,7 +291,7 @@ public class BlobTest extends BaseDbTest {
         try (InputStream is = PlatformUtils.getAsset("iTunesMusicLibrary.json")) { data = IOUtils.toByteArray(is); }
 
         InputStream blobStream = new Blob("application/json", data).getContentStream();
-        blobStream.skip(17);
+        assertEquals(17, blobStream.skip(17));
         assertEquals(blobStream.read(), data[17]);
     }
 

--- a/common/test/java/com/couchbase/lite/CollectionTest.kt
+++ b/common/test/java/com/couchbase/lite/CollectionTest.kt
@@ -206,7 +206,7 @@ class CollectionTest : BaseDbTest() {
         assertEquals(1, testCollection.count)
 
         // update doc
-        mDoc.setValue("key", "whuddaboutdit")
+        mDoc.setValue(TEST_DOC_TAG_KEY, "whuddaboutdit")
         saveDocInCollection(mDoc)
         assertEquals(1, testCollection.count)
 
@@ -675,7 +675,7 @@ class CollectionTest : BaseDbTest() {
         val db = Database(getUniqueName("test"))
         val coll = db.createCollection("aaa", "bbb")
         coll.createIndex("idx", FullTextIndexConfiguration("detail"))
-        Database(db.getName())
+        Database(db.name)
     }
 
     // Test getting index from a collection deleted from another DB instance causes CBL exception

--- a/common/test/java/com/couchbase/lite/DatabaseTest.kt
+++ b/common/test/java/com/couchbase/lite/DatabaseTest.kt
@@ -37,7 +37,6 @@ import java.util.concurrent.TimeUnit
 // baseTestDb is managed by the superclass
 // If a test creates a new database it guarantees that it is deleted.
 // If a test opens a copy of the baseTestDb, it close (but does NOT delete) it
-@Suppress("DEPRECATION")
 class DatabaseTest : LegacyBaseDbTest() {
     //---------------------------------------------
     //  Get Document

--- a/common/test/java/com/couchbase/lite/DbCollectionsTest.kt
+++ b/common/test/java/com/couchbase/lite/DbCollectionsTest.kt
@@ -242,11 +242,11 @@ class DbCollectionsTest : BaseDbTest() {
     @Test
     fun testScopeNameContainingIllegalChars() {
         for (c in invalidChars) {
-            val scopeName = "notval" + c + "d"
+            val scopeName = "notval${c}d"
             try {
                 testDatabase.createCollection("col", scopeName)
                 fail("Expect CBL Exception for scope : $scopeName")
-            } catch (e: CouchbaseLiteException) {
+            } catch (ignore: CouchbaseLiteException) {
             }
         }
     }

--- a/common/test/java/com/couchbase/lite/DictionaryTest.java
+++ b/common/test/java/com/couchbase/lite/DictionaryTest.java
@@ -85,17 +85,17 @@ public class DictionaryTest extends BaseDbTest {
     public void testGetValueFromNewEmptyDictionary() {
         MutableDictionary mDict = new MutableDictionary();
 
-        assertEquals(0, mDict.getInt("key"));
-        assertEquals(0.0f, mDict.getFloat("key"), 0.0f);
-        assertEquals(0.0, mDict.getDouble("key"), 0.0);
-        assertFalse(mDict.getBoolean("key"));
-        assertNull(mDict.getBlob("key"));
-        assertNull(mDict.getDate("key"));
-        assertNull(mDict.getNumber("key"));
-        assertNull(mDict.getValue("key"));
-        assertNull(mDict.getString("key"));
-        assertNull(mDict.getDictionary("key"));
-        assertNull(mDict.getArray("key"));
+        assertEquals(0, mDict.getInt(TEST_DOC_TAG_KEY));
+        assertEquals(0.0f, mDict.getFloat(TEST_DOC_TAG_KEY), 0.0f);
+        assertEquals(0.0, mDict.getDouble(TEST_DOC_TAG_KEY), 0.0);
+        assertFalse(mDict.getBoolean(TEST_DOC_TAG_KEY));
+        assertNull(mDict.getBlob(TEST_DOC_TAG_KEY));
+        assertNull(mDict.getDate(TEST_DOC_TAG_KEY));
+        assertNull(mDict.getNumber(TEST_DOC_TAG_KEY));
+        assertNull(mDict.getValue(TEST_DOC_TAG_KEY));
+        assertNull(mDict.getString(TEST_DOC_TAG_KEY));
+        assertNull(mDict.getDictionary(TEST_DOC_TAG_KEY));
+        assertNull(mDict.getArray(TEST_DOC_TAG_KEY));
         assertEquals(new HashMap<String, Object>(), mDict.toMap());
 
         MutableDocument mDoc = new MutableDocument("doc1");
@@ -105,17 +105,17 @@ public class DictionaryTest extends BaseDbTest {
 
         Dictionary dict = doc.getDictionary("dict");
 
-        assertEquals(0, dict.getInt("key"));
-        assertEquals(0.0f, dict.getFloat("key"), 0.0f);
-        assertEquals(0.0, dict.getDouble("key"), 0.0);
-        assertFalse(dict.getBoolean("key"));
-        assertNull(dict.getBlob("key"));
-        assertNull(dict.getDate("key"));
-        assertNull(dict.getNumber("key"));
-        assertNull(dict.getValue("key"));
-        assertNull(dict.getString("key"));
-        assertNull(dict.getDictionary("key"));
-        assertNull(dict.getArray("key"));
+        assertEquals(0, dict.getInt(TEST_DOC_TAG_KEY));
+        assertEquals(0.0f, dict.getFloat(TEST_DOC_TAG_KEY), 0.0f);
+        assertEquals(0.0, dict.getDouble(TEST_DOC_TAG_KEY), 0.0);
+        assertFalse(dict.getBoolean(TEST_DOC_TAG_KEY));
+        assertNull(dict.getBlob(TEST_DOC_TAG_KEY));
+        assertNull(dict.getDate(TEST_DOC_TAG_KEY));
+        assertNull(dict.getNumber(TEST_DOC_TAG_KEY));
+        assertNull(dict.getValue(TEST_DOC_TAG_KEY));
+        assertNull(dict.getString(TEST_DOC_TAG_KEY));
+        assertNull(dict.getDictionary(TEST_DOC_TAG_KEY));
+        assertNull(dict.getArray(TEST_DOC_TAG_KEY));
         assertEquals(new HashMap<String, Object>(), dict.toMap());
     }
 
@@ -433,7 +433,7 @@ public class DictionaryTest extends BaseDbTest {
     }
 
     @Test
-    public void testEquals() throws CouchbaseLiteException {
+    public void testEquals() {
 
         // mDict1 and mDict2 have exactly same data
         // mDict3 is different

--- a/common/test/java/com/couchbase/lite/DocumentTest.java
+++ b/common/test/java/com/couchbase/lite/DocumentTest.java
@@ -219,17 +219,17 @@ public class DocumentTest extends BaseDbTest {
     public void testGetValueFromDocument() {
         MutableDocument doc = new MutableDocument("doc1");
         saveDocInTestCollection(doc, d -> {
-            assertEquals(0, d.getInt("key"));
-            assertEquals(0.0f, d.getFloat("key"), 0.0f);
-            assertEquals(0.0, d.getDouble("key"), 0.0);
-            assertFalse(d.getBoolean("key"));
-            assertNull(d.getBlob("key"));
-            assertNull(d.getDate("key"));
-            assertNull(d.getNumber("key"));
-            assertNull(d.getValue("key"));
-            assertNull(d.getString("key"));
-            assertNull(d.getArray("key"));
-            assertNull(d.getDictionary("key"));
+            assertEquals(0, d.getInt(TEST_DOC_TAG_KEY));
+            assertEquals(0.0f, d.getFloat(TEST_DOC_TAG_KEY), 0.0f);
+            assertEquals(0.0, d.getDouble(TEST_DOC_TAG_KEY), 0.0);
+            assertFalse(d.getBoolean(TEST_DOC_TAG_KEY));
+            assertNull(d.getBlob(TEST_DOC_TAG_KEY));
+            assertNull(d.getDate(TEST_DOC_TAG_KEY));
+            assertNull(d.getNumber(TEST_DOC_TAG_KEY));
+            assertNull(d.getValue(TEST_DOC_TAG_KEY));
+            assertNull(d.getString(TEST_DOC_TAG_KEY));
+            assertNull(d.getArray(TEST_DOC_TAG_KEY));
+            assertNull(d.getDictionary(TEST_DOC_TAG_KEY));
             assertEquals(new HashMap<String, Object>(), d.toMap());
         });
     }
@@ -2124,7 +2124,7 @@ public class DocumentTest extends BaseDbTest {
     @Test
     public void testEnumeratingKeys() {
         MutableDocument doc = new MutableDocument("doc1");
-        for (long i = 0; i < 20; i++) { doc.setLong("key" + i, i); }
+        for (long i = 0; i < 20; i++) { doc.setLong(TEST_DOC_TAG_KEY + i, i); }
         Map<String, Object> content = doc.toMap();
         Map<String, Object> result = new HashMap<>();
         int count = 0;
@@ -2306,14 +2306,14 @@ public class DocumentTest extends BaseDbTest {
         assertNull(doc);
 
         MutableDocument mDoc = new MutableDocument(docID);
-        mDoc.setValue("key", "value");
+        mDoc.setValue(TEST_DOC_TAG_KEY, "value");
         doc = saveDocInTestCollection(mDoc);
         assertNotNull(doc);
         assertEquals(1, testCollection.getCount());
 
         doc = testCollection.getDocument(docID);
         assertNotNull(doc);
-        assertEquals("value", doc.getString("key"));
+        assertEquals("value", doc.getString(TEST_DOC_TAG_KEY));
 
         testCollection.delete(doc);
         assertEquals(0, testCollection.getCount());
@@ -2747,8 +2747,6 @@ public class DocumentTest extends BaseDbTest {
     }
 
     // !!! These smell bad...
-
-    private String docId() { return BaseTest.getUniqueName("doc"); }
 
     private String docId(int i) { return String.format(Locale.ENGLISH, "doc-%03d", i); }
 

--- a/common/test/java/com/couchbase/lite/LoadTest.kt
+++ b/common/test/java/com/couchbase/lite/LoadTest.kt
@@ -1,254 +1,227 @@
-////
-//// Copyright (c) 2020 Couchbase, Inc.
-////
-//// Licensed under the Apache License, Version 2.0 (the "License");
-//// you may not use this file except in compliance with the License.
-//// You may obtain a copy of the License at
-////
-//// http://www.apache.org/licenses/LICENSE-2.0
-////
-//// Unless required by applicable law or agreed to in writing, software
-//// distributed under the License is distributed on an "AS IS" BASIS,
-//// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//// See the License for the specific language governing permissions and
-//// limitations under the License.
-////
-//package com.couchbase.lite
 //
-//import com.couchbase.lite.internal.utils.LoadTest
-//import com.couchbase.lite.internal.utils.Report
-//import com.couchbase.lite.internal.utils.SlowTest
-//import com.couchbase.lite.internal.utils.VerySlowTest
-//import org.junit.Assert
-//import org.junit.Assert.assertTrue
-//import org.junit.Ignore
-//import org.junit.Test
-//import java.util.*
+// Copyright (c) 2020 Couchbase, Inc.
 //
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//private const val ITERATIONS = 2000
+// http://www.apache.org/licenses/LICENSE-2.0
 //
-//private fun interface Verifier {
-//    fun verify(n: Int, result: Result?)
-//}
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
-//// Timings were chosen to allow a Nexus 6 running Android 7.0 to pass.
-//class LoadTest : BaseDbTest() {
-//    @SlowTest
-//    @LoadTest
-//    @Test
-//    fun testAddRevisions() {
-//        timeTest("testAddRevisions", 45 * 1000L) {
-//            addRevisions(1000, false)
-//            addRevisions(1000, true)
-//        }
-//    }
-//
-//    @SlowTest
-//    @LoadTest
-//    @Test
-//    fun testCreate() {
-//        timeTest("testCreate", 10 * 1000L) {
-//            createAndSaveDocuments("Create", ITERATIONS)
-//            verifyByTag("Create", ITERATIONS)
-//            Assert.assertEquals(ITERATIONS.toLong(), baseTestDb.count)
-//        }
-//    }
-//
-//    // This test reliably drove a bug that caused C4NativePeer
-//    // to finalize what appears to h ave been an incompletely initialize
-//    // instance of C4Document.  It is, otherwise, not relevant.
-//    @Ignore("Same test as testCreate")
-//    @LoadTest
-//    @Test
-//    fun testCreateMany() {
-//        timeTest("testCreateMany", 35 * 1000L) {
-//            for (i in 0..3) {
-//                createAndSaveDocuments("Create", ITERATIONS)
-//                verifyByTag("Create", ITERATIONS)
-//                Assert.assertEquals(ITERATIONS.toLong(), baseTestDb.count)
-//            }
-//        }
-//    }
-//
-//    @VerySlowTest
-//    @LoadTest
-//    @Test
-//    fun testDelete() {
-//        timeTest("testDelete", 20 * 1000L) {
-//            // create & delete doc ITERATIONS times
-//            for (i in 0 until ITERATIONS) {
-//                val docID = "doc-${i}"
-//                createAndSaveDocument(docID, "Delete")
-//                Assert.assertEquals(1, baseTestDb.count)
-//                val doc = baseTestDb.getDocument(docID)
-//                Assert.assertNotNull(doc)
-//                Assert.assertEquals("Delete", doc!!.getString("tag"))
-//                baseTestDb.delete(doc)
-//                Assert.assertEquals(0, baseTestDb.count)
-//            }
-//        }
-//    }
-//
-//    @Test
-//    @LoadTest
-//    fun testRead() {
-//        timeTest("testRead", 5 * 1000L) {
-//            // create 1 doc
-//            createAndSaveDocument("doc1", "Read")
-//            // read the doc n times
-//            for (i in 0 until ITERATIONS) {
-//                val doc = baseTestDb.getDocument("doc1")
-//                Assert.assertNotNull(doc)
-//                Assert.assertEquals("doc1", doc!!.id)
-//                Assert.assertEquals("Read", doc.getString("tag"))
-//            }
-//        }
-//    }
-//
-//    // https://github.com/couchbase/couchbase-lite-android/issues/1447
-//    @SlowTest
-//    @LoadTest
-//    @Test
-//    fun testSaveManyDocs() {
-//        timeTest("testSaveManyDocs", 20 * 1000L) {
-//            // Without Batch
-//            for (i in 0 until ITERATIONS) {
-//                val doc = MutableDocument("doc-${i}")
-//                for (j in 0 until 100) {
-//                    doc.setInt(j.toString(), j); }
-//                try {
-//                    baseTestDb.save(doc)
-//                } catch (e: CouchbaseLiteException) {
-//                    Report.log(LogLevel.ERROR, "Failed to save", e)
-//                }
-//            }
-//            Assert.assertEquals(ITERATIONS.toLong(), baseTestDb.count)
-//        }
-//    }
-//
-//    @SlowTest
-//    @LoadTest
-//    @Test
-//    fun testUpdate() {
-//        timeTest("testUpdate", 25 * 1000L) {
-//            // create doc
-//            createAndSaveDocument("doc1", "Create")
-//
-//            var doc = baseTestDb.getDocument("doc1")
-//            Assert.assertNotNull(doc)
-//            Assert.assertEquals("doc1", doc!!.id)
-//            Assert.assertEquals("Create", doc.getString("tag"))
-//
-//            // update doc n times
-//            for (i in 1..ITERATIONS) {
-//                val mDoc = baseTestDb.getDocument("doc1")!!.toMutable()
-//                mDoc.setValue("update", i)
-//                mDoc.setValue("tag", "Update")
-//                val address = mDoc.getDictionary("address")
-//                Assert.assertNotNull(address)
-//                address!!.setValue("street", "${i} street")
-//                mDoc.setDictionary("address", address)
-//                val phones = mDoc.getArray("phones")
-//                Assert.assertNotNull(phones)
-//                Assert.assertEquals(2, phones!!.count())
-//                phones.setValue(0, "650-000-${i}")
-//                mDoc.setArray("phones", phones)
-//                mDoc.setValue("updated", Date())
-//                saveDocInBaseTestDb(mDoc)
-//            }
-//            // check document
-//            doc = baseTestDb.getDocument("doc1")
-//            Assert.assertNotNull(doc)
-//            Assert.assertEquals("doc1", doc!!.id)
-//            Assert.assertEquals("Update", doc.getString("tag"))
-//            Assert.assertEquals(ITERATIONS, doc.getInt("update"))
-//            Assert.assertEquals("${ITERATIONS} street", doc.getDictionary("address")!!.getString("street"))
-//            Assert.assertEquals("650-000-${ITERATIONS}", doc.getArray("phones")!!.getString(0))
-//        }
-//    }
-//
-//    // https://github.com/couchbase/couchbase-lite-android/issues/1610
-//    @SlowTest
-//    @LoadTest
-//    @Test
-//    fun testUpdate2() {
-//        timeTest("testUpdate2", 25 * 1000L) {
-//            val mDoc = MutableDocument("doc1")
-//            val map: MutableMap<String, Any> = HashMap()
-//            map["ID"] = "doc1"
-//            mDoc.setValue("map", map)
-//            saveDocInBaseTestDb(mDoc)
-//            for (i in 0..1999) {
-//                map["index"] = i
-//                val doc = baseTestDb.getDocument(map["ID"].toString()) ?: throw AssertionError("Failed fetching doc")
-//                val newDoc = doc.toMutable()
-//                newDoc.setValue("map", map)
-//                newDoc.setInt("int", i)
-//                newDoc.setLong("long", i.toLong())
-//                baseTestDb.save(newDoc)
-//            }
-//        }
-//    }
-//
-//
-//    /// Utility methods
-//
-//    private fun createAndSaveDocument(id: String, tag: String) {
-//        val doc = createDocumentWithTag(id, tag)
-//        baseTestDb.save(doc)
-//    }
-//
-//    private fun createAndSaveDocuments(tag: String, nDocs: Int) {
-//        for (i in 0 until nDocs) {
-//            createAndSaveDocument("doc-${i}", tag)
-//        }
-//    }
-//
-//    private fun addRevisions(revisions: Int, retrieveNewDoc: Boolean) {
-//        testDatabase.inBatch<CouchbaseLiteException> {
-//            var mDoc = MutableDocument("doc")
-//            for (i in 0 until revisions) {
-//                mDoc.setValue("count", i)
-//                testCollection.save(mDoc)
-//                if (!retrieveNewDoc) {
-//                    System.gc()
-//                } else {
-//                    mDoc = testCollection.getDocument("doc")!!.toMutable()
-//                }
-//            }
-//        }
-//        val doc = testCollection.getDocument("doc")
-//        Assert.assertEquals((revisions - 1), doc!!.getInt("count")) // start from 0.
-//    }
-//
-//    private fun verifyByTag(tag: String, nRows: Int) {
-//        Assert.assertEquals(
-//            nRows.toLong(),
-//            QueryBuilder.select(SelectResult.expression(Meta.id))
-//                .from(DataSource.collection(testCollection))
-//                .where(Expression.property("tag").equalTo(Expression.string(tag)))
-//                .execute().allResults().size
-//        );
-//    }
-//
-//    private fun verifyByTag(tag: String, verifier: Verifier) {
-//        var n = 0
-//        QueryBuilder.select(SelectResult.expression(Meta.id))
-//            .from(DataSource.collection(testCollection))
-//            .where(Expression.property("tag").equalTo(Expression.string(tag)))
-//            .execute().use { rs ->
-//                for (row in rs) {
-//                    verifier.verify(++n, row)
-//                }
-//            }
-//    }
-//
-//    private fun timeTest(testName: String, maxTimeMs: Long, test: Runnable) {
-//        val t0 = System.currentTimeMillis()
-//        test.run()
-//        val elapsedTime = System.currentTimeMillis() - t0
-//        Report.log("Test ${testName} time: " + elapsedTime)
-//        assertTrue(elapsedTime < maxTimeMs)
-//    }
-//}
+package com.couchbase.lite
+
+import com.couchbase.lite.internal.utils.LoadTest
+import com.couchbase.lite.internal.utils.Report
+import com.couchbase.lite.internal.utils.SlowTest
+import com.couchbase.lite.internal.utils.VerySlowTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.*
+
+
+private const val ITERATIONS = 2000
+
+// Timings were chosen to allow a Nexus 6 running Android 7.0 to pass.
+class LoadTest : BaseDbTest() {
+
+    // https://github.com/couchbase/couchbase-lite-android/issues/1447
+    @SlowTest
+    @LoadTest
+    @Test
+    fun testCreateUnbatched() {
+        val tag = getUniqueName("create#1")
+        val docs = createComplexTestDocs(ITERATIONS, tag)
+
+        assertEquals(0, testCollection.count)
+        timeTest("testCreateUnbatched", 7 * 1000L) {
+            for (doc in docs) {
+                testCollection.save(doc)
+            }
+        }
+        assertEquals(ITERATIONS.toLong(), testCollection.count)
+        verifyByTag(tag, ITERATIONS)
+    }
+
+    @SlowTest
+    @LoadTest
+    @Test
+    fun testCreateBatched() {
+        val tag = getUniqueName("create#2")
+        val docs = createComplexTestDocs(ITERATIONS, tag)
+
+        assertEquals(0, testCollection.count)
+        timeTest("testCreateBatched", 3 * 1000L) {
+            testDatabase.inBatch<CouchbaseLiteException> {
+                for (doc in docs) {
+                    testCollection.save(doc)
+                }
+            }
+        }
+        assertEquals(ITERATIONS.toLong(), testCollection.count)
+        verifyByTag(tag, ITERATIONS)
+    }
+
+    @Test
+    @LoadTest
+    fun testRead() {
+        val tag = getUniqueName("read")
+        val ids = saveDocsInCollection(createComplexTestDocs(ITERATIONS, tag)).map { it.id }
+
+        assertEquals(ITERATIONS.toLong(), testCollection.count)
+        timeTest("testRead", 2 * 1000L) {
+            for (id in ids) {
+                val doc = testCollection.getDocument(id)
+                assertNotNull(doc)
+
+                assertEquals(tag, doc!!.getString(TEST_DOC_TAG_KEY))
+
+                val address = doc.getDictionary("address")
+                assertNotNull(address)
+                assertEquals("Mountain View", address!!.getString("city"))
+
+                val phones = doc.getArray("phones")
+                assertNotNull(phones)
+                assertEquals("650-123-0002", phones!!.getString(1))
+            }
+        }
+    }
+
+    @SlowTest
+    @LoadTest
+    @Test
+    fun testUpdate1() {
+        val newTag = getUniqueName("update")
+        val ids = saveDocsInCollection(createComplexTestDocs(ITERATIONS, getUniqueName("update"))).map { it.id }
+
+        assertEquals(ITERATIONS.toLong(), testCollection.count)
+        timeTest("testUpdate1", 12 * 1000L) {
+            var i = 0
+            for (id in ids) {
+                i++
+
+                val mDoc = testCollection.getDocument(id)!!.toMutable()
+
+                mDoc.setValue("updated", Date())
+                mDoc.setValue("update", i)
+
+                mDoc.setValue(TEST_DOC_TAG_KEY, newTag)
+
+                val address = mDoc.getDictionary("address")
+                assertNotNull(address)
+                address!!.setValue("street", "${i} street")
+                mDoc.setDictionary("address", address)
+
+                val phones = mDoc.getArray("phones")
+                assertNotNull(phones)
+                phones!!.setValue(0, "650-000-${i}")
+                mDoc.setArray("phones", phones)
+
+                testCollection.save(mDoc)
+            }
+        }
+        assertEquals(ITERATIONS.toLong(), testCollection.count)
+        verifyByTag(newTag, ITERATIONS)
+    }
+
+    // https://github.com/couchbase/couchbase-lite-android/issues/1610
+    @SlowTest
+    @LoadTest
+    @Test
+    fun testUpdate2() {
+        var mDoc = createTestDoc()
+        mDoc.setValue("map", mapOf("idx" to 0, "long" to 0L, TEST_DOC_TAG_KEY to getUniqueName("tag")))
+        testCollection.save(mDoc)
+
+        assertEquals(1L, testCollection.count)
+        timeTest("testUpdate2", 9 * 1000L) {
+            for (i in 0..ITERATIONS) {
+                mDoc = testCollection.getDocument(mDoc.id)!!.toMutable()
+                mDoc.setValue("map", mapOf("idx" to i, "long" to i.toLong(), TEST_DOC_TAG_KEY to getUniqueName("tag")))
+                testCollection.save(mDoc)
+            }
+        }
+
+        val doc = testCollection.getDocument(mDoc.id)
+        assertNotNull(doc)
+        val map = doc!!.getDictionary("map")
+        assertNotNull(map)
+        assertEquals(ITERATIONS, map!!.getInt("idx"))
+        assertEquals(ITERATIONS.toLong(), map.getLong("long"))
+        assertEquals(mDoc.getString(TEST_DOC_TAG_KEY), doc.getString(TEST_DOC_TAG_KEY))
+    }
+
+    @VerySlowTest
+    @LoadTest
+    @Test
+    fun testDelete() {
+        val docs = saveDocsInCollection(createComplexTestDocs(ITERATIONS, getUniqueName("delete")))
+
+        assertEquals(ITERATIONS.toLong(), testCollection.count)
+        timeTest("testDelete", 8 * 1000L) {
+            for (doc in docs) {
+                testCollection.delete(doc)
+            }
+        }
+        assertEquals(0, testCollection.count)
+    }
+
+    @SlowTest
+    @LoadTest
+    @Test
+    fun testSaveRevisions1() {
+        var mDoc = MutableDocument()
+        timeTest("testSaveRevisions1", 4 * 1000L) {
+            testDatabase.inBatch<CouchbaseLiteException> {
+                for (i in 0 until ITERATIONS) {
+                    mDoc.setValue("count", i)
+                    testCollection.save(mDoc)
+                    mDoc = testCollection.getDocument(mDoc.id)!!.toMutable()
+                }
+            }
+        }
+        assertEquals((ITERATIONS - 1), testCollection.getDocument(mDoc.id)!!.getInt("count"))
+    }
+
+    @SlowTest
+    @LoadTest
+    @Test
+    fun testSaveRevisions2() {
+        val mDoc = MutableDocument()
+        timeTest("testSaveRevisions2", 2 * 1000L) {
+            testDatabase.inBatch<CouchbaseLiteException> {
+                for (i in 0 until ITERATIONS) {
+                    mDoc.setValue("count", i)
+                    testCollection.save(mDoc)
+                }
+            }
+        }
+        assertEquals((ITERATIONS - 1), testCollection.getDocument(mDoc.id)!!.getInt("count"))
+    }
+
+    // Utility methods
+
+    private fun verifyByTag(tag: String, count: Int) {
+        assertEquals(
+            count,
+            QueryBuilder.select(SelectResult.expression(Meta.id))
+                .from(DataSource.collection(testCollection))
+                .where(Expression.property(TEST_DOC_TAG_KEY).equalTo(Expression.string(tag)))
+                .execute().allResults().size
+        )
+    }
+
+    private fun timeTest(testName: String, maxTimeMs: Long, test: Runnable) {
+        val t0 = System.currentTimeMillis()
+        test.run()
+        val elapsedTime = System.currentTimeMillis() - t0
+        Report.log("Load test ${testName} completed in ${elapsedTime} ms")
+        assertTrue(elapsedTime < maxTimeMs)
+    }
+}

--- a/common/test/java/com/couchbase/lite/MigrationTest.java
+++ b/common/test/java/com/couchbase/lite/MigrationTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertNotNull;
 
 public class MigrationTest extends BaseTest {
     private static final String DB_NAME = "android-sqlite";
+    private static final String TEST_KEY = "key";
 
 
     private File dbDir;
@@ -59,11 +60,13 @@ public class MigrationTest extends BaseTest {
         ZipUtils.unzip(PlatformUtils.getAsset("replacedb/android140-sqlite.cblite2.zip"), dbDir);
 
         migrationTestDb = openDatabase();
-        assertEquals(2, migrationTestDb.getCount());
+        Collection migrationTestCollection = migrationTestDb.getDefaultCollection();
+        assertNotNull(migrationTestCollection);
+        assertEquals(2, migrationTestCollection.getCount());
         for (int i = 1; i <= 2; i++) {
-            Document doc = migrationTestDb.getDocument("doc" + i);
+            Document doc = migrationTestCollection.getDocument("doc" + i);
             assertNotNull(doc);
-            assertEquals(String.valueOf(i), doc.getString("key"));
+            assertEquals(String.valueOf(i), doc.getString(TEST_KEY));
 
             Dictionary attachments = doc.getDictionary("_attachments");
             assertNotNull(attachments);
@@ -82,11 +85,14 @@ public class MigrationTest extends BaseTest {
         ZipUtils.unzip(PlatformUtils.getAsset("replacedb/android140-sqlite-noattachment.cblite2.zip"), dbDir);
 
         migrationTestDb = openDatabase();
-        assertEquals(2, migrationTestDb.getCount());
+        Collection migrationTestCollection = migrationTestDb.getDefaultCollection();
+        assertNotNull(migrationTestCollection);
+
+        assertEquals(2, migrationTestCollection.getCount());
         for (int i = 1; i <= 2; i++) {
-            Document doc = migrationTestDb.getDocument("doc" + i);
+            Document doc = migrationTestCollection.getDocument("doc" + i);
             assertNotNull(doc);
-            assertEquals(String.valueOf(i), doc.getString("key"));
+            assertEquals(String.valueOf(i), doc.getString(TEST_KEY));
         }
     }
 
@@ -95,18 +101,21 @@ public class MigrationTest extends BaseTest {
         ZipUtils.unzip(PlatformUtils.getAsset("replacedb/android200-sqlite.cblite2.zip"), dbDir);
 
         migrationTestDb = openDatabase();
-        assertEquals(2, migrationTestDb.getCount());
+        Collection migrationTestCollection = migrationTestDb.getDefaultCollection();
+        assertNotNull(migrationTestCollection);
+
+        assertEquals(2, migrationTestCollection.getCount());
+
         for (int i = 1; i <= 2; i++) {
-            Document doc = migrationTestDb.getDocument("doc" + i);
+            Document doc = migrationTestCollection.getDocument("doc" + i);
             assertNotNull(doc);
-            assertEquals(String.valueOf(i), doc.getString("key"));
+            assertEquals(String.valueOf(i), doc.getString(TEST_KEY));
             Blob blob = doc.getBlob("attach" + i);
             assertNotNull(blob);
             byte[] attach = String.format(Locale.ENGLISH, "attach%d", i).getBytes(StandardCharsets.UTF_8);
             assertArrayEquals(attach, blob.getContent());
         }
     }
-
 
     private Database openDatabase() throws IOException, CouchbaseLiteException {
         final DatabaseConfiguration config = new DatabaseConfiguration();

--- a/common/test/java/com/couchbase/lite/QueryTest.java
+++ b/common/test/java/com/couchbase/lite/QueryTest.java
@@ -87,7 +87,7 @@ public class QueryTest extends BaseQueryTest {
         final String value = getUniqueName("value");
 
         MutableDocument document = new MutableDocument();
-        document.setString("key", value);
+        document.setString(TEST_DOC_TAG_KEY, value);
         saveDocInTestCollection(document);
 
         Query queryBuild = QueryBuilder.createQuery(
@@ -103,7 +103,7 @@ public class QueryTest extends BaseQueryTest {
         List<String> arrayResult = Arrays.asList(res);
 
         Map<String, String> mapResult = new HashMap<>();
-        mapResult.put("key", "value");
+        mapResult.put(TEST_DOC_TAG_KEY, "value");
 
         try (ResultSet rs = queryBuild.execute()) {
             Result result;
@@ -111,8 +111,8 @@ public class QueryTest extends BaseQueryTest {
                 assertEquals("{\"key\":\"value\"}", result.toJSON());
                 assertEquals(arrayResult, result.toList());
                 assertEquals(mapResult, result.toMap());
-                assertEquals("value", result.getValue("key").toString());
-                assertEquals("value", result.getString("key"));
+                assertEquals("value", result.getValue(TEST_DOC_TAG_KEY).toString());
+                assertEquals("value", result.getString(TEST_DOC_TAG_KEY));
                 assertEquals("value", result.getString(32));
             }
         }
@@ -231,8 +231,9 @@ public class QueryTest extends BaseQueryTest {
             });
     }
 
+    // Throws clause prevents Windows compiler error
     @Test
-    public void testWhereComparison() {
+    public void testWhereComparison() throws Exception {
         List<String> docIds = Fn.mapToList(loadDocuments(10), Document::getId);
         runTests(
             new TestCase(Expression.property(TEST_DOC_SORT_KEY).lessThan(Expression.intValue(3)), docIds, 1, 2),
@@ -269,8 +270,9 @@ public class QueryTest extends BaseQueryTest {
         );
     }
 
+    // Throws clause prevents Windows compiler error
     @Test
-    public void testWhereArithmetic() {
+    public void testWhereArithmetic() throws Exception {
         List<String> docIds = Fn.mapToList(loadDocuments(10), Document::getId);
         runTests(
             new TestCase(
@@ -324,8 +326,9 @@ public class QueryTest extends BaseQueryTest {
         );
     }
 
+    // Throws clause prevents Windows compiler error
     @Test
-    public void testWhereAndOr() {
+    public void testWhereAndOr() throws Exception {
         List<String> docIds = Fn.mapToList(loadDocuments(10), Document::getId);
         runTests(
             new TestCase(
@@ -469,8 +472,9 @@ public class QueryTest extends BaseQueryTest {
             });
     }
 
+    // Throws clause prevents Windows compiler error
     @Test
-    public void testWhereBetween() {
+    public void testWhereBetween() throws Exception {
         List<String> docIds = Fn.mapToList(loadDocuments(10), Document::getId);
         runTests(new TestCase(Expression.property(TEST_DOC_SORT_KEY)
             .between(Expression.intValue(3), Expression.intValue(7)), docIds, 3, 4, 5, 6, 7));
@@ -824,8 +828,9 @@ public class QueryTest extends BaseQueryTest {
         verifyQuery(query, 4, (n, result) -> assertEquals(expectedNumbers[n - 1], (long) result.getValue(0)));
     }
 
+    // Throws clause prevents Windows compiler error
     @Test
-    public void testMeta() {
+    public void testMeta() throws Exception {
         List<String> expected = Fn.mapToList(loadDocuments(5), Document::getId);
 
         Query query = QueryBuilder
@@ -1526,8 +1531,9 @@ public class QueryTest extends BaseQueryTest {
 
     // This is a pretty finickey test: the numbers are important.
     // It will fail by timing out; you'll have to figure out why.
+    // Throws clause prevents Windows compiler error
     @Test
-    public void testLiveQuery() throws InterruptedException {
+    public void testLiveQuery() throws Exception {
         List<MutableDocument> firstLoad = loadDocuments(100, 20);
 
         Query query = QueryBuilder
@@ -2109,8 +2115,9 @@ public class QueryTest extends BaseQueryTest {
             });
     }
 
+    // Throws clause prevents Windows compiler error
     @Test
-    public void testResultSetEnumeration() throws CouchbaseLiteException {
+    public void testResultSetEnumeration() throws Exception {
         List<String> docIds = Fn.mapToList(loadDocuments(5), Document::getId);
 
         Query query = QueryBuilder.select(SelectResult.expression(Meta.id))
@@ -2168,8 +2175,9 @@ public class QueryTest extends BaseQueryTest {
         }
     }
 
+    // Throws clause prevents Windows compiler error
     @Test
-    public void testGetAllResults() throws CouchbaseLiteException {
+    public void testGetAllResults() throws Exception {
         List<String> docIds = Fn.mapToList(loadDocuments(5), Document::getId);
 
         Query query = QueryBuilder.select(SelectResult.expression(Meta.id))

--- a/common/test/java/com/couchbase/lite/utils/KotlinHelpers.java
+++ b/common/test/java/com/couchbase/lite/utils/KotlinHelpers.java
@@ -26,6 +26,7 @@ import com.couchbase.lite.Replicator;
 
 
 // Utility class to make calls that Kotlin will not allow
+@SuppressWarnings("ConstantConditions")
 public final class KotlinHelpers {
     private KotlinHelpers() { }
 
@@ -33,6 +34,12 @@ public final class KotlinHelpers {
     public static boolean callIsDocumentPendingWithNullId(@NonNull Replicator repl, @Nullable Collection collection)
         throws CouchbaseLiteException {
         return repl.isDocumentPending(null, collection);
+    }
+
+    // Kotlin will not allow a the call isDocumentPending(null)
+    public static boolean callIsDocumentPendingWithNullId(@NonNull Replicator repl)
+        throws CouchbaseLiteException {
+        return repl.isDocumentPending(null);
     }
 
     // Kotlin will not allow a the call LogFileConfiguration.<init>((String) null)


### PR DESCRIPTION
This commit contains no changes to production code: It is all tests.