### PR TITLE
CBL-4173: Remove unused LiteCore calls

### DIFF
--- a/common/main/cpp/com_couchbase_lite_internal_core_C4DocEnumerator.h
+++ b/common/main/cpp/com_couchbase_lite_internal_core_C4DocEnumerator.h
@@ -17,14 +17,6 @@ JNIEXPORT jlong JNICALL Java_com_couchbase_lite_internal_core_C4DocEnumerator_en
 
 /*
  * Class:     com_couchbase_lite_internal_core_C4DocEnumerator
- * Method:    enumerateChanges
- * Signature: (JJI)J
- */
-JNIEXPORT jlong JNICALL Java_com_couchbase_lite_internal_core_C4DocEnumerator_enumerateChanges
-  (JNIEnv *, jclass, jlong, jlong, jint);
-
-/*
- * Class:     com_couchbase_lite_internal_core_C4DocEnumerator
  * Method:    next
  * Signature: (J)Z
  */

--- a/common/main/cpp/com_couchbase_lite_internal_core_C4Document.h
+++ b/common/main/cpp/com_couchbase_lite_internal_core_C4Document.h
@@ -26,14 +26,6 @@ JNIEXPORT jlong JNICALL Java_com_couchbase_lite_internal_core_C4Document_createF
 
 /*
  * Class:     com_couchbase_lite_internal_core_C4Document
- * Method:    create
- * Signature: (JLjava/lang/String;[BI)J
- */
-JNIEXPORT jlong JNICALL Java_com_couchbase_lite_internal_core_C4Document_create
-        (JNIEnv *, jclass, jlong, jstring, jbyteArray, jint);
-
-/*
- * Class:     com_couchbase_lite_internal_core_C4Document
  * Method:    put
  * Signature: (J[BLjava/lang/String;IZZ[Ljava/lang/String;ZII)J
  */

