### PR TITLE
CBL-3889: Get URLEndpointListener tests to the new API

### DIFF
--- a/common/test/java/com/couchbase/lite/BaseDbTest.kt
+++ b/common/test/java/com/couchbase/lite/BaseDbTest.kt
@@ -21,6 +21,7 @@ import com.couchbase.lite.internal.utils.Report
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.After
+import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -95,13 +96,6 @@ fun Document.delete() {
     } catch (e: CouchbaseLiteException) {
         throw AssertionError("Failed deleting document ${this.id} from collection ${coll}")
     }
-}
-
-fun assertCBLException(domain: String, code: Int, err: Exception?) {
-    assertNotNull(err!!)
-    if (err !is CouchbaseLiteException) throw java.lang.AssertionError("Especting a CouchbaseLiteException", err)
-    assertEquals(domain, err.domain)
-    assertEquals(code, err.code)
 }
 
 fun <T : Comparable<T>> assertContents(l1: List<T>, vararg contents: T) {

--- a/common/test/java/com/couchbase/lite/CollectionTest.kt
+++ b/common/test/java/com/couchbase/lite/CollectionTest.kt
@@ -52,7 +52,7 @@ class CollectionTest : BaseDbTest() {
     }
 
     // getting doc from deleted collection causes CBL exception
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testGetDocFromDeletedCollection() {
         // store doc
         val doc = createDocInCollection()
@@ -61,38 +61,38 @@ class CollectionTest : BaseDbTest() {
         testCollection.delete()
 
         // should fail
-        testCollection.getDocument(doc.id)
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.getDocument(doc.id) }
     }
 
     // getting a doc from collection that is deleted in a different database instance causes CBL exception
     @SlowTest
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testGetDocFromCollectionDeletedInDifferentDBInstance() {
         val doc = createDocInCollection()
 
         duplicateDb(testDatabase).use { it.getSimilarCollection(testCollection).delete() }
 
-        testCollection.getDocument(doc.id)
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.getDocument(doc.id) }
     }
 
     // getting doc from collection in a closed db causes CBL Exception
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testGetDocFromCollectionInClosedDB() {
         val doc = createDocInCollection()
 
         closeDb(testDatabase)
 
-        testCollection.getDocument(doc.id)
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.getDocument(doc.id) }
     }
 
     // getting doc from collection in a deleted db causes CBL Exception
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testGetDocFromCollectionInDeletedDB() {
         val doc = createDocInCollection()
 
         deleteDb(testDatabase)
 
-        testCollection.getDocument(doc.id)
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.getDocument(doc.id) }
     }
 
     // getting doc count from deleted collection returns 0
@@ -192,7 +192,7 @@ class CollectionTest : BaseDbTest() {
             assertNotNull(dupCollection)
             assertEquals(1, dupCollection.count)
 
-            assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) {
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) {
                 dupCollection.save(doc.toMutable())
             }
         }
@@ -223,30 +223,30 @@ class CollectionTest : BaseDbTest() {
         assertEquals(1, testCollection.count)
     }
 
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testSaveDocToDeletedCollection() {
         testCollection.delete()
-        testCollection.save(MutableDocument())
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.save(MutableDocument()) }
     }
 
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testSaveDocToCollectionDeletedInDifferentDBInstance() {
         duplicateDb(testDatabase).use { it.getSimilarCollection(testCollection).delete() }
-        testCollection.save(MutableDocument())
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.save(MutableDocument()) }
     }
 
     // Test saving document in a collection of a closed database causes CBLException
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testSaveDocToCollectionInClosedDB() {
         closeDb(testDatabase)
-        testCollection.save(MutableDocument())
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.save(MutableDocument()) }
     }
 
     // Test saving document in a collection of a deleted database causes CBLException
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testSaveDocToCollectionInDeletedDB() {
         deleteDb(testDatabase)
-        testCollection.save(MutableDocument())
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.save(MutableDocument()) }
     }
 
     @Test
@@ -320,7 +320,7 @@ class CollectionTest : BaseDbTest() {
     @Test
     fun testDeleteDocBeforeSave() {
         assertEquals(0, testCollection.count)
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND) {
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND) {
             testCollection.delete(MutableDocument())
         }
     }
