### PR TITLE
CBL-3886: Remove deprecated API from MessageEndpointTests

### DIFF
--- a/common/test/java/com/couchbase/lite/BaseReplicatorTest.kt
+++ b/common/test/java/com/couchbase/lite/BaseReplicatorTest.kt
@@ -207,7 +207,7 @@ abstract class BaseReplicatorTest : BaseDbTest() {
     }
 
     protected fun ReplicatorConfiguration.run(reset: Boolean = false, errDomain: String? = null, errCode: Int = 0) =
-        replicatorConfiguration.testReplicator().run(reset, errDomain, errCode)
+        this.testReplicator().run(reset, errDomain, errCode)
 
     protected fun Replicator.run(reset: Boolean = false, errDomain: String? = null, errCode: Int = 0): Replicator {
         val awaiter = ReplicatorAwaiter(this, testSerialExecutor)


### PR DESCRIPTION
I think this is the last of the tests still using deprecated API methods (except those that are doing so, on purpose)

When reading these tests I found some of them kind of hard to understand.  I believe that I've also improved that.