### PR TITLE
CBL-3887: Rewrite ReplicationConfigurationTest to avoid deprecated API

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractReplicator.java
+++ b/common/main/java/com/couchbase/lite/AbstractReplicator.java
@@ -382,9 +382,11 @@ public abstract class AbstractReplicator extends BaseReplicator
         }
     }
 
-    // When a replicator is closed it is detached from its from LiteCore and receives no further status updates.
-    // If it is not already in the STOPPED state, it will never be in the stopped state.  That means that
-    // a database that holds a reference to it can never close.
+    // This is a workaround: closing at the wrong time (while a push filter is running?) might even
+    // cause a crash.  The issue it addresses is that when a replicator is closed it is detached from
+    // its from LiteCore and receives no further status updates. If it is not already in the STOPPED
+    // state, it will never be in the stopped state.  That means that a database that holds a reference
+    // to it can never close.
     // Let's just tell the db forget about it.
     public void close() {
         getDatabase().removeActiveReplicator(this);

--- a/common/test/java/com/couchbase/lite/BaseDbTest.kt
+++ b/common/test/java/com/couchbase/lite/BaseDbTest.kt
@@ -44,14 +44,6 @@ val Database.getC4Db
 val Scope.collectionCount
     get() = this.collections.size
 
-fun CountDownLatch.stdWait(): Boolean {
-    return try {
-        await(BaseTest.STD_TIMEOUT_SEC, TimeUnit.SECONDS)
-    } catch (e: InterruptedException) {
-        false
-    }
-}
-
 fun Database.createTestCollection(name: String = "coll_", scope: String = "scope_"): Collection {
     val uname = BaseTest.getUniqueName(name)
     val uscope = BaseTest.getUniqueName(scope)
@@ -88,9 +80,6 @@ fun Collection.getQualifiedName() = "${this.scope.name}.${this.name}"
 
 fun Collection.getNonNullDoc(id: String) = this.getDocument(id) ?: throw AssertionError("document ${id} is null")
 
-fun Collection.isRevDeleted(id: String) =
-    C4BaseTest.getDocumentOrEmpty(this.openC4CollectionLocked, id)?.isRevDeleted ?: false
-
 fun Collection.delete() {
     val db = this.database
     try {
@@ -110,12 +99,26 @@ fun Document.delete() {
     }
 }
 
+fun assertCBLException(domain: String, code: Int, err: CouchbaseLiteException?) {
+    assertNotNull(err!!)
+    assertEquals(domain, err.domain)
+    assertEquals(code, err.code)
+}
+
 fun <T : Comparable<T>> assertContents(l1: List<T>, vararg contents: T) {
     assertEquals(l1.sorted(), listOf(*contents).sorted())
 }
 
 fun <T : Comparable<T>> assertContents(l1: Set<T>, vararg contents: T) {
     assertEquals(l1.sorted(), listOf(*contents).sorted())
+}
+
+fun CountDownLatch.stdWait(): Boolean {
+    return try {
+        await(BaseTest.STD_TIMEOUT_SEC, TimeUnit.SECONDS)
+    } catch (e: InterruptedException) {
+        false
+    }
 }
 
 // Comparing documents isn't trivial:

--- a/common/test/java/com/couchbase/lite/LoadTest.kt
+++ b/common/test/java/com/couchbase/lite/LoadTest.kt
@@ -33,7 +33,7 @@ class LoadTest : BaseDbTest() {
     companion object {
         private val DEVICE_SPEED_MULTIPLIER = mapOf(
             "lin" to 33,
-            "mac" to 33,
+            "mac" to 40,
             "win" to 50,
             "r8quex" to 100,
             "a12uue" to 200,

--- a/common/test/java/com/couchbase/lite/ReplicatorMiscTest.java
+++ b/common/test/java/com/couchbase/lite/ReplicatorMiscTest.java
@@ -96,7 +96,7 @@ public class ReplicatorMiscTest extends BaseReplicatorTest {
     @Test
     public void testDocumentReplication() {
         List<ReplicatedDocument> docs = new ArrayList<>();
-        Replicator repl = BaseReplicatorTestKt.testReplicator(makeConfig());
+        Replicator repl = testReplicator(makeConfig());
         DocumentReplication doc = new DocumentReplication(repl, true, docs);
         assertTrue(doc.isPush());
         assertEquals(doc.getReplicator(), repl);
@@ -106,12 +106,12 @@ public class ReplicatorMiscTest extends BaseReplicatorTest {
     // https://issues.couchbase.com/browse/CBL-89
     // Thanks to @James Flather for the ready-made test code
     @Test
-    public void testStopBeforeStart() { BaseReplicatorTestKt.testReplicator(makeConfig()).stop(); }
+    public void testStopBeforeStart() { testReplicator(makeConfig()).stop(); }
 
     // https://issues.couchbase.com/browse/CBL-88
     // Thanks to @James Flather for the ready-made test code
     @Test
-    public void testStatusBeforeStart() { BaseReplicatorTestKt.testReplicator(makeConfig()).getStatus(); }
+    public void testStatusBeforeStart() { testReplicator(makeConfig()).getStatus(); }
 
     @Test
     public void testDocumentEndListenerTokenRemove() {
@@ -151,7 +151,10 @@ public class ReplicatorMiscTest extends BaseReplicatorTest {
         });
 
         // the replicator will fail because the endpoint is bogus
-        run(repl, CBLError.Code.NETWORK_OFFSET + C4Constants.NetworkError.UNKNOWN_HOST, CBLError.Domain.CBLITE);
+        run(
+            repl,
+            false, CBLError.Domain.CBLITE, CBLError.Code.NETWORK_OFFSET + C4Constants.NetworkError.UNKNOWN_HOST
+        );
 
         synchronized (options) {
             assertEquals(
@@ -191,7 +194,10 @@ public class ReplicatorMiscTest extends BaseReplicatorTest {
         });
 
         // the replicator will fail because the endpoint is bogus
-        run(repl, CBLError.Code.NETWORK_OFFSET + C4Constants.NetworkError.UNKNOWN_HOST, CBLError.Domain.CBLITE);
+        run(
+            repl,
+            false, CBLError.Domain.CBLITE, CBLError.Code.NETWORK_OFFSET + C4Constants.NetworkError.UNKNOWN_HOST
+        );
 
         synchronized (options) {
             assertEquals(Boolean.TRUE, options.get(C4Replicator.REPLICATOR_OPTION_ACCEPT_PARENT_COOKIES));
@@ -417,7 +423,5 @@ public class ReplicatorMiscTest extends BaseReplicatorTest {
 
     private Replicator makeRepl() { return makeRepl(makeConfig()); }
 
-    private Replicator makeRepl(ReplicatorConfiguration config) { return BaseReplicatorTestKt.testReplicator(config); }
-
-    private void run(Replicator repl, int code, String domain) { run(repl, code, domain, false, null); }
+    private Replicator makeRepl(ReplicatorConfiguration config) { return testReplicator(config); }
 }

--- a/common/test/java/com/couchbase/lite/ReplicatorOfflineTest.java
+++ b/common/test/java/com/couchbase/lite/ReplicatorOfflineTest.java
@@ -135,5 +135,5 @@ public class ReplicatorOfflineTest extends BaseReplicatorTest {
 
     private Replicator makeRepl() { return makeRepl(makeConfig()); }
 
-    private Replicator makeRepl(ReplicatorConfiguration config) { return BaseReplicatorTestKt.testReplicator(config); }
+    private Replicator makeRepl(ReplicatorConfiguration config) { return testReplicator(config); }
 }

--- a/common/test/java/com/couchbase/lite/internal/ReplicationConfigurationTest.kt
+++ b/common/test/java/com/couchbase/lite/internal/ReplicationConfigurationTest.kt
@@ -31,7 +31,7 @@ import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 
-// These two functions expose package private state to other tests
+// These two functions have to be here, to expose package private state to other tests
 
 fun boundCollectionCount() = ReplicationCollection.BOUND_COLLECTIONS.size()
 

--- a/common/test/java/com/couchbase/lite/internal/core/C4BaseTest.java
+++ b/common/test/java/com/couchbase/lite/internal/core/C4BaseTest.java
@@ -49,6 +49,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 
+
 public class C4BaseTest extends BaseTest {
     public static final long MOCK_PEER = 500005L;
     public static final long MOCK_TOKEN = 0xba5eba11;

--- a/common/test/java/com/couchbase/lite/internal/core/C4CollectionTest.kt
+++ b/common/test/java/com/couchbase/lite/internal/core/C4CollectionTest.kt
@@ -16,6 +16,7 @@
 package com.couchbase.lite.internal.core
 
 import com.couchbase.lite.LiteCoreException
+import com.couchbase.lite.Collection
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull


### PR DESCRIPTION
Dramatic changes... but only to tests.  Nothing in the PR is product code.