### PR TITLE
Convert 3.1 to use the new build system

### DIFF
--- a/common/test/java/com/couchbase/lite/DictionaryTest.java
+++ b/common/test/java/com/couchbase/lite/DictionaryTest.java
@@ -624,7 +624,7 @@ public class DictionaryTest extends BaseDbTest {
 
         assertNotEquals(0, dict3.hashCode());
         assertNotEquals(dict3.hashCode(), new Object().hashCode());
-        assertNotEquals(dict3.hashCode(), new Integer(1).hashCode());
+        assertNotEquals(dict3.hashCode(), Integer.valueOf(1).hashCode());
         assertNotEquals(dict3.hashCode(), new HashMap<>().hashCode());
         assertNotEquals(dict3.hashCode(), new MutableDictionary().hashCode());
         assertNotEquals(dict3.hashCode(), new MutableArray().hashCode());

--- a/common/test/java/com/couchbase/lite/DocumentTest.java
+++ b/common/test/java/com/couchbase/lite/DocumentTest.java
@@ -2556,7 +2556,7 @@ public class DocumentTest extends BaseDbTest {
 
         Assert.assertNotEquals(doc3.hashCode(), 0);
         Assert.assertNotEquals(doc3.hashCode(), new Object().hashCode());
-        Assert.assertNotEquals(doc3.hashCode(), new Integer(1).hashCode());
+        Assert.assertNotEquals(doc3.hashCode(), Integer.valueOf(1).hashCode());
         Assert.assertNotEquals(doc3.hashCode(), new HashMap<>().hashCode());
         Assert.assertNotEquals(doc3.hashCode(), new MutableDictionary().hashCode());
         Assert.assertNotEquals(doc3.hashCode(), new MutableArray().hashCode());


### PR DESCRIPTION
This is just a couple of warnings that come from using Java 17 for the compile