### PR TITLE
CBL-3863: More straightforward Kotlin factories

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractDatabaseConfiguration.java
+++ b/common/main/java/com/couchbase/lite/AbstractDatabaseConfiguration.java
@@ -34,6 +34,7 @@ abstract class AbstractDatabaseConfiguration {
     //---------------------------------------------
     protected AbstractDatabaseConfiguration() { this((String) null); }
 
+    @SuppressWarnings("CopyConstructorMissesField")
     protected AbstractDatabaseConfiguration(@Nullable AbstractDatabaseConfiguration config) {
         this((config == null) ? null : config.getDirectory());
     }

--- a/common/main/java/com/couchbase/lite/AbstractReplicatorConfiguration.java
+++ b/common/main/java/com/couchbase/lite/AbstractReplicatorConfiguration.java
@@ -92,12 +92,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
     @Nullable
     private static Map<Collection, CollectionConfiguration> copyConfigs(
         @Nullable Map<Collection, CollectionConfiguration> configs) {
-        if (configs == null) { return null; }
-        final Map<Collection, CollectionConfiguration> configsCopy = new HashMap<>();
-        for (Map.Entry<Collection, CollectionConfiguration> config: configs.entrySet()) {
-            configsCopy.put(config.getKey(), new CollectionConfiguration(config.getValue()));
-        }
-        return configsCopy;
+        return (configs == null) ? null : new HashMap<>(configs);
     }
 
     //---------------------------------------------
@@ -150,6 +145,11 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
             db);
     }
 
