### PR TITLE
Package protect FleeceValue.withContent

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/fleece/FLValue.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/FLValue.java
@@ -17,7 +17,6 @@ package com.couchbase.lite.internal.fleece;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 
 import java.util.List;
 import java.util.Map;
@@ -240,9 +239,8 @@ public class FLValue {
         }
     }
 
-    @VisibleForTesting
     @Nullable
-    public <T> T withContent(@NonNull Fn.Function<Long, T> fn) { return fn.apply(handle); }
+    <T> T withContent(@NonNull Fn.Function<Long, T> fn) { return fn.apply(handle); }
 
     @NonNull
     FLArray asFLArray() { return FLArray.create(asArray(handle)); }

--- a/common/test/java/com/couchbase/lite/internal/ReplicationConfigurationTest.kt
+++ b/common/test/java/com/couchbase/lite/internal/ReplicationConfigurationTest.kt
@@ -23,6 +23,7 @@ import com.couchbase.lite.Scope
 import com.couchbase.lite.internal.core.C4Replicator
 import com.couchbase.lite.internal.fleece.FLEncoder
 import com.couchbase.lite.internal.fleece.FLValue
+import com.couchbase.lite.internal.fleece.withContent
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -109,7 +110,7 @@ class ReplicationConfigurationTest : BaseDbTest() {
         val colls = mapOf(testDatabase.createCollection("pogs") to config)
         val token = ReplicationCollection.createAll(colls)[0].token
 
-        body.withContent {
+        withContent(body) {
             ReplicationCollection.filterCallback(token, null, null, "doc-1", "99", 0, it, false)
             ReplicationCollection.filterCallback(token, null, null, "doc-2", "88", 0, it, true)
         }
@@ -132,7 +133,7 @@ class ReplicationConfigurationTest : BaseDbTest() {
         val colls = mapOf(testDatabase.createCollection("pogs") to config)
         val token = ReplicationCollection.createAll(colls)[0].token
 
-        body.withContent {
+        withContent(body) {
             ReplicationCollection.filterCallback(token, null, null, "doc-1", "99", 0, it, false)
             ReplicationCollection.filterCallback(token, null, null, "doc-2", "88", 0, it, true)
         }
@@ -156,7 +157,7 @@ class ReplicationConfigurationTest : BaseDbTest() {
         val colls = mapOf(testDatabase.createCollection("pogs") to config)
         val token = ReplicationCollection.createAll(colls)[0].token
 
-        body.withContent {
+        withContent(body) {
             ReplicationCollection.filterCallback(token, null, null, "doc-1", "99", 0, it, false)
             ReplicationCollection.filterCallback(token, null, null, "doc-2", "88", 0, it, true)
         }
@@ -182,7 +183,7 @@ class ReplicationConfigurationTest : BaseDbTest() {
         // this token should be ignored.
         val token = ReplicationCollection.createAll(colls)[0].token + 1
 
-        body.withContent {
+        withContent(body) {
             ReplicationCollection.filterCallback(token, null, null, "doc-1", "99", 0, it, false)
             ReplicationCollection.filterCallback(token, null, null, "doc-2", "88", 0, it, true)
         }

--- a/common/test/java/com/couchbase/lite/internal/fleece/FleeceTestHelper.kt
+++ b/common/test/java/com/couchbase/lite/internal/fleece/FleeceTestHelper.kt
@@ -1,0 +1,22 @@
+//
+// Copyright (c) 2022 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package com.couchbase.lite.internal.fleece
+
+import com.couchbase.lite.internal.utils.Fn
+
+
+fun <T> withContent(value: FLValue, fn: Fn.Function<Long, T>) = value.withContent(fn)
+


### PR DESCRIPTION
This trivial change makes FLValue.withContent package protected.  It was public so that it could be used from tests.
Changing to this implementation removes a Lint warning and returns the method to package visibility.