@@ -352,7 +352,7 @@ class CollectionTest : BaseDbTest() {
             assertEquals(1, dupColl.count)
 
             // Try to delete the doc from the duplicate db instance:
-            assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { dupColl.delete(doc) }
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { dupColl.delete(doc) }
         }
     }
 
@@ -381,35 +381,35 @@ class CollectionTest : BaseDbTest() {
     }
 
     // Test deleting doc from a deleted collection causes CBL exception
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testDeleteDocFromDeletedCollection() {
         val doc = createDocInCollection()
         testCollection.delete()
-        testCollection.delete(doc)
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.delete(doc) }
     }
 
     // Test deleting doc from a collection that is deleted from a different db instance causes CBL exception
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testDeleteDocFromCollectionDeletedInDifferentDBInstance() {
         val doc = createDocInCollection()
         duplicateDb(testDatabase).use { it.getSimilarCollection(testCollection).delete() }
-        testCollection.delete(doc)
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.delete(doc) }
     }
 
     // Test deleting doc on a collection in a closed db causes CBLException
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testDeleteDocFromCollectionInClosedDB() {
         val doc = createDocInCollection()
         closeDb(testDatabase)
-        testCollection.delete(doc)
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.delete(doc) }
     }
 
     // Test deleting doc on a collection in a deleted db causes CBLException
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testDeleteDocFromCollectionInDeletedDB() {
         val doc = createDocInCollection()
         deleteDb(testDatabase)
-        testCollection.delete(doc)
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.delete(doc) }
     }
 
     @Test
@@ -442,8 +442,8 @@ class CollectionTest : BaseDbTest() {
         assertEquals(0, testCollection.count)
         assertNull(testCollection.getDocument(doc1a.id))
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND) { testCollection.delete(doc1a) }
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND) { testCollection.delete(doc1b) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND) { testCollection.delete(doc1a) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND) { testCollection.delete(doc1b) }
     }
 
     //---------------------------------------------
@@ -454,7 +454,7 @@ class CollectionTest : BaseDbTest() {
     fun testPurgeDocBeforeSaveDoc() {
         assertEquals(0, testCollection.count)
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND) {
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND) {
             testCollection.purge(MutableDocument())
         }
     }
@@ -490,25 +490,25 @@ class CollectionTest : BaseDbTest() {
     }
 
     // Purge document from a deleted collection
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testPurgeDocFromDeletedCollection() {
         val doc = createDocInCollection()
 
         // delete collection
         testCollection.delete()
 
-        testCollection.purge(doc.id)
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.purge(doc.id) }
     }
 
     // Purge document from a collection deleted in a different DB Instance
     @SlowTest
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testPurgeDocFromCollectionDeletedInADifferentDBInstance() {
         val doc = createDocInCollection()
 
         duplicateDb(testDatabase).use { it.getSimilarCollection(testCollection).delete() }
 
-        testCollection.purge(doc.id)
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.purge(doc.id) }
     }
 
     @Test
@@ -521,7 +521,7 @@ class CollectionTest : BaseDbTest() {
             val collection = it.getSimilarCollection(testCollection)
 
             // purge document against collection in the other db:
-            assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) {
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) {
                 collection.purge(doc)
             }
         }
@@ -557,7 +557,7 @@ class CollectionTest : BaseDbTest() {
     }
 
     // Test purging doc on a deleted collection causes CBL exception
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testPurgeDocOnDeletedCollection() {
         val doc = createDocInCollection()
 
@@ -565,23 +565,23 @@ class CollectionTest : BaseDbTest() {
         testCollection.delete()
 
         // purge doc
-        testCollection.purge(doc)
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.purge(doc) }
     }
 
     // Test purging doc from a collection in a closed database causes CBL exception
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testPurgeDocFromCollectionInClosedDB() {
         val doc = createDocInCollection()
         closeDb(testDatabase)
-        testCollection.purge(doc)
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.purge(doc) }
     }
 
     // Test purging doc from a collection in a deleted database causes CBL exception
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testPurgeDocFromCollectionInDeletedDB() {
         val doc = createDocInCollection()
         deleteDb(testDatabase)
-        testCollection.purge(doc)
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.purge(doc) }
     }
 
     //---------------------------------------------
