### PR TITLE
CBL-4293: ReplicatorConfiguration.setAuthenticator should allow a null argument

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/common/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -870,7 +870,7 @@ abstract class AbstractDatabase extends BaseDatabase
      * If the executor is not specified, the changes will be delivered on the UI thread for
      * the Android platform and on an arbitrary thread for the Java platform.
      *
-     * @deprecated Use getDefaultCollection().
+     * @deprecated Use getDefaultCollection().addDocumentChangeListener
      */
     @Deprecated
     @NonNull

--- a/common/main/java/com/couchbase/lite/AbstractReplicatorConfiguration.java
+++ b/common/main/java/com/couchbase/lite/AbstractReplicatorConfiguration.java
@@ -346,7 +346,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
      */
     @NonNull
     public final ReplicatorConfiguration setAuthenticator(@Nullable Authenticator authenticator) {
-        this.authenticator = Preconditions.assertNotNull(authenticator, "authenticator");
+        this.authenticator = authenticator;
         return getReplicatorConfiguration();
     }
 


### PR DESCRIPTION
For some reason ReplicatorConfiguration.setAuthenticator disallowed a null argument.

Also fix a minor doc error