### PR TITLE
Pr/cbl 3941

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractReplicator.java
+++ b/common/main/java/com/couchbase/lite/AbstractReplicator.java
@@ -74,7 +74,7 @@ public abstract class AbstractReplicator extends BaseReplicator
         ReplicatorCookieStore(@NonNull Database db) { this.db = db; }
 
         @Override
-        public void setCookie(@NonNull URI uri, @NonNull String header) { db.setCookie(uri, header); }
+        public void setCookies(@NonNull URI uri, @NonNull List<String> cookies) { db.setCookies(uri, cookies); }
 
         @Nullable
         @Override

--- a/common/main/java/com/couchbase/lite/internal/replicator/CBLCookieStore.java
+++ b/common/main/java/com/couchbase/lite/internal/replicator/CBLCookieStore.java
@@ -18,34 +18,14 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.StringTokenizer;
-
-import okhttp3.Cookie;
-import okhttp3.HttpUrl;
 
 
 /**
  * Interface for CookieStore
  */
 public interface CBLCookieStore {
-    /**
-     * Parse request header "Cookie" in the format of "name=value;name=value..."
-     * into OKHTTP Cookie used by AbstractCBLWebSocket.
-     */
-    @NonNull
-    static List<Cookie> parseCookies(@NonNull HttpUrl url, @NonNull String cookies) {
-        final List<Cookie> cookieList = new ArrayList<>();
-        final StringTokenizer st = new StringTokenizer(cookies, ";");
-        while (st.hasMoreTokens()) {
-            final Cookie cookie = Cookie.parse(url, st.nextToken().trim());
-            if (cookie != null) { cookieList.add(cookie); }
-        }
-        return cookieList;
-    }
-
-    void setCookie(@NonNull URI uri, @NonNull String setCookieHeader);
+    void setCookies(@NonNull URI uri, @NonNull List<String> cookies);
 
     @Nullable
     String getCookies(@NonNull URI uri);

--- a/common/main/java/com/couchbase/lite/internal/sockets/OkHttpSocket.java
+++ b/common/main/java/com/couchbase/lite/internal/sockets/OkHttpSocket.java
@@ -21,13 +21,18 @@ import androidx.annotation.VisibleForTesting;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.StringTokenizer;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import okhttp3.Cookie;
 import okhttp3.Headers;
+import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -88,6 +93,20 @@ public final class OkHttpSocket extends WebSocketListener implements SocketToRem
         @Override
         public void cancel() { throw new UnsupportedOperationException(); }
     };
+
+    /**
+     * Parse request header cookie in the format of "name=value;name=value..." as an OkHttp Cookie.
+     */
+    @NonNull
+    public static List<Cookie> parseCookies(@NonNull HttpUrl url, @NonNull String cookies) {
+        final List<Cookie> cookieList = new ArrayList<>();
+        final StringTokenizer st = new StringTokenizer(cookies, ";");
+        while (st.hasMoreTokens()) {
+            final Cookie cookie = Cookie.parse(url, st.nextToken().trim());
+            if (cookie != null) { cookieList.add(cookie); }
+        }
+        return cookieList;
+    }
 
 
     //-------------------------------------------------------------------------

