### PR TITLE
Support for Version Vectors

### DIFF
--- a/android/androidTest/java/com/couchbase/lite/PlatformBaseTest.java
+++ b/android/androidTest/java/com/couchbase/lite/PlatformBaseTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 
 import com.couchbase.lite.internal.AndroidExecutionService;
 import com.couchbase.lite.internal.CouchbaseLiteInternal;
+import com.couchbase.lite.internal.core.C4Database;
 import com.couchbase.lite.internal.exec.AbstractExecutionService;
 import com.couchbase.lite.internal.exec.ExecutionService;
 import com.couchbase.lite.internal.logging.Log;

--- a/common/main/cpp/com_couchbase_lite_internal_core_impl_NativeC4Document.h
+++ b/common/main/cpp/com_couchbase_lite_internal_core_impl_NativeC4Document.h
@@ -99,17 +99,6 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getSelectedSequence
         (JNIEnv *, jclass, jlong);
 
 /*
- * DEPRECATED: remove when version vectors are enabled
- *
- * Class:     com_couchbase_lite_internal_core_impl_NativeC4Document
- * Method:    getGenerationForId
- * Signature: (Ljava/lang/String;)J
- */
-JNIEXPORT jlong JNICALL
-Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getGenerationForId
-        (JNIEnv *, jclass, jstring);
-
-/*
  * Class:     com_couchbase_lite_internal_core_impl_NativeC4Document
  * Method:    getSelectedBody2
  * Signature: (J)J

--- a/common/main/cpp/native_c4document.cc
+++ b/common/main/cpp/native_c4document.cc
@@ -175,22 +175,6 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getSelectedSequence(
 }
 
 /*
- * DEPRECATED: remove when version vectors are enabled
- *
- * Class:     com_couchbase_lite_internal_core_impl_NativeC4Document
- * Method:    getGenerationForId
- * Signature: (Ljava/lang/String;)J
- */
-JNIEXPORT jlong JNICALL
-Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getGenerationForId(
-        JNIEnv *env,
-        jclass ignore,
-        jstring jrevId) {
-    jstringSlice revId(env, jrevId);
-    return c4rev_getGeneration(revId);
-}
-
-/*
  * Class:     com_couchbase_lite_internal_core_impl_NativeC4Document
  * Method:    getSelectedBody2
  * Signature: (J)J

--- a/common/main/java/com/couchbase/lite/ConflictResolver.java
+++ b/common/main/java/com/couchbase/lite/ConflictResolver.java
@@ -18,8 +18,6 @@ package com.couchbase.lite;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.couchbase.lite.internal.core.C4Database;
-
 
 /**
  * Custom conflict resolution strategies implement this interface.
@@ -58,19 +56,9 @@ class DefaultConflictResolver implements ConflictResolver {
         if ((localDoc == null) || (remoteDoc == null)) { return null; }
 
         // if one of the docs is newer, return it
-        if (C4Database.VERSION_VECTORS_ENABLED) {
-            final long localTimestamp = localDoc.getTimestamp();
-            final long remoteTimestamp = remoteDoc.getTimestamp();
-            if (localTimestamp > remoteTimestamp) { return localDoc; }
-            else if (localTimestamp < remoteTimestamp) { return remoteDoc; }
-        }
-        // remove when version vectors are enabled
-        else {
-            final long localGen = localDoc.generation();
-            final long remoteGen = remoteDoc.generation();
-            if (localGen > remoteGen) { return localDoc; }
-            else if (localGen < remoteGen) { return remoteDoc; }
-        }
+        final int cmp = localDoc.compareAge(remoteDoc);
+        if (cmp > 0) { return localDoc; }
+        else if (cmp < 0) { return remoteDoc; }
 
         // otherwise, choose one randomly, but deterministically.
         final String localRevId = localDoc.getRevisionID();

--- a/common/main/java/com/couchbase/lite/Document.java
+++ b/common/main/java/com/couchbase/lite/Document.java
@@ -201,7 +201,7 @@ public class Document implements DictionaryInterface, Iterable<String> {
      * The sequence number indicates how recently the document has been changed.  Every time a document
      * is updated, the database assigns it the next sequential sequence number.  Thus, when a document's
      * sequence number changes it means that the document been updated (on-disk).  If one document's sequence
-     * is different than another's, the document with the larger sequence number was changed more recently.
+     * is different from another's, the document with the larger sequence number was changed more recently.
      * Sequence numbers are not available for documents obtained from a replication filter.  This method
      * will always return 0 for such documents.
      *
@@ -239,7 +239,7 @@ public class Document implements DictionaryInterface, Iterable<String> {
     //---------------------------------------------
 
     /**
-     * Get an List containing all keys, or an empty List if the document has no properties.
+     * Get a List containing all keys, or an empty List if the document has no properties.
      *
      * @return all keys
      */
