### PR TITLE
CBL-3757: Use Default values in LogFileConfiguration

### DIFF
--- a/common/main/java/com/couchbase/lite/LogFileConfiguration.java
+++ b/common/main/java/com/couchbase/lite/LogFileConfiguration.java
@@ -70,15 +70,9 @@ public final class LogFileConfiguration {
         this(directory, config, false);
     }
 
-    /**
-     * Constructs a file configuration object based on another one so
-     * that it may be modified
-     *
-     * @param config The other configuration to copy settings from
-     */
     LogFileConfiguration(@NonNull String directory, @Nullable LogFileConfiguration config, boolean readonly) {
         this(
-            Preconditions.assertNotNull(directory, "directory"),
+            directory,
             (config == null) ? null : config.maxSize,
             (config == null) ? null : config.maxRotateCount,
             (config == null) ? null : config.usePlaintext,

--- a/common/test/java/com/couchbase/lite/LogTest.kt
+++ b/common/test/java/com/couchbase/lite/LogTest.kt
@@ -24,6 +24,7 @@ import com.couchbase.lite.utils.KotlinHelpers
 import org.junit.After
 import org.junit.AfterClass
 import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import java.io.BufferedReader
@@ -125,6 +126,14 @@ class LogTest : BaseDbTest() {
     fun tearDownLogTest() {
         Database.log.custom = null
         reloadStandardErrorMessages()
+    }
+
+    @Test
+    fun testFileLoggerDefaults() {
+        val config = LogFileConfiguration("up/down")
+        assertEquals(Defaults.LogFile.MAX_SIZE, config.maxSize)
+        assertEquals(Defaults.LogFile.MAX_ROTATE_COUNT, config.maxRotateCount)
+        assertEquals(Defaults.LogFile.USE_PLAIN_TEXT, config.usesPlaintext())
     }
 
     @Test


### PR DESCRIPTION
LogFileConfig is already using defaults from the new, autogenerated Defaults file.

Just add tests to verify.