### PR TITLE
CBL-1048: char[] encoding in Fleece encoder

### DIFF
--- a/android-ktx/main/kotlin/com/couchbase/lite/internal/ReplicatorWorker.kt
+++ b/android-ktx/main/kotlin/com/couchbase/lite/internal/ReplicatorWorker.kt
@@ -166,7 +166,7 @@ class ReplicatorWorker(appContext: Context, params: WorkerParameters) : Coroutin
     private fun getFactory(factoryClass: String?): WorkManagerReplicatorFactory {
         factoryClass ?: throw IllegalArgumentException("Factory class name is null")
         try {
-            return (Class.forName(factoryClass).newInstance() as WorkManagerReplicatorFactory)
+            return (Class.forName(factoryClass).getDeclaredConstructor().newInstance() as WorkManagerReplicatorFactory)
         } catch (e: Exception) {
             throw IllegalStateException("Failed creating factory ${factoryClass}", e)
         }

--- a/common/main/cpp/com_couchbase_lite_internal_fleece_FLEncoder.h
+++ b/common/main/cpp/com_couchbase_lite_internal_fleece_FLEncoder.h
@@ -81,6 +81,14 @@ JNIEXPORT jboolean JNICALL Java_com_couchbase_lite_internal_fleece_FLEncoder_wri
 
 /*
  * Class:     com_couchbase_lite_internal_fleece_FLEncoder
+ * Method:    writeStringBytes
+ * Signature: (J[B)Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_couchbase_lite_internal_fleece_FLEncoder_writeStringBytes
+        (JNIEnv *, jclass, jlong, jbyteArray);
+
+/*
+ * Class:     com_couchbase_lite_internal_fleece_FLEncoder
  * Method:    writeData
  * Signature: (J[B)Z
  */

--- a/common/main/cpp/native_flencoder.cc
+++ b/common/main/cpp/native_flencoder.cc
@@ -129,6 +129,20 @@ Java_com_couchbase_lite_internal_fleece_FLEncoder_writeString(
 
 /*
  * Class:     com_couchbase_lite_internal_fleece_FLEncoder
+ * Method:    writeStringBytes
+ * Signature: (J[B)Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_couchbase_lite_internal_fleece_FLEncoder_writeStringBytes(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jenc,
+        jbyteArray jvalue) {
+    jstringSlice value(env, jvalue);
+    return (jboolean) FLEncoder_WriteString((FLEncoder) jenc, value);
+}
+
+/*
+ * Class:     com_couchbase_lite_internal_fleece_FLEncoder
  * Method:    writeData
  * Signature: (J[B)Z
  */

--- a/common/main/cpp/native_glue.cc
+++ b/common/main/cpp/native_glue.cc
@@ -237,7 +237,10 @@ namespace litecore {
             }
         }
 
-        jstringSlice::jstringSlice(JNIEnv *env, jbyteArray jchars) {
+        jstringSlice::jstringSlice(JNIEnv *env, jbyteArray jchars)
+                : _env(env)
+                , _jbytes(jchars) {
+            assert(env != nullptr);
             if (jchars == nullptr) {
                 _slice = kFLSliceNull;
             } else {
@@ -245,8 +248,8 @@ namespace litecore {
                 if (length <= 0) {
                     _slice = kFLSliceNull;
                 } else {
-                    auto *chars = env->GetByteArrayElements(jchars, nullptr);
-                    _slice = {chars, length};
+                    _bytes = env->GetByteArrayElements(jchars, nullptr);
+                    _slice = {_bytes, length};
                 }
             }
         }
@@ -254,6 +257,12 @@ namespace litecore {
         const char *jstringSlice::c_str() {
             return (const char *) _slice.buf;
         };
+
+        jstringSlice::~jstringSlice() {
+            if (_bytes) {
+                _env->ReleaseByteArrayElements(_jbytes, _bytes, JNI_ABORT);
+            }
+        }
 
         // ATTN: In critical, should not call any other JNI methods.
         // http://docs.oracle.com/javase/6/docs/technotes/guides/jni/spec/functions.html

--- a/common/main/cpp/native_glue.cc
+++ b/common/main/cpp/native_glue.cc
@@ -237,6 +237,20 @@ namespace litecore {
             }
         }
 
+        jstringSlice::jstringSlice(JNIEnv *env, jbyteArray jchars) {
+            if (jchars == nullptr) {
+                _slice = kFLSliceNull;
+            } else {
+                size_t length = env->GetArrayLength(jchars);
+                if (length <= 0) {
+                    _slice = kFLSliceNull;
+                } else {
+                    auto *chars = env->GetByteArrayElements(jchars, nullptr);
+                    _slice = {chars, length};
+                }
+            }
+        }
+
         const char *jstringSlice::c_str() {
             return (const char *) _slice.buf;
         };

--- a/common/main/cpp/native_glue.hh
+++ b/common/main/cpp/native_glue.hh
@@ -69,6 +69,8 @@ namespace litecore {
             jstringSlice(jstringSlice &&s)
                     : _str(std::move(s._str)), _slice(s._slice) { s._slice = kFLSliceNull; }
 
+            ~jstringSlice();
+
             operator FLSlice() { return _slice; }
 
             const char *c_str();
@@ -76,6 +78,9 @@ namespace litecore {
         private:
             std::string _str;
             FLSlice _slice;
+            JNIEnv *_env;
+            jbyte* _bytes {nullptr};
+            jbyteArray _jbytes;
         };
 
         // Creates a temporary slice value from a Java byte[], attempting to avoid copying

--- a/common/main/cpp/native_glue.hh
+++ b/common/main/cpp/native_glue.hh
@@ -64,6 +64,8 @@ namespace litecore {
         public:
             jstringSlice(JNIEnv *env, jstring js);
 
+            jstringSlice(JNIEnv *env, jbyteArray jchars);
+
             jstringSlice(jstringSlice &&s)
                     : _str(std::move(s._str)), _slice(s._slice) { s._slice = kFLSliceNull; }
 

--- a/common/main/java/com/couchbase/lite/BasicAuthenticator.java
+++ b/common/main/java/com/couchbase/lite/BasicAuthenticator.java
@@ -101,8 +101,7 @@ public final class BasicAuthenticator extends BaseAuthenticator {
         final Map<String, Object> auth = new HashMap<>();
         auth.put(C4Replicator.REPLICATOR_AUTH_TYPE, C4Replicator.AUTH_TYPE_BASIC);
         auth.put(C4Replicator.REPLICATOR_AUTH_USER_NAME, username);
-        // !!! Temporary hack until there is JNI/Core support for clearable passwords.
-        auth.put(C4Replicator.REPLICATOR_AUTH_PASSWORD, new String(password));
+        auth.put(C4Replicator.REPLICATOR_AUTH_PASSWORD, password);
         options.put(C4Replicator.REPLICATOR_OPTION_AUTHENTICATION, auth);
     }
 }

--- a/common/main/java/com/couchbase/lite/internal/core/C4Key.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Key.java
@@ -17,7 +17,6 @@ package com.couchbase.lite.internal.core;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 
 import com.couchbase.lite.CBLError;
 import com.couchbase.lite.CouchbaseLiteException;
@@ -33,7 +32,6 @@ public final class C4Key {
     }
 
     @NonNull
-    @VisibleForTesting
     private static final NativeImpl NATIVE_IMPL = new NativeC4Key();
 
     @NonNull

--- a/common/main/java/com/couchbase/lite/internal/fleece/FLEncoder.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/FLEncoder.java
@@ -18,6 +18,10 @@ package com.couchbase.lite.internal.fleece;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -144,6 +148,12 @@ public abstract class FLEncoder extends C4NativePeer {
 
     public boolean writeString(String value) { return writeString(getPeer(), value); }
 
+    public boolean writeString(char[] value) {
+        final ByteBuffer byteBuffer = StandardCharsets.UTF_8.encode(CharBuffer.wrap(value));
+        byte[] bytes = Arrays.copyOf(byteBuffer.array(), byteBuffer.limit());
+        return writeStringBytes(getPeer(), bytes);
+    }
+
     public boolean writeData(byte[] value) { return writeData(getPeer(), value); }
 
     public boolean beginDict(long reserve) { return beginDict(getPeer(), reserve); }
@@ -185,6 +195,9 @@ public abstract class FLEncoder extends C4NativePeer {
 
         // String
         if (value instanceof String) { return writeString(peer, (String) value); }
+
+        // String (represented as char[])
+        if (value instanceof char[]) { return writeString((char[]) value); }
 
         // byte[]
         if (value instanceof byte[]) { return writeData(peer, (byte[]) value); }
@@ -273,6 +286,8 @@ public abstract class FLEncoder extends C4NativePeer {
     private static native boolean writeDouble(long encoder, double value);
 
     private static native boolean writeString(long encoder, String value);
+
+    private static native boolean writeStringBytes(long encoder, byte[] value);
 
     private static native boolean writeData(long encoder, byte[] value);
 

--- a/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
+++ b/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
@@ -347,9 +347,12 @@ public abstract class AbstractCBLWebSocket implements SocketFromCore, SocketFrom
         this.toCore = toCore;
         this.toRemote = toRemote;
         this.uri = uri;
-        this.options = (opts == null) ? null : Collections.unmodifiableMap(FLValue.fromData(opts).asDict());
         this.cookieStore = cookieStore;
         this.serverCertsListener = serverCertsListener;
+        // Despite best practice, this may deserialize a password as a String.
+        // It's there in LiteCore, too. :shrug:
+        // see setupBasicAuthenticator
+        this.options = (opts == null) ? null : Collections.unmodifiableMap(FLValue.fromData(opts).asDict());
     }
 
     @Override

--- a/common/test/java/com/couchbase/lite/internal/fleece/EncodingTest.java
+++ b/common/test/java/com/couchbase/lite/internal/fleece/EncodingTest.java
@@ -31,13 +31,13 @@ import static org.junit.Assert.assertTrue;
 
 
 public class EncodingTest extends BaseTest {
-
     // https://github.com/couchbase/couchbase-lite-android/issues/1453
     @Test
-    public void testFLEncode() throws Exception {
+    public void testFLEncode() throws LiteCoreException {
         testRoundTrip(42L);
         testRoundTrip(Long.MIN_VALUE);
         testRoundTrip("Fleece");
+        testRoundTrip("Goodbye cruel world".toCharArray(), "Goodbye cruel world");
         Map<String, Object> map = new HashMap<>();
         map.put("foo", "bar");
         testRoundTrip(map);
@@ -48,7 +48,7 @@ public class EncodingTest extends BaseTest {
     }
 
     @Test
-    public void testFLEncodeUTF8() throws Exception {
+    public void testFLEncodeUTF8() throws LiteCoreException {
         testRoundTrip("Goodbye cruel world"); // one byte utf-8 chars
         testRoundTrip("Goodbye cruel £ world"); // a two byte utf-8 chars
         testRoundTrip("Goodbye cruel ᘺ world"); // a three byte utf-8 char
@@ -58,14 +58,14 @@ public class EncodingTest extends BaseTest {
     }
 
     @Test
-    public void testFLEncodeBadUTF8() throws Exception {
+    public void testFLEncodeBadUTF8() throws LiteCoreException {
         skipTestWhen("WINDOWS");
         testRoundTrip("Goodbye cruel \uD83D\uDE3A\uDE3A world", ""); // a cat and a half
     }
 
     // Oddly windows seems to parse this differently...
     @Test
-    public void testFLEncodeUTF8Win() throws Exception {
+    public void testFLEncodeUTF8Win() throws LiteCoreException {
         skipTestWhen("NOT WINDOWS");
         testRoundTrip("Goodbye cruel \uD83D\uDE3A\uDE3A world"); // a cat and a half
     }


### PR DESCRIPTION
There are some other "in passing" fixes here.  Mostly though, I'd appreciate having you look at `jstringSlice::jstringSlice(JNIEnv *env, jbyteArray jchars)`

That's the heart of the matter.  `testBasicAuthOptions` verifies that the authenticator password option does, in fact, make it to the network code as a string.