### PR TITLE
CBL-3761: Use Default values in FullTextIndexConfiguration

### DIFF
--- a/common/test/java/com/couchbase/lite/QueryTest.java
+++ b/common/test/java/com/couchbase/lite/QueryTest.java
@@ -597,14 +597,22 @@ public class QueryTest extends BaseQueryTest {
     }
 
     @Test
+    public void testFullTextIndexConfigDefaults() throws CouchbaseLiteException {
+        final FullTextIndexConfiguration idxConfig = new FullTextIndexConfiguration("sentence", "nonesense");
+        assertEquals(Defaults.FullTextIndex.IGNORE_ACCENTS, idxConfig.isIgnoringAccents());
+        assertEquals(Locale.getDefault().getLanguage(), idxConfig.getLanguage());
+
+        idxConfig.setLanguage(null);
+        assertNull(idxConfig.getLanguage());
+    }
+
+    @Test
     public void testFullTextIndexConfig() throws CouchbaseLiteException {
         loadJSONResourceIntoCollection("sentences.json");
 
-        final FullTextIndexConfiguration idxConfig = new FullTextIndexConfiguration("sentence", "nonesense");
-        assertFalse(idxConfig.isIgnoringAccents());
-        assertEquals("en", idxConfig.getLanguage());
-
-        idxConfig.setLanguage("en-ca").ignoreAccents(true);
+        final FullTextIndexConfiguration idxConfig = new FullTextIndexConfiguration("sentence", "nonesense")
+            .setLanguage("en-ca")
+            .ignoreAccents(true);
         assertEquals("en-ca", idxConfig.getLanguage());
         assertTrue(idxConfig.isIgnoringAccents());
 


### PR DESCRIPTION
FTIConfig is already using autogenerated defaults.

Add tests to verify default values and to verify that null (disable language feature) is a legal option.

Note that this does not actually test that setting null actually disables the feature.