--- a/common/test/java/com/couchbase/lite/CookieStoreTest.kt
+++ b/common/test/java/com/couchbase/lite/CookieStoreTest.kt
@@ -1,0 +1,117 @@
+//
+// Copyright (c) 2020 Couchbase. All rights reserved.
+// COUCHBASE CONFIDENTIAL - part of Couchbase Lite Enterprise Edition
+//
+package com.couchbase.lite
+
+import com.couchbase.lite.internal.sockets.OkHttpSocket
+import com.couchbase.lite.internal.utils.SlowTest
+import okhttp3.Cookie
+import okhttp3.HttpUrl
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.net.URI
+
+class CookieStoreTest : BaseDbTest() {
+    @SlowTest
+    @Test
+    fun testSetGetCookies() {
+        val cookieStore = AbstractReplicator.ReplicatorCookieStore(testDatabase)
+
+        // Session cookie
+        val c1 = makeCookie("sessionid", "s1234", -1, "localhost")
+        // Cookie with max-age
+        val c2 = makeCookie("geoid", "g1000", 30, "localhost")
+        // Cookie with short max-age for testing expiration
+        val c3 = makeCookie("fav", "choco", 1, "localhost")
+        // Cookie with a specific domain
+        val c4 = makeCookie("comp", "couchbase", 30, "www.couchbase.com")
+
+
+        // Save each cookie in the store
+        val uri = URI.create("http://localhost:4984/" + testDatabase.name)
+        cookieStore.setCookies(uri, listOf(c1.toString(), c2.toString(), c3.toString(), c4.toString()))
+
+
+        // Save couchbase domain cookie
+        val cbUri = URI.create("http://www.couchbase.com/")
+        cookieStore.setCookies(cbUri, listOf(c4.toString()))
+
+        // Sleep for 2 seconds for the c3 cookie to expire
+        Thread.sleep(2000)
+
+        // Get localhost cookie
+        var cookieHeader = cookieStore.getCookies(uri)
+        assertNotNull(cookieHeader)
+        var cookies = OkHttpSocket.parseCookies(HttpUrl.get(uri)!!, cookieHeader!!)
+        assertEquals(2, cookies.size)
+        assertTrue(containsCookie(cookies, c1))
+        assertTrue(containsCookie(cookies, c2))
+        assertFalse(containsCookie(cookies, c3)) // Expired
+        assertFalse(containsCookie(cookies, c4)) // Mismatched domain
+
+        // Get couchbase domain cookie
+        cookieHeader = cookieStore.getCookies(cbUri)
+        assertNotNull(cookieHeader)
+        cookies = OkHttpSocket.parseCookies(HttpUrl.get(cbUri)!!, cookieHeader!!)
+        assertEquals(1, cookies.size)
+        assertTrue(containsCookie(cookies, c4))
+
+        // After reopen db, the c1 cookie should be gone as it is a session cookie
+        reopenTestDb()
+        cookieHeader = AbstractReplicator.ReplicatorCookieStore(testDatabase).getCookies(uri)
+        assertNotNull(cookies)
+        cookies = OkHttpSocket.parseCookies(HttpUrl.get(uri)!!, cookieHeader!!)
+        assertEquals(1, cookies.size)
+        assertTrue(containsCookie(cookies, c2))
+    }
+
+    @Test
+    fun testParseCookies() {
+        val uri = URI.create("http://www.couchbase.com/")
+
+        // Empty
+        var cookies = OkHttpSocket.parseCookies(HttpUrl.get(uri)!!, "")
+        assertNotNull(cookies)
+        assertEquals(0, cookies.size)
+
+        // Invalid
+        cookies = OkHttpSocket.parseCookies(HttpUrl.get(uri)!!, "cookie")
+        assertNotNull(cookies)
+        assertEquals(0, cookies.size)
+
+        // One cookie
+        cookies = OkHttpSocket.parseCookies(HttpUrl.get(uri)!!, "a1=b1")
+        assertNotNull(cookies)
+        assertEquals(1, cookies.size)
+        assertEquals("a1", cookies[0].name())
+        assertEquals("b1", cookies[0].value())
+
+        // Multiple cookies
+        cookies = OkHttpSocket.parseCookies(HttpUrl.get(uri)!!, "a1=b1; a2=b2")
+        assertNotNull(cookies)
+        assertEquals(2, cookies.size)
+        assertEquals("a1", cookies[0].name())
+        assertEquals("b1", cookies[0].value())
+        assertEquals("a2", cookies[1].name())
+        assertEquals("b2", cookies[1].value())
+    }
+
+    private fun makeCookie(name: String, value: String, maxAge: Long, domain: String?): Cookie {
+        val builder = Cookie.Builder().name(name).value(value)
+        if (maxAge >= 0) {
+            builder.expiresAt(System.currentTimeMillis() + (maxAge * 1000))
+        }
+        if (domain != null) {
+            builder.domain(domain)
+        }
+        return builder.build()
+    }
+
+    private fun containsCookie(list: List<Cookie>, cookie: Cookie): Boolean {
+        return null != list.firstOrNull { it.name().equals(cookie.name()) && it.value().equals(cookie.value()) }
+    }
+}

--- a/common/test/java/com/couchbase/lite/LoadTest.kt
+++ b/common/test/java/com/couchbase/lite/LoadTest.kt
@@ -28,7 +28,7 @@ import java.util.*
 
 private const val ITERATIONS = 2000
 
