### PR TITLE
CBL-3939: Keep legacy setters from modifying the CollectionConfiguration

### DIFF
--- a/common/test/kotlin/com/couchbase/lite/DeprecatedConfigFactoryTest.kt
+++ b/common/test/kotlin/com/couchbase/lite/DeprecatedConfigFactoryTest.kt
@@ -88,7 +88,7 @@ class DeprecatedConfigFactoryTest : BaseDbTest() {
     fun testReplicatorConfigFromCollectionWithDefaultAndOther() {
         val config1 = ReplicatorConfigurationFactory
             .newConfig(testEndpoint, mapOf(testCollection to CollectionConfiguration()))
-        val filter = ReplicationFilter {document, flags -> true }
+        val filter = ReplicationFilter {_, _ -> true }
 
         // Information gets lost here (the configuration of testCollection): should be a log message
         val config2 = config1.create(pushFilter = filter)


### PR DESCRIPTION
An edge case that is a significant bug: Multiple collections may be configured by a single instance of CollectionConfiguration.  The legacy ReplicatorConfiguration mutators mutate the CollectionConfiguration for the default collection.  If the default collection is one of multiple collections configured with a single configuration, then using the legacy mutators will change all of them.