### PR TITLE
CBL-4435:Replicator.close() stops status updates

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/replicator/BaseReplicator.java
+++ b/common/main/java/com/couchbase/lite/internal/replicator/BaseReplicator.java
@@ -37,28 +37,31 @@ public abstract class BaseReplicator implements AutoCloseable {
     protected BaseReplicator() { }
 
     @Override
-    public void close() {
-        final C4Replicator c4Repl;
-        synchronized (getReplicatorLock()) {
-            c4Repl = c4Replicator;
-            c4Replicator = null;
-        }
-        if (c4Repl != null) { c4Repl.close(); }
-    }
+    public void close() { setC4ReplicatorInternal(null); }
 
     @Nullable
     public C4Replicator getC4Replicator() {
         synchronized (getReplicatorLock()) { return c4Replicator; }
     }
 
-    protected void setC4Replicator(@NonNull C4Replicator c4Repl) {
+    protected void setC4Replicator(@NonNull C4Replicator newC4Repl) {
         Log.d(
             LogDomain.REPLICATOR,
-            "Setting c4 replicator %s for replicator %s", ClassUtils.objId(c4Repl), ClassUtils.objId(this));
-
-        synchronized (getReplicatorLock()) { c4Replicator = c4Repl; }
+            "Setting c4 replicator %s for replicator %s",
+            ClassUtils.objId(newC4Repl), ClassUtils.objId(this));
+        setC4ReplicatorInternal(newC4Repl);
     }
 
     @NonNull
     protected Object getReplicatorLock() { return lock; }
+
+    private void setC4ReplicatorInternal(@Nullable C4Replicator newC4Repl) {
+        final C4Replicator oldC4Repl;
+        synchronized (getReplicatorLock()) {
+            oldC4Repl = c4Replicator;
+            c4Replicator = newC4Repl;
+        }
+
+        if (oldC4Repl != null) { oldC4Repl.close(); }
+    }
 }

--- a/common/test/java/com/couchbase/lite/BaseDbTest.kt
+++ b/common/test/java/com/couchbase/lite/BaseDbTest.kt
@@ -21,7 +21,6 @@ import com.couchbase.lite.internal.utils.Report
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.After
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -31,7 +30,7 @@ import org.junit.Before
 import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.nio.charset.StandardCharsets
-import java.util.*
+import java.util.Locale
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -223,9 +222,8 @@ abstract class BaseDbTest : BaseTest() {
     ): MutableDocument {
         val mDoc = createTestDoc(tag)
         val n = collection.count
-        val doc = saveDocInCollection(mDoc, collection)
+        saveDocInCollection(mDoc, collection)
         assertEquals(n + 1, collection.count)
-        assertEquals(1, doc.sequence)
         return mDoc
     }
 

--- a/common/test/java/com/couchbase/lite/BaseTest.java
+++ b/common/test/java/com/couchbase/lite/BaseTest.java
@@ -110,13 +110,12 @@ public abstract class BaseTest extends PlatformBaseTest {
     // one of these methods (or their equvalents in C4BaseTest and OKHttpSocketTest
 
     public static <T extends Exception> void assertThrows(Class<T> ex, @NonNull Fn.TaskThrows<Exception> test) {
-        try {
-            test.run();
-            fail("Expecting exception: " + ex);
-        }
+        try { test.run(); }
         catch (Throwable e) {
             if (!ex.equals(e.getClass())) { fail("Expecting exception: " + ex + " but got " + e); }
+            return;
         }
+        fail("Expecting exception: " + ex);
     }
 
     public static void assertIsCBLException(@Nullable Exception e, @Nullable String domain, int code) {


### PR DESCRIPTION
An extensive comment describes the choice I mede for implementation.

tl; dr: I believe the intention of the close() method is to do exactly what would happen if the GC got the object, but to do it right now.  That is exactly what this implementation does.  It tells LiteCore to close the replicator and then completely forgets about it.  No zombie objects, no long delays, no unexpected exceptions.