@@ -665,40 +665,48 @@ class CollectionTest : BaseDbTest() {
     }
 
     // Test create index from a deleted collection
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testCreateIndexFromDeletedCollection() {
         // Delete collection
         testCollection.delete()
-        testCollection.createIndex("index2", ValueIndexConfiguration("firstName", "lastName"))
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) {
+            testCollection.createIndex("index2", ValueIndexConfiguration("firstName", "lastName"))
+        }
     }
 
     // Test create index from a collection deleted in a different db instance
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testCreateIndexFromCollectionDeletedInDifferentDBInstance() {
         duplicateDb(testDatabase).use { it.getSimilarCollection(testCollection).delete() }
-        testCollection.createIndex("index2", ValueIndexConfiguration("firstName", "lastName"))
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) {
+            testCollection.createIndex("index2", ValueIndexConfiguration("firstName", "lastName"))
+        }
     }
 
     // Test that createIndex in collection in closed database causes CBLException
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testCreateIndexInCollectionInClosedDatabase() {
         closeDb(testDatabase)
-        testCollection.createIndex("test_index", ValueIndexConfiguration("firstName", "lastName"))
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) {
+            testCollection.createIndex("test_index", ValueIndexConfiguration("firstName", "lastName"))
+        }
     }
 
     // Test that createIndex in collection in deleted database causes CBLException
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testCreateIndexInCollectionInDeletedDatabase() {
         deleteDb(testDatabase)
-        testCollection.createIndex("test_index", ValueIndexConfiguration("firstName", "lastName"))
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) {
+            testCollection.createIndex("test_index", ValueIndexConfiguration("firstName", "lastName"))
+        }
     }
 
     // Test getting index from a deleted collection causes CBL exception
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testGetIndexFromDeletedCollection() {
         // Delete collection
         testCollection.delete()
-        testCollection.indexes
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.indexes }
     }
 
     @Test
@@ -710,32 +718,31 @@ class CollectionTest : BaseDbTest() {
     }
 
     // Test getting index from a collection deleted from another DB instance causes CBL exception
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testGetIndexFromCollectionDeletedFromADifferentDBInstance() {
         duplicateDb(testDatabase).use { it.getSimilarCollection(testCollection).delete() }
-        testCollection.indexes
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.indexes }
     }
 
     // Test that getIndexes from collection in closed database causes CBLException
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testGetIndexesFromCollectionFromClosedDatabase() {
-        failOnError("Failed to create index 'index1' for collection ${testCollection}") {
-            testCollection.createIndex("index1", ValueIndexConfiguration("firstName", "lastName"))
-            assertContents(testCollection.indexes.toList(), "index1")
-        }
+        testCollection.createIndex("index1", ValueIndexConfiguration("firstName", "lastName"))
+        assertContents(testCollection.indexes.toList(), "index1")
+
         closeDb(testDatabase)
-        testCollection.indexes
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.indexes }
     }
 
     // Test that getIndexes from collection in deleted database causes CBLException
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testGetIndexesFromCollectionFromDeletedDatabase() {
-        failOnError("Failed to create index 'index1' for collection ${testCollection}") {
+
             testCollection.createIndex("index1", ValueIndexConfiguration("firstName", "lastName"))
             assertContents(testCollection.indexes.toList(), "index1")
-        }
+
         deleteDb(testDatabase)
-        testCollection.indexes
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.indexes }
     }
 
     @Test
@@ -784,53 +791,47 @@ class CollectionTest : BaseDbTest() {
     }
 
     // Test delete index from a deletedCollection
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testDeleteIndexFromDeletedCollection() {
-        failOnError("Failed to create index 'index1' for collection ${testCollection}") {
             testCollection.createIndex("index1", ValueIndexConfiguration("firstName", "lastName"))
             assertContents(testCollection.indexes.toList(), "index1")
-        }
 
         // Delete collection
         testCollection.delete()
 
         // delete index
-        testCollection.deleteIndex("index1")
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.deleteIndex("index1") }
     }
 
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testDeleteIndexFromCollectionDeletedInDifferentDbInstance() {
-        failOnError("Failed to create index 'index1' for collection ${testCollection}") {
             testCollection.createIndex("index1", ValueIndexConfiguration("firstName", "lastName"))
             assertContents(testCollection.indexes.toList(), "index1")
-        }
 
         duplicateDb(testDatabase).use { it.getSimilarCollection(testCollection).delete() }
 
         // delete index
-        testCollection.deleteIndex("index1")
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.deleteIndex("index1") }
     }
 
     // Test that deletedIndex in collection in closed database causes CBLException
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testDeleteIndexInCollectionInClosedDatabase() {
-        failOnError("Failed to create index 'index1' for collection ${testCollection}") {
             testCollection.createIndex("index1", ValueIndexConfiguration("firstName", "lastName"))
             assertContents(testCollection.indexes.toList(), "index1")
-        }
+
         closeDb(testDatabase)
-        testCollection.deleteIndex("index1")
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.deleteIndex("index1") }
     }
 
     // Test that deleteIndex in collection in deleted causes CBLException
