### PR TITLE
Backport outstanding 3.1 fixes to 3.0

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/common/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -174,7 +174,7 @@ abstract class AbstractDatabase extends BaseDatabase {
      */
     public static boolean exists(@NonNull String name, @Nullable File directory) {
         Preconditions.assertNotNull(name, "name");
-        if (directory == null) { directory = CouchbaseLiteInternal.getDefaultDbDir(); }
+        if (directory == null) { directory = CouchbaseLiteInternal.getRootDir(); }
         return C4Database.getDatabaseFile(directory, name).exists();
     }
 

--- a/common/main/java/com/couchbase/lite/internal/exec/ClientTask.java
+++ b/common/main/java/com/couchbase/lite/internal/exec/ClientTask.java
@@ -42,7 +42,7 @@ import com.couchbase.lite.internal.support.Log;
  */
 public class ClientTask<T> {
     private static final CBLExecutor EXECUTOR
-        = new CBLExecutor("Client worker", 128, 128, new SynchronousQueue<>());
+        = new CBLExecutor("Client worker", 4, 8, new SynchronousQueue<>());
 
     public static void dumpState() {
         EXECUTOR.dumpState();


### PR DESCRIPTION
CBL-4922: Backport: failure in OkHttp authenticator
CBL-4921: Backport: lower the max size on the ClientTask thread pool
CBL-4799: Database.exists should support the default directory

I miss-labeled the branch.  It should be `candidate/3.0.14`, of course.