### PR TITLE
CBL-3884: Rewrite PendingDocId test to avoid using deprecated API methods

### DIFF
--- a/common/test/java/com/couchbase/lite/BaseDbTest.kt
+++ b/common/test/java/com/couchbase/lite/BaseDbTest.kt
@@ -15,7 +15,6 @@
 //
 package com.couchbase.lite
 
-import com.couchbase.lite.internal.core.C4BaseTest
 import com.couchbase.lite.internal.utils.Fn.ConsumerThrows
 import com.couchbase.lite.internal.utils.JSONUtils
 import com.couchbase.lite.internal.utils.PlatformUtils
@@ -99,8 +98,9 @@ fun Document.delete() {
     }
 }
 
-fun assertCBLException(domain: String, code: Int, err: CouchbaseLiteException?) {
+fun assertCBLException(domain: String, code: Int, err: Exception?) {
     assertNotNull(err!!)
+    if (err !is CouchbaseLiteException) throw java.lang.AssertionError("Especting a CouchbaseLiteException", err)
     assertEquals(domain, err.domain)
     assertEquals(code, err.code)
 }

--- a/common/test/java/com/couchbase/lite/BaseReplicatorTest.kt
+++ b/common/test/java/com/couchbase/lite/BaseReplicatorTest.kt
@@ -122,7 +122,7 @@ abstract class BaseReplicatorTest : BaseDbTest() {
         return config
     }
 
-    protected fun makeReplConfig(
+    protected fun makeSimpleReplConfig(
         target: Endpoint = mockURLEndpoint,
         source: kotlin.collections.Collection<Collection> = setOf(testCollection),
         srcConfig: CollectionConfiguration? = null,
@@ -148,7 +148,7 @@ abstract class BaseReplicatorTest : BaseDbTest() {
     )
 
     protected fun makeReplConfig(
-        target: Endpoint,
+        target: Endpoint = mockURLEndpoint,
         source: Map<out kotlin.collections.Collection<Collection>, CollectionConfiguration?> =
             mapOf(setOf(testCollection) to null),
         type: ReplicatorType? = null,

--- a/common/test/java/com/couchbase/lite/DictionaryTest.java
+++ b/common/test/java/com/couchbase/lite/DictionaryTest.java
@@ -624,7 +624,7 @@ public class DictionaryTest extends BaseDbTest {
 
         assertNotEquals(0, dict3.hashCode());
         assertNotEquals(dict3.hashCode(), new Object().hashCode());
-        assertNotEquals(dict3.hashCode(), new Integer(1).hashCode());
+        assertNotEquals(dict3.hashCode(), Integer.valueOf(1).hashCode());
         assertNotEquals(dict3.hashCode(), new HashMap<>().hashCode());
         assertNotEquals(dict3.hashCode(), new MutableDictionary().hashCode());
         assertNotEquals(dict3.hashCode(), new MutableArray().hashCode());

--- a/common/test/java/com/couchbase/lite/DocumentTest.java
+++ b/common/test/java/com/couchbase/lite/DocumentTest.java
@@ -2557,7 +2557,7 @@ public class DocumentTest extends BaseDbTest {
 
         Assert.assertNotEquals(doc3.hashCode(), 0);
         Assert.assertNotEquals(doc3.hashCode(), new Object().hashCode());
-        Assert.assertNotEquals(doc3.hashCode(), new Integer(1).hashCode());
+        Assert.assertNotEquals(doc3.hashCode(), Integer.valueOf(1).hashCode());
         Assert.assertNotEquals(doc3.hashCode(), new HashMap<>().hashCode());
         Assert.assertNotEquals(doc3.hashCode(), new MutableDictionary().hashCode());
         Assert.assertNotEquals(doc3.hashCode(), new MutableArray().hashCode());

--- a/common/test/java/com/couchbase/lite/LoadTest.kt
+++ b/common/test/java/com/couchbase/lite/LoadTest.kt
@@ -34,7 +34,7 @@ class LoadTest : BaseDbTest() {
         private val DEVICE_SPEED_MULTIPLIER = mapOf(
             "lin" to 33,
             "mac" to 40,
-            "win" to 50,
+            "win" to 110,
             "r8quex" to 100,
             "a12uue" to 200,
             "starqlteue" to 150,
@@ -161,7 +161,7 @@ class LoadTest : BaseDbTest() {
         testCollection.save(mDoc)
 
         assertEquals(1L, testCollection.count)
-        timeTest("testUpdate2", 75) {
+        timeTest("testUpdate2", 90) {
             for (i in 0..ITERATIONS) {
                 mDoc = testCollection.getDocument(mDoc.id)!!.toMutable()
                 mDoc.setValue("map", mapOf("idx" to i, "long" to i.toLong(), TEST_DOC_TAG_KEY to getUniqueName("tag")))

--- a/common/test/java/com/couchbase/lite/ReplicatorConfigurationTest.kt
+++ b/common/test/java/com/couchbase/lite/ReplicatorConfigurationTest.kt
@@ -31,37 +31,37 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
 
     @Test(expected = java.lang.IllegalArgumentException::class)
     fun testIllegalMaxAttempts() {
-        makeReplConfig(maxAttempts = -1)
+        makeSimpleReplConfig(maxAttempts = -1)
     }
 
     @Test
     fun testMaxAttemptsZero() {
-        makeReplConfig(maxAttempts = 0)
+        makeSimpleReplConfig(maxAttempts = 0)
     }
 
     @Test(expected = java.lang.IllegalArgumentException::class)
     fun testIllegalAttemptsWaitTime() {
-        makeReplConfig(maxAttemptWaitTime = -1)
+        makeSimpleReplConfig(maxAttemptWaitTime = -1)
     }
 
     @Test
     fun testMaxAttemptsWaitTimeZero() {
-        makeReplConfig(maxAttemptWaitTime = 0)
+        makeSimpleReplConfig(maxAttemptWaitTime = 0)
     }
 
     @Test(expected = java.lang.IllegalArgumentException::class)
     fun testIllegalHeartbeatMin() {
-        makeReplConfig().heartbeat = -1
+        makeSimpleReplConfig().heartbeat = -1
     }
 
     @Test
     fun testHeartbeatZero() {
-        makeReplConfig().heartbeat = 0
+        makeSimpleReplConfig().heartbeat = 0
     }
 
     @Test(expected = java.lang.IllegalArgumentException::class)
     fun testIllegalHeartbeatMax() {
-        makeReplConfig().heartbeat = 2147484
+        makeSimpleReplConfig().heartbeat = 2147484
     }
 
     // Can't test the EE parameter (self-signed only) here


### PR DESCRIPTION
Adjacent changes.