-    @Test(expected = CouchbaseLiteException::class)
+    @Test
     fun testDeleteIndexInCollectionInDeletedDatabase() {
-        failOnError("Failed to create index 'index1' for collection ${testCollection}") {
             testCollection.createIndex("index1", ValueIndexConfiguration("firstName", "lastName"))
             assertContents(testCollection.indexes.toList(), "index1")
-        }
+
         deleteDb(testDatabase)
-        testCollection.deleteIndex("index1")
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.deleteIndex("index1") }
     }
 
     //---------------------------------------------

--- a/common/test/java/com/couchbase/lite/DatabaseTest.kt
+++ b/common/test/java/com/couchbase/lite/DatabaseTest.kt
@@ -96,7 +96,7 @@ class DatabaseTest : BaseDbTest() {
         testDatabase.close()
 
         // should fail
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.getDocument(docId) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.getDocument(docId) }
     }
 
     @Test
@@ -108,7 +108,7 @@ class DatabaseTest : BaseDbTest() {
         testDatabase.delete()
 
         // should fail
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.getDocument(docId) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.getDocument(docId) }
     }
 
     //---------------------------------------------
@@ -181,7 +181,7 @@ class DatabaseTest : BaseDbTest() {
 
             // Attempt to save the doc in the wrong db
             doc.setValue(TEST_DOC_TAG_KEY, "bam!!!")
-            assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherCollection.save(doc) }
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherCollection.save(doc) }
         } finally {
             eraseDb(otherDb)
         }
@@ -202,7 +202,7 @@ class DatabaseTest : BaseDbTest() {
 
             // Attempt to save the doc in a *very* wrong db
             doc.setValue(TEST_DOC_TAG_KEY, "bam!!!")
-            assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherCollection.save(doc) }
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherCollection.save(doc) }
         } finally {
             // delete otherDb
             eraseDb(otherDb)
@@ -239,7 +239,7 @@ class DatabaseTest : BaseDbTest() {
         testDatabase.close()
         val doc = MutableDocument()
         doc.setValue(TEST_DOC_TAG_KEY, testTag)
-        assertThrowsCBL(CBLError.Domain.CBLITE, C4Constants.LiteCoreError.NOT_OPEN) { testCollection.save(doc) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, C4Constants.LiteCoreError.NOT_OPEN) { testCollection.save(doc) }
     }
 
     @Test
@@ -248,7 +248,7 @@ class DatabaseTest : BaseDbTest() {
         testDatabase.delete()
         val doc = MutableDocument()
         doc.setValue(TEST_DOC_TAG_KEY, testTag)
-        assertThrowsCBL(CBLError.Domain.CBLITE, C4Constants.LiteCoreError.NOT_OPEN) { testCollection.save(doc) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, C4Constants.LiteCoreError.NOT_OPEN) { testCollection.save(doc) }
     }
 
     //---------------------------------------------
@@ -258,7 +258,7 @@ class DatabaseTest : BaseDbTest() {
     fun testDeleteNonExistentDoc() {
         val doc = MutableDocument("doesnt_exist")
         doc.setValue(TEST_DOC_TAG_KEY, testTag)
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND) { testCollection.delete(doc) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND) { testCollection.delete(doc) }
     }
 
     @Test
@@ -288,7 +288,7 @@ class DatabaseTest : BaseDbTest() {
             assertEquals(n + 1, testCollection.count)
 
             // Delete from the the wrong db
-            assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherCollection.delete(doc) }
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherCollection.delete(doc) }
         } finally {
             eraseDb(otherDb)
         }