@@ -293,7 +293,7 @@ public class Document implements DictionaryInterface, Iterable<String> {
     public int getInt(@NonNull String key) { return getContent().getInt(key); }
 
     /**
-     * Gets a property's value as an long.
+     * Gets a property's value as a long.
      * Floating point values will be rounded. The value `true` is returned as 1, `false` as 0.
      * Returns 0 if the value doesn't exist or does not have a numeric value.
      *
@@ -304,7 +304,7 @@ public class Document implements DictionaryInterface, Iterable<String> {
     public long getLong(@NonNull String key) { return getContent().getLong(key); }
 
     /**
-     * Gets a property's value as an float.
+     * Gets a property's value as a float.
      * Integers will be converted to float. The value `true` is returned as 1.0, `false` as 0.0.
      * Returns 0.0 if the value doesn't exist or does not have a numeric value.
      *
@@ -315,7 +315,7 @@ public class Document implements DictionaryInterface, Iterable<String> {
     public float getFloat(@NonNull String key) { return getContent().getFloat(key); }
 
     /**
-     * Gets a property's value as an double.
+     * Gets a property's value as a double.
      * Integers will be converted to double. The value `true` is returned as 1.0, `false` as 0.0.
      * Returns 0.0 if the property doesn't exist or does not have a numeric value.
      *
@@ -362,8 +362,8 @@ public class Document implements DictionaryInterface, Iterable<String> {
     public Date getDate(@NonNull String key) { return getContent().getDate(key); }
 
     /**
-     * Get a property's value as a Array.
-     * Returns null if the property doesn't exists, or its value is not an Array.
+     * Get a property's value as an Array.
+     * Returns null if the property doesn't exist, or its value is not an Array.
      *
      * @param key the key
      * @return The Array object or null.
@@ -374,7 +374,7 @@ public class Document implements DictionaryInterface, Iterable<String> {
 
     /**
      * Get a property's value as a Dictionary.
-     * Returns null if the property doesn't exists, or its value is not a Dictionary.
+     * Returns null if the property doesn't exist, or its value is not a Dictionary.
      *
      * @param key the key
      * @return The Dictionary object or null.
@@ -384,7 +384,7 @@ public class Document implements DictionaryInterface, Iterable<String> {
     public Dictionary getDictionary(@NonNull String key) { return getContent().getDictionary(key); }
 
     /**
-     * Gets content of the current object as an Map. The values contained in the returned
+     * Gets content of the current object as a Map. The values contained in the returned
      * Map object are all JSON based values.
      *
      * @return the Map object representing the content of the current object in the JSON format.
@@ -506,15 +506,7 @@ public class Document implements DictionaryInterface, Iterable<String> {
 
     final boolean isMutable() { return mutable; }
 
-    // Remove when VersionVectors are enabled
-    @Deprecated
-    long generation() {
-        final String revId = getRevisionID();
-        if (revId == null) { return 0; }
-        final C4Document c4Doc = getC4doc();
-        if (c4Doc == null) { return 0; }
-        return c4Doc.getGeneration(revId);
-    }
+    int compareAge(@NonNull Document target) { return Long.compare(getTimestamp(), target.getTimestamp()); }
 
     final boolean isEmpty() { return getContent().isEmpty(); }
 
@@ -632,3 +624,4 @@ public class Document implements DictionaryInterface, Iterable<String> {
         root = newRoot;
     }
 }
+

--- a/common/main/java/com/couchbase/lite/MutableDocument.java
+++ b/common/main/java/com/couchbase/lite/MutableDocument.java
@@ -352,17 +352,8 @@ public final class MutableDocument extends Document implements MutableDictionary
     public String toJSON() { throw new IllegalStateException("Mutable objects may not be encoded as JSON"); }
 
     //---------------------------------------------
-    // Package level access
-    //---------------------------------------------
-
-    @Override
-    long generation() { return super.generation() + (isChanged() ? 1 : 0); }
-
-    //---------------------------------------------
     // Private access
     //---------------------------------------------
-
-    private boolean isChanged() { return getMutableContent().isChanged(); }
 
     @NonNull
     private MutableDictionary getMutableContent() { return (MutableDictionary) getContent(); }

--- a/common/main/java/com/couchbase/lite/internal/core/C4Document.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Document.java
@@ -67,10 +67,6 @@ public final class C4Document extends C4NativePeer {
         void nFree(long doc);
         //// Utility
         boolean nDictContainsBlobs(long dictPtr, long dictSize, long sk);
-
-        // remove when version vectors are enabled
-        @Deprecated
-        long nGetGenerationForId(@NonNull String doc);
     }
 
     @NonNull
@@ -178,10 +174,6 @@ public final class C4Document extends C4NativePeer {
         return value == 0 ? null : FLDict.create(value);
     }
 
-    // Remove when version vectors are enabled
-    @Deprecated
-    public long getGeneration(String id) { return impl.nGetGenerationForId(id); }
-
     // - Conflict resolution
 
     public long getTimestamp() { return withPeerOrDefault(-1L, impl::nGetTimestamp); }
@@ -285,7 +277,7 @@ public final class C4Document extends C4NativePeer {
     // This idiom, which you will see in many places in this code,
     // may protect against a failure that both customers and I have seen:
     // the ART runtime frees (and nulls) a member reference before freeing the
-    // object that refers to it it: impl may be null.
+    // object that refers to it: impl may be null.
     // If that happens, we are going to leak memory.  This idiom, though
     // may prevent an NPE on the finalizer thread.
     private void closePeer(@Nullable LogDomain domain) {

--- a/common/main/java/com/couchbase/lite/internal/core/impl/NativeC4Document.java
+++ b/common/main/java/com/couchbase/lite/internal/core/impl/NativeC4Document.java
@@ -107,11 +107,6 @@ public final class NativeC4Document implements C4Document.NativeImpl {
         return dictContainsBlobs(dictPtr, dictSize, sk);
     }
 
-    // Remove when Version Vectors are enabled
-    @Deprecated
-    @Override
-    public long nGetGenerationForId(@NonNull String doc) { return getGenerationForId(doc); }
-
     //-------------------------------------------------------------------------
     // native methods
     //-------------------------------------------------------------------------

--- a/common/test/java/com/couchbase/lite/DatabaseTest.kt
+++ b/common/test/java/com/couchbase/lite/DatabaseTest.kt
@@ -1818,7 +1818,7 @@ class DatabaseTest : BaseDbTest() {
         val doc1 = saveDocInTestCollection(mDoc)
         mDoc.setValue("age", 20)
         val doc2 = saveDocInTestCollection(mDoc)
-        assertEquals(2, doc2.generation());
+        assertEquals(1, doc2.compareAge(doc1))
         assertEquals(20, doc2.getInt("age"))
         assertEquals("Scott Tiger", doc2.getString("name"))
     }

--- a/common/test/java/com/couchbase/lite/internal/core/C4CollectionObserverTest.kt
+++ b/common/test/java/com/couchbase/lite/internal/core/C4CollectionObserverTest.kt
@@ -132,21 +132,4 @@ class C4CollectionObserverTest : C4BaseTest() {
             }
         }
     }
-
-    //helper method
-    private fun checkChanges(
-        observer: C4CollectionObserver,
-        expectedDocIds: List<String>,
-        expectedRevIds: List<String>,
-        external: Boolean,
-    ) {
-        val changes = observer.getChanges(100)
-        assertNotNull(changes!!)
-        assertEquals(expectedDocIds.size, changes.size)
-        for (i in changes.indices) {
-            assertEquals(expectedDocIds[i], changes[i].docID)
-            assertEquals(expectedRevIds[i], changes[i].revID)
-            assertEquals(external, changes[i].isExternal)
-        }
-    }
 }

--- a/common/test/java/com/couchbase/lite/internal/core/C4ObserverTest.java
+++ b/common/test/java/com/couchbase/lite/internal/core/C4ObserverTest.java
@@ -16,7 +16,6 @@
 package com.couchbase.lite.internal.core;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
@@ -43,10 +42,6 @@ public class C4ObserverTest extends C4BaseTest {
         }
     }
 
-    // - DB Observer
-    // This test will fail on LiteCore using Version Vectors
-    // C4DocumentChange.revId under VV contains not the latest version,
-    // but a semicolon separated list of versions
     @Test
     public void testCollectionObserver() throws LiteCoreException {
         C4CollectionObserver collObserver = null;
@@ -137,10 +132,6 @@ public class C4ObserverTest extends C4BaseTest {
         }
     }
 
-    // - Multi-DBObservers
-    // This test will fail on LiteCore using Version Vectors
-    // C4DocumentChange.revId under VV contains not the latest version,
-    // but a semicolon separated list of versions
     @Test
     public void testMultiDBObservers() throws LiteCoreException {
         C4CollectionObserver collObserver = null;
@@ -186,23 +177,6 @@ public class C4ObserverTest extends C4BaseTest {
         }
         finally {
             if (collObserver != null) { collObserver.close(); }
-        }
-    }
-
-    private void checkChanges(
-        C4CollectionObserver observer,
-        List<String> expectedDocIDs,
-        List<String> expectedRevIDs,
-        boolean expectedExternal) {
-        List<C4DocumentChange> changes = observer.getChanges(100);
-        assertNotNull(changes);
-
-        int n = changes.size();
-        assertEquals(expectedDocIDs.size(), n);
-        for (int i = 0; i < n; i++) {
-            assertEquals(expectedDocIDs.get(i), changes.get(i).getDocID());
-            assertEquals(expectedRevIDs.get(i), changes.get(i).getRevID());
-            assertEquals(expectedExternal, changes.get(i).isExternal());
         }
     }
 }

--- a/java/test/java/com/couchbase/lite/PlatformBaseTest.java
+++ b/java/test/java/com/couchbase/lite/PlatformBaseTest.java
@@ -34,6 +34,7 @@ import com.couchbase.lite.internal.logging.Log;
 import com.couchbase.lite.internal.utils.FileUtils;
 import com.couchbase.lite.internal.utils.Report;
 
+import com.couchbase.lite.internal.core.C4Database;
 
 /**
  * Platform test class for Java.


### PR DESCRIPTION
Remove C4Document.generation
The default ConflictResolver now depends on a document's timestamp instead of its generation
Fix tests that depended on generation to work with timestamps.
Fix grammar in some comments