+    // maxAttemptsSet is not copied into the new config, by design:
+    // changing the the replication type will reset maxAttempts
+    // If there is a way to get rid of the whole kludgy business,
+    // this warning suppression can be removed
+    @SuppressWarnings("CopyConstructorMissesField")
     protected AbstractReplicatorConfiguration(@NonNull AbstractReplicatorConfiguration config) {
         this(
             config.collectionConfigurations,
@@ -186,8 +186,8 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
     // Although they are mutable, an AbstractReplicatorConfiguration holds
     // the only reference to its copies (they are copied in and copied out)
     // They are, therefore, effectively immutable
-    @SuppressWarnings({"PMD.ExcessiveParameterList", "PMD.ArrayIsStoredDirectly"})
-    protected AbstractReplicatorConfiguration(
+    @SuppressWarnings("PMD.ExcessiveParameterList")
+    private AbstractReplicatorConfiguration(
         @Nullable Map<Collection, CollectionConfiguration> collections,
         @NonNull Endpoint target,
         @NonNull com.couchbase.lite.ReplicatorType type,
@@ -403,6 +403,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
      * @return this.
      * @deprecated Use setType(AbstractReplicator.ReplicatorType)
      */
+    @SuppressWarnings({"DeprecatedIsStillUsed", "deprecation"})
     @Deprecated
     @NonNull
     public final ReplicatorConfiguration setReplicatorType(
@@ -432,6 +433,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
      * @return this.
      * @deprecated Please use setPinnedServerX509Certificate(Certificate)
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated
     @NonNull
     public final ReplicatorConfiguration setPinnedServerCertificate(@Nullable byte[] pinnedCert) {
@@ -458,6 +460,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
      * @return this.
      * @deprecated Use CollectionConfiguration.setDocumentIDs
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated
     @NonNull
     public final ReplicatorConfiguration setDocumentIDs(@Nullable List<String> documentIDs) {
@@ -476,6 +479,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
      * @return this.
      * @deprecated Use CollectionConfiguration.setChannels
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated
     @NonNull
     public final ReplicatorConfiguration setChannels(@Nullable List<String> channels) {
@@ -491,6 +495,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
      * @return this.
      * @deprecated Use CollectionConfiguration.setConflictResolver
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated
     @NonNull
     public final ReplicatorConfiguration setConflictResolver(@Nullable ConflictResolver conflictResolver) {
@@ -507,6 +512,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
      * @return this.
      * @deprecated Use CollectionConfiguration.setPullFilter
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated
     @NonNull
     public final ReplicatorConfiguration setPullFilter(@Nullable ReplicationFilter pullFilter) {
@@ -523,6 +529,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
      * @return this.
      * @deprecated Use CollectionConfiguration.setPushFilter
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated
     @NonNull
     public final ReplicatorConfiguration setPushFilter(@Nullable ReplicationFilter pushFilter) {
@@ -555,12 +562,8 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
     /**
      * Return the list of collections in the replicator configuration
      */
-    @Nullable
-    public final Set<Collection> getCollections() {
-        final Set<Collection> collections = collectionConfigurations.keySet();
-        // ??? should check for isEmpty and return null?
-        return (collections == null) ? null : new HashSet<>(collections);
-    }
+    @NonNull
+    public final Set<Collection> getCollections() { return new HashSet<>(collectionConfigurations.keySet()); }
 
     /**
      * Return Replicator type indicating the direction of the replicator.
@@ -601,7 +604,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
     /**
      * Return the max number of retry attempts made after connection failure.
      * This method will return 0 when implicitly using the default:
-     * 10 total connection attempts (the inital attempt and up to 9 retries) for
+     * 10 total connection attempts (the initial attempt and up to 9 retries) for
      * a one-shot replicator and a very, very large number of retries, for a continuous replicator.
      */
     public final int getMaxAttempts() { return maxAttempts; }
@@ -625,6 +628,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
      *
      * @deprecated Use getType()
      */
+    @SuppressWarnings({"DeprecatedIsStillUsed", "deprecation"})
     @Deprecated
     @NonNull
     public final AbstractReplicatorConfiguration.ReplicatorType getReplicatorType() {
@@ -664,6 +668,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
     @NonNull
     public final Database getDatabase() {
         if (database != null) { return database; }
+        // Can't change the nullity of this method: it has to throw.
         throw new IllegalStateException("No database or collections provided for replication configuration");
     }
 

--- a/common/main/java/com/couchbase/lite/FullTextIndexConfiguration.java
+++ b/common/main/java/com/couchbase/lite/FullTextIndexConfiguration.java
@@ -38,16 +38,6 @@ public class FullTextIndexConfiguration extends IndexConfiguration {
 
     FullTextIndexConfiguration(@NonNull List<String> expressions) { super(IndexType.FULL_TEXT, expressions); }
 
-    // For Kotlin
-    FullTextIndexConfiguration(
-        @Nullable String language,
-        boolean ignoreDiacritics,
-        @NonNull List<String> expressions) {
-        super(IndexType.FULL_TEXT, expressions);
-        this.language = language;
-        this.ignoreDiacrits = ignoreDiacritics;
-    }
-
     /**
      * The language code which is an ISO-639 language such as "en", "fr", etc.
      * Setting the language code affects how word breaks and word stems are parsed.

--- a/common/main/kotlin/com/couchbase/lite/internal/Helpers.kt
+++ b/common/main/kotlin/com/couchbase/lite/internal/Helpers.kt
@@ -19,5 +19,7 @@ import com.couchbase.lite.Collection
 import com.couchbase.lite.CollectionConfiguration
 
 
-internal fun getCollectionConfigs(config: BaseReplicatorConfiguration?): Map<Collection, CollectionConfiguration>? =
-    config?.collectionConfigurations
+internal fun getCollectionConfigs(config: BaseReplicatorConfiguration?): Map<Collection, CollectionConfiguration>? {
+    val colls = config?.collectionConfigurations
+    return if ((colls == null) || (colls.isEmpty())) null else colls
+}

--- a/common/test/java/com/couchbase/lite/BaseDbTest.kt
+++ b/common/test/java/com/couchbase/lite/BaseDbTest.kt
@@ -135,7 +135,6 @@ fun readJSONResource(name: String?): String {
     return buf.toString()
 }
 
-@Suppress("SameParameterValue")
 abstract class BaseDbTest : BaseTest() {
     protected lateinit var testDatabase: Database
     protected lateinit var testCollection: Collection

--- a/common/test/java/com/couchbase/lite/BaseTest.java
+++ b/common/test/java/com/couchbase/lite/BaseTest.java
@@ -91,7 +91,7 @@ public abstract class BaseTest extends PlatformBaseTest {
 
     // Run a boolean function every `waitMs` until it it true
     // If it is not true within `maxWaitMs` fail.
-    @SuppressWarnings("BusyWait")
+    @SuppressWarnings({"BusyWait", "ConditionalBreakInInfiniteLoop"})
     protected static void waitUntil(long maxWaitMs, Fn.Provider<Boolean> test) {
         final long waitMs = 100L;
         final long endTime = System.currentTimeMillis() + maxWaitMs - waitMs;

--- a/common/test/java/com/couchbase/lite/DatabaseTest.kt
+++ b/common/test/java/com/couchbase/lite/DatabaseTest.kt
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+@file:Suppress("DEPRECATION")
+
 package com.couchbase.lite
 
 import com.couchbase.lite.internal.CouchbaseLiteInternal

--- a/common/test/java/com/couchbase/lite/LoadTest.kt
+++ b/common/test/java/com/couchbase/lite/LoadTest.kt
@@ -222,6 +222,6 @@ class LoadTest : BaseDbTest() {
         test.run()
         val elapsedTime = System.currentTimeMillis() - t0
         Report.log("Load test ${testName} completed in ${elapsedTime} ms")
-        assertTrue(elapsedTime < maxTimeMs)
+        assertTrue("Load test ${testName} over time: ${elapsedTime} > ${maxTimeMs}", elapsedTime < maxTimeMs)
     }
 }

--- a/common/test/java/com/couchbase/lite/QueryTest.java
+++ b/common/test/java/com/couchbase/lite/QueryTest.java
@@ -232,6 +232,7 @@ public class QueryTest extends BaseQueryTest {
     }
 
     // Throws clause prevents Windows compiler error
+    @SuppressWarnings("RedundantThrows")
     @Test
     public void testWhereComparison() throws Exception {
         List<String> docIds = Fn.mapToList(loadDocuments(10), Document::getId);
@@ -271,6 +272,7 @@ public class QueryTest extends BaseQueryTest {
     }
 
     // Throws clause prevents Windows compiler error
+    @SuppressWarnings("RedundantThrows")
     @Test
     public void testWhereArithmetic() throws Exception {
         List<String> docIds = Fn.mapToList(loadDocuments(10), Document::getId);
@@ -327,6 +329,7 @@ public class QueryTest extends BaseQueryTest {
     }
 
     // Throws clause prevents Windows compiler error
+    @SuppressWarnings("RedundantThrows")
     @Test
     public void testWhereAndOr() throws Exception {
         List<String> docIds = Fn.mapToList(loadDocuments(10), Document::getId);
@@ -473,6 +476,7 @@ public class QueryTest extends BaseQueryTest {
     }
 
     // Throws clause prevents Windows compiler error
+    @SuppressWarnings("RedundantThrows")
     @Test
     public void testWhereBetween() throws Exception {
         List<String> docIds = Fn.mapToList(loadDocuments(10), Document::getId);
@@ -829,6 +833,7 @@ public class QueryTest extends BaseQueryTest {
     }
 
     // Throws clause prevents Windows compiler error
+    @SuppressWarnings("RedundantThrows")
     @Test
     public void testMeta() throws Exception {
         List<String> expected = Fn.mapToList(loadDocuments(5), Document::getId);
@@ -1532,7 +1537,7 @@ public class QueryTest extends BaseQueryTest {
     // This is a pretty finickey test: the numbers are important.
     // It will fail by timing out; you'll have to figure out why.
     @Test
-    public void testLiveQuery() throws InterruptedException {
+    public void testLiveQuery() {
         List<MutableDocument> firstLoad = loadDocuments(100, 20);
 
         Query query = QueryBuilder

--- a/common/test/java/com/couchbase/lite/ReplicatorConfigurationTest.kt
+++ b/common/test/java/com/couchbase/lite/ReplicatorConfigurationTest.kt
@@ -70,8 +70,8 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     fun testCreateConfigWithDatabase1() {
         val replConfig = ReplicatorConfiguration(testDatabase, mockURLEndpoint)
         val collections = replConfig.collections
-        assertEquals(1, collections?.size)
-        assertTrue(collections?.contains(testDatabase.defaultCollection) ?: false)
+        assertEquals(1, collections.size)
+        assertTrue(collections.contains(testDatabase.defaultCollection))
         assertEquals(testDatabase, replConfig.database)
     }
 
@@ -275,7 +275,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
 
         val collections = replConfig1.collections
         assertNotNull(collections)
-        assertTrue(collections!!.isEmpty())
+        assertTrue(collections.isEmpty())
     }
 
     //     1: Create a config object with ReplicatorConfiguration.init(endpoint: endpoint).
@@ -386,8 +386,8 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
             .setConflictResolver(resolver)
         replConfig1.addCollection(collectionB, collectionConfig0)
 
-        assertTrue(replConfig1.collections?.contains(collectionA) ?: false)
-        assertTrue(replConfig1.collections?.contains(collectionB) ?: false)
+        assertTrue(replConfig1.collections.contains(collectionA))
+        assertTrue(replConfig1.collections.contains(collectionB))
 
         val collectionConfig1 = replConfig1.getCollectionConfiguration(collectionA)
         assertNotNull(collectionConfig1)
@@ -433,8 +433,8 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
         replConfig1.addCollection(collectionB, collectionConfig0)
 
 
-        assertTrue(replConfig1.collections?.contains(collectionA) ?: false)
-        assertTrue(replConfig1.collections?.contains(collectionB) ?: false)
+        assertTrue(replConfig1.collections.contains(collectionA))
+        assertTrue(replConfig1.collections.contains(collectionB))
 
         val collectionConfig1 = replConfig1.getCollectionConfiguration(collectionA)
         assertNotNull(collectionConfig1)
@@ -500,12 +500,12 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
         replConfig1.addCollection(collectionA, collectionConfig0)
         replConfig1.addCollection(collectionB, collectionConfig0)
 
-        assertTrue(replConfig1.collections?.contains(collectionA) ?: false)
-        assertTrue(replConfig1.collections?.contains(collectionB) ?: false)
+        assertTrue(replConfig1.collections.contains(collectionA))
+        assertTrue(replConfig1.collections.contains(collectionB))
 
         replConfig1.removeCollection(collectionB)
-        assertTrue(replConfig1.collections?.contains(collectionA) ?: false)
-        assertFalse(replConfig1.collections?.contains(collectionB) ?: false)
+        assertTrue(replConfig1.collections.contains(collectionA))
+        assertFalse(replConfig1.collections.contains(collectionB))
 
         assertNotNull(replConfig1.getCollectionConfiguration(collectionA))
         assertNull(replConfig1.getCollectionConfiguration(collectionB))
@@ -566,7 +566,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     @Test
     fun testAddDeletedCollections2() {
         val collectionA = testDatabase.createCollection("colA", "scopeA")
-        val collectionB = targetDatabase.createCollection("colB", "scopeA")
+        targetDatabase.createCollection("colB", "scopeA")
 
         testDatabase.deleteCollection("colB", "scopeA")
 
@@ -575,8 +575,8 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
         replConfig1.addCollection(collectionA, null)
 
         val collections = replConfig1.collections
-        assertEquals(1, collections?.size ?: 0)
-        assertTrue(collections?.contains(collectionA) ?: false)
+        assertEquals(1, collections.size)
+        assertTrue(collections.contains(collectionA))
     }
 
     //     1: Create collection "colA" in the scope "scopeA" using database instance A.
@@ -586,7 +586,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     //     7: Use addCollection() to add colB. This should cause an InvalidArgumentException.
     @Test(expected = IllegalArgumentException::class)
     fun testAddDeletedCollections3() {
-        val collectionA = testDatabase.createCollection("colA", "scopeA")
+        testDatabase.createCollection("colA", "scopeA")
         val collectionB = targetDatabase.createCollection("colB", "scopeA")
 
         targetDatabase.deleteCollection("colB", "scopeA")

--- a/common/test/kotlin/com/couchbase/lite/CommonConfigFactoryTest.kt
+++ b/common/test/kotlin/com/couchbase/lite/CommonConfigFactoryTest.kt
@@ -22,10 +22,10 @@ import org.junit.Test
 
 const val CONFIG_FACTORY_TEST_STRING = "midway down the midway"
 
-class ConfigFactoryTest : BaseTest() {
+class CommonConfigFactoryTest : BaseTest() {
     @Test
     fun testFullTextIndexConfigurationFactory() {
-        val config = FullTextIndexConfigurationFactory.create(CONFIG_FACTORY_TEST_STRING)
+        val config = FullTextIndexConfigurationFactory.newConfig(CONFIG_FACTORY_TEST_STRING)
         assertEquals(1, config.expressions.size)
         assertEquals(CONFIG_FACTORY_TEST_STRING, config.expressions[0])
     }
@@ -33,7 +33,7 @@ class ConfigFactoryTest : BaseTest() {
     @Test
     fun testFullTextIndexConfigurationFactoryWithProps() {
         val config =
-            FullTextIndexConfigurationFactory.create(CONFIG_FACTORY_TEST_STRING, language = "fr", ignoreAccents = true)
+            FullTextIndexConfigurationFactory.newConfig(CONFIG_FACTORY_TEST_STRING, language = "fr", ignoreAccents = true)
         assertEquals(1, config.expressions.size)
         assertEquals(CONFIG_FACTORY_TEST_STRING, config.expressions[0])
         assertEquals(true, config.isIgnoringAccents)
@@ -42,13 +42,13 @@ class ConfigFactoryTest : BaseTest() {
 
     @Test(expected = IllegalArgumentException::class)
     fun testFullTextIndexConfigurationFactoryNullExp() {
-        FullTextIndexConfigurationFactory.create()
+        FullTextIndexConfigurationFactory.newConfig()
     }
 
     @Test
     fun testFullTextIndexConfigurationFactoryCopy() {
-        val config1 = FullTextIndexConfigurationFactory.create(CONFIG_FACTORY_TEST_STRING)
-        val config2 = config1.create()
+        val config1 = FullTextIndexConfigurationFactory.newConfig(CONFIG_FACTORY_TEST_STRING)
+        val config2 = config1.newConfig()
         assertNotEquals(config1, config2)
         assertEquals(1, config2.expressions.size)
         assertEquals(CONFIG_FACTORY_TEST_STRING, config2.expressions[0])
@@ -56,20 +56,20 @@ class ConfigFactoryTest : BaseTest() {
 
     @Test
     fun testValueIndexConfigurationFactory() {
-        val config = ValueIndexConfigurationFactory.create(CONFIG_FACTORY_TEST_STRING)
+        val config = ValueIndexConfigurationFactory.newConfig(CONFIG_FACTORY_TEST_STRING)
         assertEquals(1, config.expressions.size)
         assertEquals(CONFIG_FACTORY_TEST_STRING, config.expressions[0])
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun testValueIndexConfigurationFactoryNullExp() {
-        ValueIndexConfigurationFactory.create()
+        ValueIndexConfigurationFactory.newConfig()
     }
 
     @Test
     fun testValueIndexConfigurationFactoryCopy() {
-        val config1 = ValueIndexConfigurationFactory.create(CONFIG_FACTORY_TEST_STRING)
-        val config2 = config1.create()
+        val config1 = ValueIndexConfigurationFactory.newConfig(CONFIG_FACTORY_TEST_STRING)
+        val config2 = config1.newConfig()
         assertNotEquals(config1, config2)
         assertEquals(1, config2.expressions.size)
         assertEquals(CONFIG_FACTORY_TEST_STRING, config2.expressions[0])
@@ -77,20 +77,20 @@ class ConfigFactoryTest : BaseTest() {
 
     @Test
     fun testLogFileConfigurationFactory() {
-        val config = LogFileConfigurationFactory.create(directory = CONFIG_FACTORY_TEST_STRING, maxSize = 4096L)
+        val config = LogFileConfigurationFactory.newConfig(directory = CONFIG_FACTORY_TEST_STRING, maxSize = 4096L)
         assertEquals(CONFIG_FACTORY_TEST_STRING, config.directory)
         assertEquals(4096L, config.maxSize)
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun testLogFileConfigurationFactoryNullDir() {
-        LogFileConfigurationFactory.create()
+        LogFileConfigurationFactory.newConfig()
     }
 
     @Test
     fun testLogFileConfigurationFactoryCopy() {
-        val config1 = LogFileConfigurationFactory.create(directory = CONFIG_FACTORY_TEST_STRING, maxSize = 4096L)
-        val config2 = config1.create(maxSize = 1024L)
+        val config1 = LogFileConfigurationFactory.newConfig(directory = CONFIG_FACTORY_TEST_STRING, maxSize = 4096L)
+        val config2 = config1.newConfig(maxSize = 1024L)
         assertNotEquals(config1, config2)
         assertEquals(CONFIG_FACTORY_TEST_STRING, config2.directory)
         assertEquals(1024L, config2.maxSize)


### PR DESCRIPTION
I have reversed my original decision to try to make the Kotlin factories backwards compatible.  Though it worked, as soon as I tried to use it I realized that it was pretty weird and prone to error.

I have deprecated all the original "create" factories and replaced them with new factory methods named "newConfig".  The new versions do not take legacy arguments.

There are a few small changes in the Java code.  The significant changes are in the ConfigurationFactories.  The bulk of the changes are the factory tests.
