### PR TITLE
CBL-4990: A list of null changes should not stop change processing.

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/core/C4CollectionObserver.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4CollectionObserver.java
@@ -20,14 +20,20 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
+import java.util.Arrays;
+import java.util.List;
+
 import com.couchbase.lite.LiteCoreException;
 import com.couchbase.lite.LogDomain;
 import com.couchbase.lite.internal.core.impl.NativeC4CollectionObserver;
 import com.couchbase.lite.internal.core.peers.TaggedWeakPeerBinding;
+import com.couchbase.lite.internal.listener.ChangeNotifier;
 import com.couchbase.lite.internal.logging.Log;
 
 
-public final class C4CollectionObserver extends C4NativePeer {
+public final class C4CollectionObserver
+    extends C4NativePeer
+    implements ChangeNotifier.C4ChangeProducer<C4DocumentChange> {
     public interface NativeImpl {
         long nCreate(long token, long coll) throws LiteCoreException;
         @NonNull
@@ -101,9 +107,11 @@ public final class C4CollectionObserver extends C4NativePeer {
     // public methods
     //-------------------------------------------------------------------------
 
-    @NonNull
-    public C4DocumentChange[] getChanges(int maxChanges) {
-        return withPeerOrThrow((peer) -> impl.nGetChanges(peer, maxChanges));
+    @Override
+    @Nullable
+    public List<C4DocumentChange> getChanges(int maxChanges) {
+        final C4DocumentChange[] changes = withPeerOrThrow((peer) -> impl.nGetChanges(peer, maxChanges));
+        return (changes.length <= 0) ? null : Arrays.asList(changes);
     }
 
     @CallSuper

--- a/common/main/java/com/couchbase/lite/internal/core/C4DocumentChange.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4DocumentChange.java
@@ -30,21 +30,21 @@ public final class C4DocumentChange {
         @Nullable String revId,
         long seq,
         boolean ext) {
-        if ((docId != null) && (revId != null)) { return new C4DocumentChange(docId, revId, seq, ext); }
+        if (docId != null) { return new C4DocumentChange(docId, revId, seq, ext); }
 
-        Log.i(LogDomain.DATABASE, "Bad db change notification: (%s, %s)", docId, revId);
+        Log.i(LogDomain.DATABASE, "Doc id is null in createC4DocumentChange");
         return null;
     }
 
 
     @NonNull
     private final String docID;
-    @NonNull
+    @Nullable
     private final String revID;
     private final long sequence;
     private final boolean external;
 
-    private C4DocumentChange(@NonNull String docID, @NonNull String revID, long seq, boolean ext) {
+    private C4DocumentChange(@NonNull String docID, @Nullable String revID, long seq, boolean ext) {
         this.docID = docID;
         this.revID = revID;
         this.sequence = seq;
@@ -54,7 +54,7 @@ public final class C4DocumentChange {
     @NonNull
     public String getDocID() { return docID; }
 
-    @NonNull
+    @Nullable
     public String getRevID() { return revID; }
 
     public long getSequence() { return sequence; }

--- a/common/main/java/com/couchbase/lite/internal/core/C4Log.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Log.java
@@ -80,7 +80,7 @@ public class C4Log {
         final Map<String, LogDomain> m = new HashMap<>();
         m.put(C4Constants.LogDomain.BLIP, LogDomain.NETWORK);
         m.put(C4Constants.LogDomain.BLIP_MESSAGES, LogDomain.NETWORK);
-        m.put(C4Constants.LogDomain.CHANGES, LogDomain.REPLICATOR);
+        m.put(C4Constants.LogDomain.CHANGES, LogDomain.DATABASE);
         m.put(C4Constants.LogDomain.DATABASE, LogDomain.DATABASE);
         m.put(C4Constants.LogDomain.LISTENER, LogDomain.LISTENER);
         m.put(C4Constants.LogDomain.QUERY, LogDomain.QUERY);

--- a/common/main/java/com/couchbase/lite/internal/listener/ChangeNotifier.java
+++ b/common/main/java/com/couchbase/lite/internal/listener/ChangeNotifier.java
@@ -20,12 +20,14 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executor;
 
 import com.couchbase.lite.ChangeListener;
 import com.couchbase.lite.ListenerToken;
 import com.couchbase.lite.internal.utils.Fn;
+
 
 // Used for Document and Collection (and MessageEndpoint) change notification.
 // When used for a collection, we register a single callback with Core.
@@ -49,6 +51,14 @@ import com.couchbase.lite.internal.utils.Fn;
 // free their companions in their finalizers, releasing the replicator will
 // correctly free all this stuff... eventually.
 public abstract class ChangeNotifier<T> {
+
+    // a factory for changes.
+    public interface C4ChangeProducer<T1> extends AutoCloseable {
+        @Nullable
+        List<T1> getChanges(int maxChanges);
+        void close();
+    }
+
     @NonNull
     private final Object lock = new Object();
     @NonNull

--- a/common/test/java/com/couchbase/lite/LiveQueryTest.java
+++ b/common/test/java/com/couchbase/lite/LiveQueryTest.java
@@ -273,7 +273,7 @@ public class LiveQueryTest extends BaseDbTest {
         final List<QueryChangeListener> listeners = new ArrayList<>();
         final List<ListenerToken> tokens = new ArrayList<>();
         for (int i = 0; i < 7; i++) {
-            QueryChangeListener listener = (change) -> { };
+            QueryChangeListener listener = change -> { };
             listeners.add(listener);
             tokens.add(query.addChangeListener(listener));
         }

--- a/common/test/java/com/couchbase/lite/internal/core/C4CollectionObserverTest.kt
+++ b/common/test/java/com/couchbase/lite/internal/core/C4CollectionObserverTest.kt
@@ -141,7 +141,7 @@ class C4CollectionObserverTest : C4BaseTest() {
         external: Boolean,
     ) {
         val changes = observer.getChanges(100)
-        assertNotNull(changes)
+        assertNotNull(changes!!)
         assertEquals(expectedDocIds.size, changes.size)
         for (i in changes.indices) {
             assertEquals(expectedDocIds[i], changes[i].docID)

--- a/common/test/java/com/couchbase/lite/internal/core/C4ObserverTest.java
+++ b/common/test/java/com/couchbase/lite/internal/core/C4ObserverTest.java
@@ -194,13 +194,15 @@ public class C4ObserverTest extends C4BaseTest {
         List<String> expectedDocIDs,
         List<String> expectedRevIDs,
         boolean expectedExternal) {
-        C4DocumentChange[] changes = observer.getChanges(100);
+        List<C4DocumentChange> changes = observer.getChanges(100);
         assertNotNull(changes);
-        assertEquals(expectedDocIDs.size(), changes.length);
-        for (int i = 0; i < changes.length; i++) {
-            assertEquals(expectedDocIDs.get(i), changes[i].getDocID());
-            assertEquals(expectedRevIDs.get(i), changes[i].getRevID());
-            assertEquals(expectedExternal, changes[i].isExternal());
+
+        int n = changes.size();
+        assertEquals(expectedDocIDs.size(), n);
+        for (int i = 0; i < n; i++) {
+            assertEquals(expectedDocIDs.get(i), changes.get(i).getDocID());
+            assertEquals(expectedRevIDs.get(i), changes.get(i).getRevID());
+            assertEquals(expectedExternal, changes.get(i).isExternal());
         }
     }
 }


### PR DESCRIPTION
A fix for the root cause of CBSE-15160.
Add tests to verify the above fix.
CBL-4992: Null revId is legal in document change
CBL-4988: Map LiteCore CHANGES domain to platform DATABASE domain