@@ -307,7 +307,7 @@ class DatabaseTest : BaseDbTest() {
             assertNotSame(otherCollection, testCollection)
 
             // Delete from the different db:
-            assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherCollection.delete(doc) }
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherCollection.delete(doc) }
         } finally {
             eraseDb(otherDb)
         }
@@ -341,7 +341,7 @@ class DatabaseTest : BaseDbTest() {
         testDatabase.close()
 
         // Delete doc from closed db:
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.delete(doc) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.delete(doc) }
     }
 
     @Test
@@ -352,7 +352,7 @@ class DatabaseTest : BaseDbTest() {
         testDatabase.delete()
 
         // Delete doc from deleted db:
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.delete(doc) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.delete(doc) }
     }
 
     //---------------------------------------------
@@ -362,7 +362,7 @@ class DatabaseTest : BaseDbTest() {
     fun testPurgeNonexistentDoc() {
         val n = testCollection.count
         val doc = MutableDocument("doc1")
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND) { testCollection.purge(doc) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND) { testCollection.purge(doc) }
         assertEquals(n, testCollection.count)
     }
 
@@ -394,7 +394,7 @@ class DatabaseTest : BaseDbTest() {
             assertEquals(n + 1, otherCollection.count)
 
             // purge document against other db instance:
-            assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherCollection.purge(doc) }
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherCollection.purge(doc) }
         } finally {
             eraseDb(otherDb)
         }
@@ -414,7 +414,7 @@ class DatabaseTest : BaseDbTest() {
             assertEquals(0, otherCollection.count)
 
             // Purge document against other db:
-            assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherCollection.purge(doc) }
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherCollection.purge(doc) }
         } finally {
             eraseDb(otherDb)
         }
@@ -469,7 +469,7 @@ class DatabaseTest : BaseDbTest() {
         testDatabase.close()
 
         // Purge doc:
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.purge(doc) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.purge(doc) }
     }
 
     @Test
@@ -481,7 +481,7 @@ class DatabaseTest : BaseDbTest() {
         testDatabase.close()
 
         // Purge doc:
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.purge(doc) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.purge(doc) }
     }
 
     //---------------------------------------------
@@ -601,7 +601,7 @@ class DatabaseTest : BaseDbTest() {
     fun testCloseInInBatch() {
         testDatabase.inBatch<RuntimeException> {
             // can't close a db in a transaction
-            assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.TRANSACTION_NOT_CLOSED) { testDatabase.close() }
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.TRANSACTION_NOT_CLOSED) { testDatabase.close() }
         }
     }
 
@@ -722,7 +722,7 @@ class DatabaseTest : BaseDbTest() {
         val path = File(testDatabase.path!!)
         assertTrue(path.exists())
         testDatabase.inBatch<RuntimeException> {
-            assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.TRANSACTION_NOT_CLOSED) { testDatabase.delete() }
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.TRANSACTION_NOT_CLOSED) { testDatabase.delete() }
         }
     }
 
@@ -741,7 +741,7 @@ class DatabaseTest : BaseDbTest() {
             assertEquals(n, otherCollection.count)
 
             // delete db
-            assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.BUSY) { testDatabase.delete() }
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.BUSY) { testDatabase.delete() }
         } finally {
             eraseDb(otherDb)
         }
@@ -771,7 +771,7 @@ class DatabaseTest : BaseDbTest() {
         assertNotNull(path)
         assertTrue(path.exists())
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.BUSY) { Database.delete(testDatabase.name, null) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.BUSY) { Database.delete(testDatabase.name, null) }
     }
 
     @Test
@@ -796,21 +796,21 @@ class DatabaseTest : BaseDbTest() {
     @SlowTest
     @Test
     fun testDeleteOpenDBWithStaticMethod() {
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.BUSY) {
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.BUSY) {
             Database.delete(testDatabase.name, testDatabase.filePath!!.parentFile)
         }
     }
 
     @Test
     fun testDeleteNonExistingDBWithDefaultDir() {
-        assertThrowsCBL(CBLError.Domain.CBLITE, C4Constants.LiteCoreError.NOT_FOUND) {
+        assertThrowsCBLException(CBLError.Domain.CBLITE, C4Constants.LiteCoreError.NOT_FOUND) {
             Database.delete("doesntexist", testDatabase.filePath)
         }
     }
 
     @Test
     fun testDeleteNonExistingDB() {
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND) {
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND) {
             Database.delete(testDatabase.name, File(getScratchDirectoryPath("nowhere")))
         }
     }
