### PR TITLE
CBL-4283: Make Collection.collectionChangeFlow's executor argument optional

### DIFF
--- a/common/main/kotlin/com/couchbase/lite/CommonFlows.kt
+++ b/common/main/kotlin/com/couchbase/lite/CommonFlows.kt
@@ -27,7 +27,7 @@ import java.util.concurrent.Executor
  *
  * @see com.couchbase.lite.Collection.addChangeListener
  */
-fun Collection.collectionChangeFlow(executor: Executor?) = callbackFlow {
+fun Collection.collectionChangeFlow(executor: Executor? = null) = callbackFlow {
     val token = this@collectionChangeFlow.addChangeListener(executor) { trySend(it) }
     awaitClose { token.remove() }
 }


### PR DESCRIPTION
Collection.collectionChangeFlow should default its argument, the Executor, to null, making it optional

Ticket: https://issues.couchbase.com/browse/CBL-4283
Targeting the RC2 release
This is very low risk.