### PR TITLE
CBL-5038: HELIUM: Allow empty log domain list

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractConsoleLogger.java
+++ b/common/main/java/com/couchbase/lite/AbstractConsoleLogger.java
@@ -87,7 +87,7 @@ abstract class AbstractConsoleLogger implements Logger {
      */
     public void setDomains(@NonNull LogDomain... domains) {
         Preconditions.assertNotNull(domains, "domains");
-        setDomains(EnumSet.copyOf(Arrays.asList(domains)));
+        setDomains((domains.length <= 0) ? EnumSet.noneOf(LogDomain.class) : EnumSet.copyOf(Arrays.asList(domains)));
     }
 
     protected abstract void doLog(@NonNull LogLevel level, @NonNull LogDomain domain, @NonNull String message);


### PR DESCRIPTION
Small fix for silly oversight.

Will require new 3.1.3 releases for Java, Android and Kotlin