### PR TITLE
CBL-4799: Fix test and docs for null param == default dir

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/common/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -169,7 +169,7 @@ abstract class AbstractDatabase extends BaseDatabase {
      * Checks whether a database of the given name exists in the given directory or not.
      *
      * @param name      the database's name
-     * @param directory the path where the database is located.
+     * @param directory the path where the database is located. If null, the default db directory will be used.
      * @return true if exists, false otherwise.
      */
     public static boolean exists(@NonNull String name, @Nullable File directory) {

--- a/common/test/java/com/couchbase/lite/DatabaseTest.java
+++ b/common/test/java/com/couchbase/lite/DatabaseTest.java
@@ -785,13 +785,21 @@ public class DatabaseTest extends BaseDbTest {
             () -> Database.delete(baseTestDb.getName(), new File(getScratchDirectoryPath("nowhere"))));
     }
 
-    // NOTE: Android/Java does not allow to use null as directory parameters
-    @Test(expected = IllegalArgumentException.class)
-    public void testDatabaseExistsWithDefaultDir() { Database.exists(baseTestDb.getName(), null); }
-
     //---------------------------------------------
     //  Database Existing
     //---------------------------------------------
+
+    @Test
+    public void testDatabaseExistsWithDefaultDir() throws CouchbaseLiteException {
+        Database db = null;
+        try {
+            db = new Database(getUniqueName("defaultDb"));
+            assertTrue(Database.exists(db.getName(), null));
+        }
+        finally {
+            deleteDb(db);
+        }
+    }
 
     @Test
     public void testDatabaseExistsWithDir() throws CouchbaseLiteException {


### PR DESCRIPTION
The test for the incorrect API of Database.exists needs to test for the correct behavior, instead.