@@ -878,19 +878,19 @@ class DatabaseTest : BaseDbTest() {
         collection.addDocumentChangeListener(doc.id) { }
 
         // All of these things should throw
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.getDocument(doc.id) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.getDocument(doc.id) }
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.save(MutableDocument()) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.save(MutableDocument()) }
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.delete(doc) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.delete(doc) }
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.purge(doc.id) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.purge(doc.id) }
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.indexes }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.indexes }
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.deleteIndex("foo") }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.deleteIndex("foo") }
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) {
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) {
             collection.createIndex("index", IndexBuilder.valueIndex(ValueIndexItem.property("firstName")))
         }
     }
@@ -918,19 +918,19 @@ class DatabaseTest : BaseDbTest() {
         collection.addDocumentChangeListener("docId") { }
 
         // All of these things should throw
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.getDocument(doc.id) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.getDocument(doc.id) }
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.save(MutableDocument()) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.save(MutableDocument()) }
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.delete(doc) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.delete(doc) }
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.purge(doc.id) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.purge(doc.id) }
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.indexes }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.indexes }
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.deleteIndex("foo") }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.deleteIndex("foo") }
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) {
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) {
             collection.createIndex("index", IndexBuilder.valueIndex(ValueIndexItem.property("firstName")))
         }
     }
@@ -950,7 +950,7 @@ class DatabaseTest : BaseDbTest() {
         assertNotNull(scope.collections)
 
         testDatabase.close()
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { scope.collections }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { scope.collections }
     }
 
     @Test
@@ -962,7 +962,7 @@ class DatabaseTest : BaseDbTest() {
         assertNotNull(scope.collections)
 
         testDatabase.close()
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { scope.getCollection("bobblehead") }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { scope.getCollection("bobblehead") }
     }
 
     //---------------------------------------------
@@ -980,7 +980,7 @@ class DatabaseTest : BaseDbTest() {
         assertNotNull(scope.collections)
 
         testDatabase.delete()
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { scope.collections }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { scope.collections }
     }
 
     @Test
@@ -992,7 +992,7 @@ class DatabaseTest : BaseDbTest() {
         assertNotNull(scope.collections)
 
         testDatabase.delete()
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { scope.getCollection("bobblehead") }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { scope.getCollection("bobblehead") }
     }
 
     //---------------------------------------------
@@ -1009,7 +1009,7 @@ class DatabaseTest : BaseDbTest() {
 
         testDatabase.close()
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testDatabase.getScope("horo") }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testDatabase.getScope("horo") }
     }
 
     @Test
@@ -1020,7 +1020,7 @@ class DatabaseTest : BaseDbTest() {
 
         testDatabase.close()
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) {
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) {
             testDatabase.getCollection("bobblehead", "horo")
         }
     }
@@ -1035,7 +1035,7 @@ class DatabaseTest : BaseDbTest() {
 
         testDatabase.delete()
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testDatabase.getScope("horo") }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testDatabase.getScope("horo") }
     }
 
     @Test
@@ -1046,7 +1046,7 @@ class DatabaseTest : BaseDbTest() {
 
         testDatabase.delete()
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) {
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) {
             testDatabase.getCollection("bobblehead", "horo")
         }
     }
@@ -1565,8 +1565,8 @@ class DatabaseTest : BaseDbTest() {
         assertEquals(0, testCollection.count)
         assertNull(testCollection.getDocument(docA.id))
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND) { testCollection.delete(docA) }
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND) { testCollection.delete(docB!!) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND) { testCollection.delete(docA) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND) { testCollection.delete(docB!!) }
         assertEquals(0, testCollection.count)
 
         assertNull(testCollection.getDocument(docB!!.id))

