### PR TITLE
CBL-3769: Use Default values in CollectionConfiguration

### DIFF
--- a/common/test/java/com/couchbase/lite/ReplicatorConfigurationTest.kt
+++ b/common/test/java/com/couchbase/lite/ReplicatorConfigurationTest.kt
@@ -62,6 +62,24 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
         makeReplicatorConfig().heartbeat = 2147484
     }
 
+    @Test
+    fun testConfigDefaults() {
+        val config = CollectionConfiguration()
+        assertNull(config.channels)
+        assertNull(config.documentIDs)
+        assertNull(config.pushFilter)
+        assertNull(config.pullFilter)
+        assertNull(config.conflictResolver)
+
+        // this does not actually verify that setting null
+        // causes Replication to use the default resolver.
+        // It just tests that null is a legal value and that it sticks.
+        config.conflictResolver = ConflictResolver { conflict -> null }
+        assertNotNull(config.conflictResolver)
+        config.conflictResolver = null
+        assertNull(config.conflictResolver)
+    }
+
     //     1: Create a config object with ReplicatorConfiguration.init(database, endpoint).
     //     2: Access collections property. It mush have one collection which is the default collection.
     //     6: ReplicatorConfiguration.database should be the database with which the configuration was created


### PR DESCRIPTION
Again: already using defaults.  Just add a test to be sure they are correct.

Note, again, that the test for a null arg does not actually test null == default resolver