### PR TITLE
CBL-4423: Stop LiveQueries before closing a DB

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/core/C4QueryObserver.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4QueryObserver.java
@@ -137,6 +137,8 @@ public class C4QueryObserver extends C4NativePeer {
         if ((results != null) || (err != null)) { callback.onQueryChanged(results, err); }
     }
 
+    // ??? This is called only from LiteCore.
+    // Should it still be guarded by the db lock?
     @Nullable
     private C4QueryEnumerator getEnumerator() throws LiteCoreException {
         return withPeerOrNull(h -> c4QueryEnumeratorFactory.apply(impl.nGetEnumerator(h, false)));


### PR DESCRIPTION
This commit is a little bigger than it really ought to be:

- In addition to adding a test for the bug fix, I changed several of the other tests to avoid a compiler warning.  Instead of try-finally, they are now try-with-resources.
- There is a publicly visible comment on AbstractQuery.explain that was just really broken
- there were two locks missing in the call to AbstractQuery.addChangeListener: one to protect getC4QueryLocked, and one to protect C4QueryObserver.setEnabled