### PR TITLE
Temporary workaround for CBL-4435: remove stopped replicator from DB active process list

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractReplicator.java
+++ b/common/main/java/com/couchbase/lite/AbstractReplicator.java
@@ -382,6 +382,15 @@ public abstract class AbstractReplicator extends BaseReplicator
         }
     }
 
+    // When a replicator is closed it is detached from its from LiteCore and receives no further status updates.
+    // If it is not already in the STOPPED state, it will never be in the stopped state.  That means that
+    // a database that holds a reference to it can never close.
+    // Let's just tell the db forget about it.
+    public void close() {
+        getDatabase().removeActiveReplicator(this);
+        super.close();
+    }
+
     @NonNull
     @Override
     public String toString() {
@@ -726,7 +735,7 @@ public abstract class AbstractReplicator extends BaseReplicator
             err,
             this);
 
-        return c4Status.copy();
+        return new C4ReplicatorStatus(c4Status);
     }
 
     private void queueConflictResolution(@NonNull ReplicatedDocument rDoc, @Nullable ConflictResolver resolver) {

--- a/common/main/java/com/couchbase/lite/CollectionChangeNotifier.java
+++ b/common/main/java/com/couchbase/lite/CollectionChangeNotifier.java
@@ -63,7 +63,7 @@ final class CollectionChangeNotifier extends ChangeNotifier<CollectionChange> im
     private void collectionChanged() {
         synchronized (collection.getDbLock()) {
             final C4CollectionObserver observer = c4Observer;
-            if (!collection.isOpen() || (observer == null)) { return; }
+            if (!collection.isOpenLocked() || (observer == null)) { return; }
 
             boolean external = false;
             List<String> docIDs = new ArrayList<>();

--- a/common/main/java/com/couchbase/lite/internal/core/C4ReplicatorStatus.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4ReplicatorStatus.java
@@ -75,16 +75,15 @@ public final class C4ReplicatorStatus {
         }
     }
 
-    @NonNull
-    public C4ReplicatorStatus copy() {
-        return new C4ReplicatorStatus(
-            activityLevel,
-            progressUnitsCompleted,
-            progressUnitsTotal,
-            progressDocumentCount,
-            errorDomain,
-            errorCode,
-            errorInternalInfo);
+    public C4ReplicatorStatus(@NonNull C4ReplicatorStatus c4Status) {
+        this(
+            c4Status.activityLevel,
+            c4Status.progressUnitsCompleted,
+            c4Status.progressUnitsTotal,
+            c4Status.progressDocumentCount,
+            c4Status.errorDomain,
+            c4Status.errorCode,
+            c4Status.errorInternalInfo);
     }
 
     public int getActivityLevel() { return activityLevel; }


### PR DESCRIPTION
This is just so I can get the dev tests to work.  I don't think it is a full fix for the issue.

Also: fix unsafe call to getOpenC4CollectionLocked() and replace C4ReplicatorStatus.copy with a more idiomatic copy constructor.