### PR TITLE
Fix for CBSE-15160

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/core/C4Database.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Database.java
@@ -171,7 +171,13 @@ public abstract class C4Database extends C4NativePeer {
             finally { super.finalize(); }
         }
 
-        private void closePeer(@Nullable LogDomain domain) { releasePeer(domain, impl::nFree); }
+        // Some versions of ART will GC the final field, before finalizing this object.
+        private void closePeer(@Nullable LogDomain domain) {
+            releasePeer(domain, (db) -> {
+                final NativeImpl nativeImpl = impl;
+                if (nativeImpl != null) { nativeImpl.nFree(db); }
+            });
+        }
     }
 
     @NonNull

--- a/common/main/java/com/couchbase/lite/internal/core/C4DocumentChange.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4DocumentChange.java
@@ -30,21 +30,21 @@ public final class C4DocumentChange {
         @Nullable String revId,
         long seq,
         boolean ext) {
-        if ((docId != null) && (revId != null)) { return new C4DocumentChange(docId, revId, seq, ext); }
+        if (docId != null) { return new C4DocumentChange(docId, revId, seq, ext); }
 
-        Log.i(LogDomain.DATABASE, "Bad db change notification: (%s, %s)", docId, revId);
+        Log.i(LogDomain.DATABASE, "Doc id is null in createC4DocumentChange");
         return null;
     }
 
 
     @NonNull
     private final String docID;
-    @NonNull
+    @Nullable
     private final String revID;
     private final long sequence;
     private final boolean external;
 
-    private C4DocumentChange(@NonNull String docID, @NonNull String revID, long seq, boolean ext) {
+    private C4DocumentChange(@NonNull String docID, @Nullable String revID, long seq, boolean ext) {
         this.docID = docID;
         this.revID = revID;
         this.sequence = seq;
@@ -54,7 +54,7 @@ public final class C4DocumentChange {
     @NonNull
     public String getDocID() { return docID; }
 
-    @NonNull
+    @Nullable
     public String getRevID() { return revID; }
 
     public long getSequence() { return sequence; }

--- a/common/main/java/com/couchbase/lite/internal/core/C4Log.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Log.java
@@ -81,7 +81,7 @@ public class C4Log {
         final Map<String, LogDomain> m = new HashMap<>();
         m.put(C4Constants.LogDomain.BLIP, LogDomain.NETWORK);
         m.put(C4Constants.LogDomain.BLIP_MESSAGES, LogDomain.NETWORK);
-        m.put(C4Constants.LogDomain.CHANGES, LogDomain.REPLICATOR);
+        m.put(C4Constants.LogDomain.CHANGES, LogDomain.DATABASE);
         m.put(C4Constants.LogDomain.DATABASE, LogDomain.DATABASE);
         m.put(C4Constants.LogDomain.LISTENER, LogDomain.LISTENER);
         m.put(C4Constants.LogDomain.QUERY, LogDomain.QUERY);


### PR DESCRIPTION
 This is a group of 4 related changes, each in its own commit:
    CBL-4989: Prevent an NPE in the C4Document finalizer.  A user encountered this problem and described it in a forum post.
    CBL-4989: A list of null changes should not stop change processing. Root cause of [CBSE-15160](https://issues.couchbase.com/browse/CBSE-15160)
    CBL-4991: Null revId is legal in document change. Another bug discovered in the analysis of [CBSE-15160](https://issues.couchbase.com/browse/CBSE-15160)
    CBL-4987: Map LiteCore CHANGES domain to platform DATABASE domain. Pasin requested fix.
    
    This is a 3.1.3 release candidate
