### PR TITLE
CBL-5245: Add 'pending' property to executors

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/exec/ConcurrentExecutor.java
+++ b/common/main/java/com/couchbase/lite/internal/exec/ConcurrentExecutor.java
@@ -55,6 +55,13 @@ class ConcurrentExecutor implements ExecutionService.CloseableExecutor {
     }
 
     /**
+     * Get the number of tasks awaiting execution.
+     *
+     * @return the number of tasks awaiting execution.
+     */
+    public int getPending() { return executor.getQueue().size(); }
+
+    /**
      * Schedule a task for concurrent execution.
      * There are absolutely no guarantees about execution order, on this executor.
      *

--- a/common/main/java/com/couchbase/lite/internal/exec/ExecutionService.java
+++ b/common/main/java/com/couchbase/lite/internal/exec/ExecutionService.java
@@ -31,9 +31,12 @@ public interface ExecutionService {
      */
     interface CloseableExecutor extends Executor {
         class ExecutorClosedException extends RejectedExecutionException {
-            public ExecutorClosedException() {}
+            public ExecutorClosedException() { }
+
             public ExecutorClosedException(@Nullable String msg) { super(msg); }
+
             public ExecutorClosedException(@Nullable String msg, @Nullable Throwable err) { super(msg, err); }
+
             public ExecutorClosedException(@Nullable Throwable err) { super(err); }
         }
 
@@ -47,6 +50,13 @@ public interface ExecutionService {
          * @return true if all scheduled tasks have been completed
          */
         boolean stop(long timeout, @NonNull TimeUnit unit);
+
+        /**
+         * Get the number of tasks awaiting execution.
+         *
+         * @return the number of tasks awaiting execution.
+         */
+        int getPending();
     }
 
     /**

--- a/common/main/java/com/couchbase/lite/internal/exec/SerialExecutor.java
+++ b/common/main/java/com/couchbase/lite/internal/exec/SerialExecutor.java
@@ -20,8 +20,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.LinkedList;
-import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -48,7 +48,7 @@ class SerialExecutor implements ExecutionService.CloseableExecutor {
 
     @GuardedBy("this")
     @NonNull
-    private final Queue<InstrumentedTask> pendingTasks = new LinkedList<>();
+    private final Deque<InstrumentedTask> pendingTasks = new LinkedList<>();
 
     // a non-null stop latch is the flag that this executor has been stopped
     @GuardedBy("this")
@@ -58,6 +58,15 @@ class SerialExecutor implements ExecutionService.CloseableExecutor {
     SerialExecutor(@NonNull ThreadPoolExecutor executor) {
         Preconditions.assertNotNull(executor, "executor");
         this.executor = executor;
+    }
+
+    /**
+     * Get the number of tasks awaiting execution.
+     *
+     * @return the number of tasks awaiting execution.
+     */
+    public int getPending() {
+        synchronized (this) { return pendingTasks.size(); }
     }
 
     /**
@@ -127,7 +136,7 @@ class SerialExecutor implements ExecutionService.CloseableExecutor {
 
         if (executor instanceof CBLExecutor) { ((CBLExecutor) executor).dumpState(); }
 
-         AbstractExecutionService.dumpThreads();
+        AbstractExecutionService.dumpThreads();
     }
 
 

--- a/java/main/java/com/couchbase/lite/ConsoleLogger.java
+++ b/java/main/java/com/couchbase/lite/ConsoleLogger.java
@@ -53,6 +53,7 @@ public class ConsoleLogger extends AbstractConsoleLogger {
             + message;
     }
 
+
     ConsoleLogger(@Nullable C4Log c4Log) { super(c4Log); }
 
     @Override


### PR DESCRIPTION
Client code may wish to be able to decide not to queue additional tasks if too many tasks are already pending