-// Timings were chosen to allow a Nexus 6 running Android 7.0 to pass.
+// Timings were chosen to allow a Samsung Galaxy A1 running Android 7.0 to pass.
 class LoadTest : BaseDbTest() {
 
     // https://github.com/couchbase/couchbase-lite-android/issues/1447
@@ -40,7 +40,7 @@ class LoadTest : BaseDbTest() {
         val docs = createComplexTestDocs(ITERATIONS, tag)
 
         assertEquals(0, testCollection.count)
-        timeTest("testCreateUnbatched", 9 * 1000L) {
+        timeTest("testCreateUnbatched", 11) {
             for (doc in docs) {
                 testCollection.save(doc)
             }
@@ -57,7 +57,7 @@ class LoadTest : BaseDbTest() {
         val docs = createComplexTestDocs(ITERATIONS, tag)
 
         assertEquals(0, testCollection.count)
-        timeTest("testCreateBatched", 5 * 1000L) {
+        timeTest("testCreateBatched", 5) {
             testDatabase.inBatch<CouchbaseLiteException> {
                 for (doc in docs) {
                     testCollection.save(doc)
@@ -75,7 +75,7 @@ class LoadTest : BaseDbTest() {
         val ids = saveDocsInCollection(createComplexTestDocs(ITERATIONS, tag)).map { it.id }
 
         assertEquals(ITERATIONS.toLong(), testCollection.count)
-        timeTest("testRead", 2 * 1000L) {
+        timeTest("testRead", 3) {
             for (id in ids) {
                 val doc = testCollection.getDocument(id)
                 assertNotNull(doc)
@@ -101,7 +101,7 @@ class LoadTest : BaseDbTest() {
         val ids = saveDocsInCollection(createComplexTestDocs(ITERATIONS, getUniqueName("update"))).map { it.id }
 
         assertEquals(ITERATIONS.toLong(), testCollection.count)
-        timeTest("testUpdate1", 14 * 1000L) {
+        timeTest("testUpdate1", 21) {
             var i = 0
             for (id in ids) {
                 i++
@@ -140,7 +140,7 @@ class LoadTest : BaseDbTest() {
         testCollection.save(mDoc)
 
         assertEquals(1L, testCollection.count)
-        timeTest("testUpdate2", 11 * 1000L) {
+        timeTest("testUpdate2", 15) {
             for (i in 0..ITERATIONS) {
                 mDoc = testCollection.getDocument(mDoc.id)!!.toMutable()
                 mDoc.setValue("map", mapOf("idx" to i, "long" to i.toLong(), TEST_DOC_TAG_KEY to getUniqueName("tag")))
@@ -164,7 +164,7 @@ class LoadTest : BaseDbTest() {
         val docs = saveDocsInCollection(createComplexTestDocs(ITERATIONS, getUniqueName("delete")))
 
         assertEquals(ITERATIONS.toLong(), testCollection.count)
-        timeTest("testDelete", 9 * 1000L) {
+        timeTest("testDelete", 12) {
             for (doc in docs) {
                 testCollection.delete(doc)
             }
@@ -177,7 +177,7 @@ class LoadTest : BaseDbTest() {
     @Test
     fun testSaveRevisions1() {
         var mDoc = MutableDocument()
-        timeTest("testSaveRevisions1", 4 * 1000L) {
+        timeTest("testSaveRevisions1", 8) {
             testDatabase.inBatch<CouchbaseLiteException> {
                 for (i in 0 until ITERATIONS) {
                     mDoc.setValue("count", i)
@@ -194,7 +194,7 @@ class LoadTest : BaseDbTest() {
     @Test
     fun testSaveRevisions2() {
         val mDoc = MutableDocument()
-        timeTest("testSaveRevisions2", 2 * 1000L) {
+        timeTest("testSaveRevisions2", 4) {
             testDatabase.inBatch<CouchbaseLiteException> {
                 for (i in 0 until ITERATIONS) {
                     mDoc.setValue("count", i)
@@ -217,11 +217,13 @@ class LoadTest : BaseDbTest() {
         )
     }
 
-    private fun timeTest(testName: String, maxTimeMs: Long, test: Runnable) {
+    private fun timeTest(testName: String, maxTimeSec: Long, test: Runnable) {
         val t0 = System.currentTimeMillis()
         test.run()
         val elapsedTime = System.currentTimeMillis() - t0
         Report.log("Load test ${testName} completed in ${elapsedTime} ms")
-        assertTrue("Load test ${testName} over time: ${elapsedTime} > ${maxTimeMs}", elapsedTime < maxTimeMs)
+        assertTrue(
+            "Load test ${testName} over time: ${elapsedTime} > ${maxTimeSec}",
+            elapsedTime < (maxTimeSec * 1000L))
     }
 }

--- a/common/test/java/com/couchbase/lite/internal/core/C4ReplicatorTest.kt
+++ b/common/test/java/com/couchbase/lite/internal/core/C4ReplicatorTest.kt
@@ -90,7 +90,7 @@ class C4ReplicatorTest : BaseDbTest() {
             SocketFactory(
                 testReplicatorConfig,
                 object : CBLCookieStore {
-                    override fun setCookie(uri: URI, setCookieHeader: String) = Unit
+                    override fun setCookies(uri: URI, cookies: List<String>) = Unit
                     override fun getCookies(uri: URI): String? = null
                 })
             { }

--- a/common/test/java/com/couchbase/lite/mock/SocketMocks.kt
+++ b/common/test/java/com/couchbase/lite/mock/SocketMocks.kt
@@ -17,7 +17,11 @@ package com.couchbase.lite.mock
 
 import com.couchbase.lite.internal.replicator.AbstractCBLWebSocket
 import com.couchbase.lite.internal.replicator.CBLCookieStore
-import com.couchbase.lite.internal.sockets.*
+import com.couchbase.lite.internal.sockets.CloseStatus
+import com.couchbase.lite.internal.sockets.SocketFromCore
+import com.couchbase.lite.internal.sockets.SocketFromRemote
+import com.couchbase.lite.internal.sockets.SocketToCore
+import com.couchbase.lite.internal.sockets.SocketToRemote
 import com.couchbase.lite.internal.utils.Fn
 import java.net.URI
 import java.security.cert.Certificate
@@ -44,8 +48,7 @@ open class MockCore : SocketToCore {
     override fun writeToCore(data: ByteArray): Unit = TODO("Not yet implemented")
     override fun requestCoreClose(status: CloseStatus): Unit = TODO("Not yet implemented")
     override fun closeCore(status: CloseStatus): Unit = TODO("Not yet implemented")
-    override fun ackOpenToCore(httpStatus: Int, responseHeadersFleece: ByteArray?): Unit =
-        TODO("Not yet implemented")
+    override fun ackOpenToCore(httpStatus: Int, responseHeadersFleece: ByteArray?): Unit = TODO("Not yet implemented")
 }
 
 open class MockRemote : SocketToRemote {
@@ -54,11 +57,10 @@ open class MockRemote : SocketToRemote {
     override fun writeToRemote(data: ByteArray): Boolean = TODO("Not yet implemented")
     override fun closeRemote(status: CloseStatus): Boolean = TODO("Not yet implemented")
     override fun cancelRemote(): Unit = TODO("Not yet implemented")
-    override fun openRemote(uri: URI, options: MutableMap<String, Any>?): Boolean =
-        TODO("Not yet implemented")
+    override fun openRemote(uri: URI, options: MutableMap<String, Any>?): Boolean = TODO("Not yet implemented")
 }
 
 open class MockCookieStore : CBLCookieStore {
-    override fun setCookie(uri: URI, setCookieHeader: String): Unit = TODO("Not yet implemented")
+    override fun setCookies(uri: URI, cookies: List<String>): Unit = TODO("Not yet implemented")
     override fun getCookies(uri: URI): String? = TODO("Not yet implemented")
 }


### PR DESCRIPTION
I verify (after extensive discussion with @pasin ) that Java is doing the right thing.  It passes the *entire* value of the Set-Cookie header to Lite Core.

In any subsequent request in which the socket is in the UNOPENED or OPENING state (that is, not OPEN, CLOSING or CLOSED), it will add any cookies that it gets from LiteCore in the `options` parameter passed in the socket creation callback, as well as any cookies it gets from Lite Core, in a call to `c4db_getCookies`.

In both of these two cases the Java code expects that the string that it gets from Lite Core will *NOT* be cookies as they appear in a request header but will, instead, be <cookie-name>=<cookie-value>(;<cookie-name>=<cookie-value>)*

As long as Lite Core is correctly parsing and expiring cookies, the Java code is doing the right thing.

En-passant, I've eliminated a bunch of unnecessary locking and moved a test that should be common, out of the EE only tests.