--- a/common/test/java/com/couchbase/lite/DocumentTest.java
+++ b/common/test/java/com/couchbase/lite/DocumentTest.java
@@ -89,7 +89,7 @@ public class DocumentTest extends BaseDbTest {
     public void testCreateDocWithEmptyStringID() {
         final MutableDocument doc1a = new MutableDocument("");
         assertNotNull(doc1a);
-        assertThrowsCBL(
+        assertThrowsCBLException(
             CBLError.Domain.CBLITE,
             CBLError.Code.BAD_DOC_ID,
             () -> getTestCollection().save(doc1a));
@@ -1568,7 +1568,10 @@ public class DocumentTest extends BaseDbTest {
         MutableDocument mDoc = new MutableDocument("doc1");
         mDoc.setString("name", "Scott Tiger");
 
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND, () -> getTestCollection().delete(mDoc));
+        assertThrowsCBLException(
+            CBLError.Domain.CBLITE,
+            CBLError.Code.NOT_FOUND,
+            () -> getTestCollection().delete(mDoc));
 
         assertEquals("Scott Tiger", mDoc.getString("name"));
     }
@@ -1671,7 +1674,7 @@ public class DocumentTest extends BaseDbTest {
         doc.setValue("name", "Scott");
 
         // Purge before save:
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND, () -> getTestCollection().purge(doc));
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND, () -> getTestCollection().purge(doc));
 
         assertEquals("profile", doc.getValue("type"));
         assertEquals("Scott", doc.getValue("name"));
@@ -1692,7 +1695,10 @@ public class DocumentTest extends BaseDbTest {
         doc.setValue("name", "Scott");
 
         // Purge before save:
-        assertThrowsCBL(CBLError.Domain.CBLITE, CBLError.Code.NOT_FOUND, () -> getTestCollection().purge(docID));
+        assertThrowsCBLException(
+            CBLError.Domain.CBLITE,
+            CBLError.Code.NOT_FOUND,
+            () -> getTestCollection().purge(docID));
 
         assertEquals("profile", doc.getValue("type"));
         assertEquals("Scott", doc.getValue("name"));
@@ -1841,7 +1847,9 @@ public class DocumentTest extends BaseDbTest {
 
         getTestCollection().setDocumentExpiration(id, new Date(System.currentTimeMillis() + 30000L));
 
-        getTestCollection().getDatabase().deleteCollection(getTestCollection().getName(), getTestCollection().getScope().getName());
+        getTestCollection().getDatabase().deleteCollection(
+            getTestCollection().getName(),
+            getTestCollection().getScope().getName());
 
         try {
             getTestCollection().getDocumentExpiration(id);
@@ -2753,7 +2761,11 @@ public class DocumentTest extends BaseDbTest {
 
     // Kotlin shim functions
 
-    private Document saveDocInTestCollection(MutableDocument mDoc) { return validateAndSaveDocInTestCollection(mDoc, null); }
+    private Document saveDocInTestCollection(MutableDocument mDoc) {
+        return validateAndSaveDocInTestCollection(
+            mDoc,
+            null);
+    }
 
     private Document validateAndSaveDocInTestCollection(MutableDocument mDoc, DocValidator validator) {
         try {

--- a/common/test/java/com/couchbase/lite/ReplicatorMiscTest.java
+++ b/common/test/java/com/couchbase/lite/ReplicatorMiscTest.java
@@ -151,10 +151,7 @@ public class ReplicatorMiscTest extends BaseReplicatorTest {
         });
 
         // the replicator will fail because the endpoint is bogus
-        run(
-            repl,
-            false, CBLError.Domain.CBLITE, CBLError.Code.NETWORK_OFFSET + C4Constants.NetworkError.UNKNOWN_HOST
-        );
+        run(repl, false, CBLError.Domain.CBLITE, CBLError.Code.UNKNOWN_HOST);
 
         synchronized (options) {
             assertEquals(
@@ -194,10 +191,7 @@ public class ReplicatorMiscTest extends BaseReplicatorTest {
         });
 
         // the replicator will fail because the endpoint is bogus
-        run(
-            repl,
-            false, CBLError.Domain.CBLITE, CBLError.Code.NETWORK_OFFSET + C4Constants.NetworkError.UNKNOWN_HOST
-        );
+        run(repl, false, CBLError.Domain.CBLITE, CBLError.Code.UNKNOWN_HOST);
 
         synchronized (options) {
             assertEquals(Boolean.TRUE, options.get(C4Replicator.REPLICATOR_OPTION_ACCEPT_PARENT_COOKIES));


### PR DESCRIPTION
Also a fix to the LiveQueries class that makes it more sensible.  This is the only change that affects production.