### PR TITLE
CBL-3765:  Use Default values in ReplicatorConfiguration

### DIFF
--- a/common/main/java/com/couchbase/lite/Defaults.java
+++ b/common/main/java/com/couchbase/lite/Defaults.java
@@ -64,6 +64,9 @@ public final class Defaults {
 
         /** Purge documents when a user loses access */
         public static final boolean ENABLE_AUTO_PURGE = true;
+
+        /** Whether or not a replicator only accepts self-signed certificates from the remote */
+        public static final boolean SELF_SIGNED_CERTIFICATE_ONLY = false;
     }
 
     public static final class Listener {


### PR DESCRIPTION
The last of the updates to use defaults.  The only change is splitting the test into two: one test for defaults, the other for backwards compatibility.  Use of the new default is in EE

This uses my approximation of change to the auto-generated Defaults class.  If the real one becomes available, before the push, I will use it instead.