### PR TITLE
CBL-3964: Set per-device timeouts for load tests

### DIFF
--- a/android/androidTest/java/com/couchbase/lite/PlatformBaseTest.java
+++ b/android/androidTest/java/com/couchbase/lite/PlatformBaseTest.java
@@ -22,7 +22,6 @@ import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -98,4 +97,7 @@ public abstract class PlatformBaseTest implements PlatformTest {
 
     @Override
     public final Exclusion getExclusions(@NonNull String tag) { return PLATFORM_DEPENDENT_TESTS.get(tag); }
+
+    @Override
+    public final String getDevice() { return android.os.Build.PRODUCT; }
 }

--- a/common/test/java/com/couchbase/lite/BaseTest.java
+++ b/common/test/java/com/couchbase/lite/BaseTest.java
@@ -89,7 +89,7 @@ public abstract class BaseTest extends PlatformBaseTest {
     @NonNull
     public static String getUniqueName(@NonNull String prefix) { return StringUtils.getUniqueName(prefix, 8); }
 
-    // Run a boolean function every `waitMs` until it it true
+    // Run a boolean function every `waitMs` until it is true
     // If it is not true within `maxWaitMs` fail.
     @SuppressWarnings({"BusyWait", "ConditionalBreakInInfiniteLoop"})
     protected static void waitUntil(long maxWaitMs, Fn.Provider<Boolean> test) {

--- a/common/test/java/com/couchbase/lite/PlatformTest.java
+++ b/common/test/java/com/couchbase/lite/PlatformTest.java
@@ -51,6 +51,9 @@ public interface PlatformTest {
     /* Skip the test on some platforms */
     Exclusion getExclusions(@NonNull String tag);
 
+    /* Get the device name */
+    String getDevice();
+
     AbstractExecutionService getExecutionService(ThreadPoolExecutor executor);
 
     /* Schedule a task to be executed asynchronously. */

--- a/java/test/java/com/couchbase/lite/PlatformBaseTest.java
+++ b/java/test/java/com/couchbase/lite/PlatformBaseTest.java
@@ -107,10 +107,6 @@ public abstract class PlatformBaseTest implements PlatformTest {
 
     @Override
     public final void reloadStandardErrorMessages() { Log.initLogging(CouchbaseLiteInternal.loadErrorMessages()); }
-
-    @Override
-    public final Exclusion getExclusions(@NonNull String tag) { return PLATFORM_DEPENDENT_TESTS.get(tag); }
-
     @Override
     public final AbstractExecutionService getExecutionService(ThreadPoolExecutor executor) {
         return new JavaExecutionService(executor);
@@ -121,4 +117,10 @@ public abstract class PlatformBaseTest implements PlatformTest {
         ExecutionService executionService = CouchbaseLiteInternal.getExecutionService();
         executionService.postDelayedOnExecutor(delayMs, executionService.getDefaultExecutor(), task);
     }
+
+    @Override
+    public final Exclusion getExclusions(@NonNull String tag) { return PLATFORM_DEPENDENT_TESTS.get(tag); }
+
+    @Override
+    public final String getDevice() { return "JVM"; }
 }


### PR DESCRIPTION
Trivial change makes load tests more relevant.
No changes to production code.