### PR TITLE
CBL-4292: The argument to Collection.collectionChangeFlow(Executor?) should be optional

### DIFF
--- a/android-ktx/main/kotlin/com/couchbase/lite/internal/AbstractWorkManagerReplication.kt
+++ b/android-ktx/main/kotlin/com/couchbase/lite/internal/AbstractWorkManagerReplication.kt
@@ -22,8 +22,7 @@ import com.couchbase.lite.ReplicatorConfiguration
 import com.couchbase.lite.ReplicatorType
 import java.security.cert.X509Certificate
 
-abstract class AbstractWorkManagerReplicatorConfiguration
-constructor(protected val replConfig: ReplicatorConfiguration) {
+abstract class AbstractWorkManagerReplicatorConfiguration(protected val replConfig: ReplicatorConfiguration) {
     val collections: Set<Collection> by replConfig::collections
 
     var type: ReplicatorType by replConfig::type

--- a/common/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/common/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -870,7 +870,7 @@ abstract class AbstractDatabase extends BaseDatabase
      * If the executor is not specified, the changes will be delivered on the UI thread for
      * the Android platform and on an arbitrary thread for the Java platform.
      *
-     * @deprecated Use getDefaultCollection().
+     * @deprecated Use getDefaultCollection().addDocumentChangeListener
      */
     @Deprecated
     @NonNull

--- a/common/main/kotlin/com/couchbase/lite/CommonFlows.kt
+++ b/common/main/kotlin/com/couchbase/lite/CommonFlows.kt
@@ -27,7 +27,7 @@ import java.util.concurrent.Executor
  *
  * @see com.couchbase.lite.Collection.addChangeListener
  */
-fun Collection.collectionChangeFlow(executor: Executor?) = callbackFlow {
+fun Collection.collectionChangeFlow(executor: Executor? = null) = callbackFlow {
     val token = this@collectionChangeFlow.addChangeListener(executor) { trySend(it) }
     awaitClose { token.remove() }
 }

--- a/common/test/java/com/couchbase/lite/QueryTest.java
+++ b/common/test/java/com/couchbase/lite/QueryTest.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -42,7 +41,6 @@ import com.couchbase.lite.internal.utils.Fn;
 import com.couchbase.lite.internal.utils.MathUtils;
 import com.couchbase.lite.internal.utils.Report;
 import com.couchbase.lite.internal.utils.SlowTest;
-import com.couchbase.lite.internal.utils.StringUtils;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -50,7 +48,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 
 @SuppressWarnings("ConstantConditions")


### PR DESCRIPTION
Backport from 3.1