### PR TITLE
CBL-3981: Update core; disallow deleting the default collection

### DIFF
--- a/common/test/java/com/couchbase/lite/DatabaseTest.kt
+++ b/common/test/java/com/couchbase/lite/DatabaseTest.kt
@@ -35,6 +35,11 @@ import java.util.*
 import java.util.concurrent.FutureTask
 import java.util.concurrent.TimeUnit
 
+
+// The suite of tests that verifies behavior
+// with a deleted default collection are in
+// cbl-java-common @ a2de0d43d09ce64fd3a1301dc35
+
 // The rules in this test are:
 // baseTestDb is managed by the superclass
 // If a test creates a new database it guarantees that it is deleted.
@@ -868,110 +873,6 @@ class DatabaseTest : LegacyBaseDbTest() {
         assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) {
             baseTestDb.getCollection("bobblehead", "horo")
         }
-    }
-
-    //---------------------------------------------
-    //  Collections, 8.9 Use Database API when the Default Collection is Deleted
-    //---------------------------------------------
-
-    @Test
-    fun testUseDatabaseCountWhenDefaultCollectionIsDeleted() {
-        baseTestDb.deleteCollection(Collection.DEFAULT_NAME)
-        assertEquals(0, baseTestDb.count)
-    }
-
-    @Test(expected = IllegalStateException::class)
-    fun testUseDatabaseSaveDocumentWhenDefaultCollectionIsDeleted() {
-        baseTestDb.deleteCollection(Collection.DEFAULT_NAME)
-        baseTestDb.save(MutableDocument("BobaFet"))
-    }
-
-    @Test(expected = IllegalStateException::class)
-    fun testUseDatabaseGetDocumentWhenDefaultCollectionIsDeleted() {
-        baseTestDb.save(MutableDocument("BobaFet"))
-        assertNotNull(baseTestDb.getDocument("BobaFet"))
-        baseTestDb.deleteCollection(Collection.DEFAULT_NAME)
-        baseTestDb.getDocument("BobaFet")
-    }
-
-    @Test(expected = IllegalStateException::class)
-    fun testUseDatabaseDeleteDocumentWhenDefaultCollectionIsDeleted() {
-        baseTestDb.save(MutableDocument("BobaFet"))
-        val doc = baseTestDb.getDocument("BobaFet")
-        assertNotNull(doc)
-        baseTestDb.deleteCollection(Collection.DEFAULT_NAME)
-        baseTestDb.delete(doc!!)
-    }
-
-    @Test(expected = IllegalStateException::class)
-    fun testUseDatabasePurgeDocumentWhenDefaultCollectionIsDeleted() {
-        baseTestDb.save(MutableDocument("BobaFet"))
-        val doc = baseTestDb.getDocument("BobaFet")
-        assertNotNull(doc)
-        baseTestDb.deleteCollection(Collection.DEFAULT_NAME)
-        baseTestDb.purge(doc!!)
-    }
-
-    @Test(expected = IllegalStateException::class)
-    fun testUseDatabaseSetDocumentExpirationWhenDefaultCollectionIsDeleted() {
-        baseTestDb.save(MutableDocument("BobaFet"))
-        baseTestDb.deleteCollection(Collection.DEFAULT_NAME)
-        baseTestDb.setDocumentExpiration("BobaFet", Date(System.currentTimeMillis() + (5 * (60 * 1000))))
-    }
-
-    @Test(expected = IllegalStateException::class)
-    fun testUseDatabaseGetDocumentExpirationWhenDefaultCollectionIsDeleted() {
-        baseTestDb.save(MutableDocument("BobaFet"))
-        baseTestDb.setDocumentExpiration("BobaFet", Date(System.currentTimeMillis() + (5 * (60 * 1000))))
-        baseTestDb.deleteCollection(Collection.DEFAULT_NAME)
-        baseTestDb.getDocumentExpiration("BobaFet")
-    }
-
-    @Test
-    fun testUseDatabaseCreateQueryWhenDefaultCollectionIsDeleted() {
-        baseTestDb.deleteCollection(Collection.DEFAULT_NAME)
-        baseTestDb.createQuery("SELECT _id FROM .")
-    }
-
-    @Test(expected = IllegalStateException::class)
-    fun testUseDatabaseCreateIndexesWhenDefaultCollectionIsDeleted() {
-        baseTestDb.deleteCollection(Collection.DEFAULT_NAME)
-        baseTestDb.createIndex("Princesses", ValueIndexConfiguration("HanSolo"))
-    }
-
-    @Test(expected = IllegalStateException::class)
-    fun testUseDatabaseGetIndexesWhenDefaultCollectionIsDeleted() {
-        baseTestDb.createIndex("Princesses", ValueIndexConfiguration("Leia"))
-        baseTestDb.deleteCollection(Collection.DEFAULT_NAME)
-        baseTestDb.indexes.size
-    }
-
-    @Test(expected = IllegalStateException::class)
-    fun testUseDatabaseDeleteIndexWhenDefaultCollectionIsDeleted() {
-        baseTestDb.createIndex("Princesses", ValueIndexConfiguration("Leia"))
-        assertEquals(1, baseTestDb.indexes.size)
-        baseTestDb.deleteCollection(Collection.DEFAULT_NAME)
-        baseTestDb.deleteIndex("index")
-    }
-
-    @Test(expected = IllegalStateException::class)
-    fun testUseDatabaseAddChangeListenerWhenDefaultCollectionIsDeleted() {
-        baseTestDb.deleteCollection(Collection.DEFAULT_NAME)
-        baseTestDb.addChangeListener { fail("Unexpected call to change listener") }
-    }
-
-    @Test(expected = IllegalStateException::class)
-    fun testUseDatabaseAddDocumentChangeListenerWhenDefaultCollectionIsDeleted() {
-        baseTestDb.save(MutableDocument("BobaFet"))
-        baseTestDb.deleteCollection(Collection.DEFAULT_NAME)
-        baseTestDb.addDocumentChangeListener("BobaFet") { fail("Unexpected call to change listener") }
-    }
-
-    @Test(expected = IllegalStateException::class)
-    fun testUseDatabaseRemoveChangeListenerWhenDefaultCollectionIsDeleted() {
-        val token = baseTestDb.addChangeListener { fail("Unexpected call to change listener") }
-        baseTestDb.deleteCollection(Collection.DEFAULT_NAME)
-        baseTestDb.removeChangeListener(token)
     }
 
     //---------------------------------------------