--- a/common/main/cpp/native_c4docenumerator.cc
+++ b/common/main/cpp/native_c4docenumerator.cc
@@ -33,28 +33,6 @@ extern "C" {
 
 /*
  * Class:     com_couchbase_lite_internal_core_C4DocEnumerator
- * Method:    enumerateChanges
- * Signature: (JJI)J
- */
-JNIEXPORT jlong JNICALL
-Java_com_couchbase_lite_internal_core_C4DocEnumerator_enumerateChanges(
-        JNIEnv *env,
-        jclass ignore,
-        jlong jdb,
-        jlong since,
-        jint jflags) {
-    const C4EnumeratorOptions options = {C4EnumeratorFlags(jflags)};
-    C4Error error{};
-    C4DocEnumerator *e = c4db_enumerateChanges((C4Database *) jdb, (uint16_t) since, &options, &error);
-    if (!e) {
-        throwError(env, error);
-        return 0;
-    }
-    return (jlong) e;
-}
-
-/*
- * Class:     com_couchbase_lite_internal_core_C4DocEnumerator
  * Method:    enumerateAllDocs
  * Signature: (JI)J
  */

--- a/common/main/cpp/native_c4document.cc
+++ b/common/main/cpp/native_c4document.cc
@@ -336,32 +336,6 @@ Java_com_couchbase_lite_internal_core_C4Document_dictContainsBlobs(
 
 /*
  * Class:     com_couchbase_lite_internal_core_C4Document
- * Method:    create
- * Signature: (JLjava/lang/String;[BI)J
- * !!! Deprecated
- */
-JNIEXPORT jlong JNICALL
-Java_com_couchbase_lite_internal_core_C4Document_create(
-        JNIEnv *env,
-        jclass ignore,
-        jlong jdb,
-        jstring jdocID,
-        jbyteArray jbody,
-        jint flags) {
-    jstringSlice docID(env, jdocID);
-    jbyteArraySlice body(env, jbody, false);
-    C4Error error{};
-    C4Document *doc = c4doc_create((C4Database *) jdb, docID, body, (unsigned) flags, &error);
-    if (!doc) {
-        throwError(env, error);
-        return 0;
-    }
-
-    return (jlong) doc;
-}
-
-/*
- * Class:     com_couchbase_lite_internal_core_C4Document
  * Method:    put
  * Signature: (J[BLjava/lang/String;IZZ[Ljava/lang/String;ZII)J
  */

--- a/common/main/java/com/couchbase/lite/internal/core/C4DocEnumerator.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4DocEnumerator.java
@@ -34,10 +34,6 @@ public class C4DocEnumerator extends C4NativePeer {
     //-------------------------------------------------------------------------
     // Constructor
     //-------------------------------------------------------------------------
-    C4DocEnumerator(long db, long since, int flags) throws LiteCoreException {
-        this(enumerateChanges(db, since, flags));
-    }
-
     C4DocEnumerator(long db, int flags) throws LiteCoreException { this(enumerateAllDocs(db, flags)); }
 
     private C4DocEnumerator(long peer) { super(peer); }
@@ -75,8 +71,6 @@ public class C4DocEnumerator extends C4NativePeer {
     //-------------------------------------------------------------------------
 
     private static native long enumerateAllDocs(long db, int flags) throws LiteCoreException;
-
-    private static native long enumerateChanges(long db, long since, int flags) throws LiteCoreException;
 
     private static native boolean next(long peer) throws LiteCoreException;
 

--- a/common/test/java/com/couchbase/lite/internal/core/C4DocumentTest.java
+++ b/common/test/java/com/couchbase/lite/internal/core/C4DocumentTest.java
@@ -57,88 +57,10 @@ public class C4DocumentTest extends C4BaseTest {
     @Test
     public void testFleeceDocs() throws LiteCoreException, IOException { loadJsonAsset("names_100.json"); }
 
-    // - "Document Put"
-    @Test
-    public void testPut() throws LiteCoreException {
-        boolean commit = false;
-        c4Database.beginTransaction();
-        try {
-            // Creating doc given ID:
-            C4Document doc = C4Document.create(
-                c4Database,
-                fleeceBody,
-                DOC_ID,
-                0,
-                false,
-                false,
-                new String[0],
-                true,
-                0,
-                0);
-            assertNotNull(doc);
-            assertEquals(DOC_ID, doc.getDocID());
-            String kExpectedRevID = "1-042ca1d3a1d16fd5ab2f87efc7ebbf50b7498032";
-            assertEquals(kExpectedRevID, doc.getRevID());
-            assertTrue(doc.docExists());
-            assertEquals(kExpectedRevID, doc.getSelectedRevID());
-            doc.close();
-
-            // Update doc:
-            String[] history = {kExpectedRevID};
-
-            doc = C4Document.create(
-                c4Database,
-                json2fleece("{'ok':'go'}"),
-                DOC_ID,
-                0,
-                false,
-                false,
-                history,
-                true,
-                0,
-                0);
-            assertNotNull(doc);
-            // NOTE: With current JNI binding, unable to check commonAncestorIndex value
-            String kExpectedRevID2 = "2-201796aeeaa6ddbb746d6cab141440f23412ac51";
-            assertEquals(kExpectedRevID2, doc.getRevID());
-            assertTrue(doc.docExists());
-            assertEquals(kExpectedRevID2, doc.getSelectedRevID());
-            doc.close();
-
-            // Insert existing rev that conflicts:
-            String kConflictRevID = "2-deadbeef";
-            String[] history2 = {kConflictRevID, kExpectedRevID};
-            doc = C4Document.create(
-                c4Database,
-                json2fleece("{'from':'elsewhere'}"),
-                DOC_ID,
-                0,
-                true,
-                true,
-                history2,
-                true,
-                0,
-                1);
-            assertNotNull(doc);
-            // NOTE: With current JNI binding, unable to check commonAncestorIndex value
-            assertEquals(kExpectedRevID2, doc.getRevID());
-            assertTrue(doc.docExists());
-            assertTrue(doc.isDocConflicted());
-            assertEquals(kConflictRevID, doc.getSelectedRevID());
-            doc.close();
-
-            commit = true;
-        }
-        finally {
-            c4Database.endTransaction(commit);
-        }
-    }
-
     private void testInvalidDocID(String docID) throws LiteCoreException {
         c4Database.beginTransaction();
         try {
-            C4Document.create(c4Database, fleeceBody, docID, 0, false, false,
-                new String[0], true, 0, 0);
+            C4Document.create(c4Database, fleeceBody, docID, 0, false, false, new String[0], true, 0, 0);
             fail();
         }
         catch (LiteCoreException e) {


### PR DESCRIPTION
There are two that can go.  The rest are used in tests.