--- a/common/test/java/com/couchbase/lite/internal/core/C4DatabaseTest.kt
+++ b/common/test/java/com/couchbase/lite/internal/core/C4DatabaseTest.kt
@@ -390,11 +390,8 @@ class C4DatabaseTest : C4BaseTest() {
         assertEquals(setOf("test_coll_1", "test_coll_2", "test_coll_3"), c4Database.getCollectionNames("test_scope"))
     }
 
-    @Test
-    fun testDeleteDefaultCollection() {
-        c4Database.deleteCollection(Scope.DEFAULT_NAME, Collection.DEFAULT_NAME)
-        assertNull(c4Database.defaultCollection)
-    }
+    // Test DeleteDefaultCollection are in
+    // cbl-java-common @ a2de0d43d09ce64fd3a1301dc35
 
     // After deleting a collection, we can no longer get that collection (make sure test doesn't crash)
     @Test(expected = LiteCoreException::class)

--- a/common/test/kotlin/com/couchbase/lite/DeprecatedConfigFactoryTest.kt
+++ b/common/test/kotlin/com/couchbase/lite/DeprecatedConfigFactoryTest.kt
@@ -13,6 +13,9 @@ import org.junit.Test
 import java.net.URI
 
 
+// The suite of tests that verifies behavior
+// with a deleted default collection are in
+// cbl-java-common @ a2de0d43d09ce64fd3a1301dc35
 class DeprecatedConfigFactoryTest : BaseDbTest() {
     private val testEndpoint = URLEndpoint(URI("ws://foo.couchbase.com/db"))
 
@@ -33,13 +36,6 @@ class DeprecatedConfigFactoryTest : BaseDbTest() {
     @Test(expected = IllegalArgumentException::class)
     fun testReplicatorConfigNoProtocol() {
         ReplicatorConfigurationFactory.create(testDatabase, type = ReplicatorType.PULL)
-    }
-
-    // Create on factory with db with no default collection should fail
-    @Test(expected = IllegalArgumentException::class)
-    fun testReplicatorConfigNoDefaultCollection() {
-        testDatabase.defaultCollection?.delete()
-        ReplicatorConfigurationFactory.create(testDatabase, testEndpoint)
     }
 
     // Create with db and endpoint should succeed
@@ -101,18 +97,6 @@ class DeprecatedConfigFactoryTest : BaseDbTest() {
 
         assertEquals(setOf(defaultCollection), config2.collections)
         assertEquals(filter, config2.getCollectionConfiguration(defaultCollection)?.pushFilter)
-    }
-
-    // Create from a source without default collection,
-    // explicitly specifying a non-default collection should fail
-    // ReplicatorConfiguration.create() needs to be able to configure
-    // a default collection.  If there is none, it must fail.
-    @Test(expected = IllegalArgumentException::class)
-    fun testReplicatorConfigFromCollectionWithoutDefault() {
-        testCollection.database.defaultCollection!!.delete()
-        val config1 = ReplicatorConfigurationFactory
-            .newConfig(testEndpoint, mapOf(testCollection to CollectionConfiguration()))
-        config1.create()
     }
 
     // Create with one of the parameters that has migrated to the collection configuration


### PR DESCRIPTION
Remove tests that delete the default collection