### PR TITLE
CBL-5269: Make sure that QueryObs functions are called correctly

### DIFF
--- a/common/main/cpp/com_couchbase_lite_internal_core_impl_NativeC4QueryObserver.h
+++ b/common/main/cpp/com_couchbase_lite_internal_core_impl_NativeC4QueryObserver.h
@@ -21,15 +21,14 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4QueryObserver_create(
 
 /*
  * Class:     com_couchbase_lite_internal_core_NativeC4QueryObserver
- * Method:    setEnabled
- * Signature: (JZ)V
+ * Method:    enable
+ * Signature: (J)V
  */
 JNIEXPORT void JNICALL
-Java_com_couchbase_lite_internal_core_impl_NativeC4QueryObserver_setEnabled(
+Java_com_couchbase_lite_internal_core_impl_NativeC4QueryObserver_enable(
         JNIEnv *,
         jclass,
-        jlong,
-        jboolean);
+        jlong);
 
 /*
  * Class:     com_couchbase_lite_internal_core_NativeC4QueryObserver
@@ -41,17 +40,6 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4QueryObserver_free(
         JNIEnv *,
         jclass,
         jlong);
-
-/*
- * Class:     com_couchbase_lite_internal_core_NativeC4QueryObserver
- * Method:    getEnumerator
- * Signature: (JZ)J
- */
-JNIEXPORT jlong JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4QueryObserver_getEnumerator(
-        JNIEnv *,
-        jclass,
-        jlong,
-        jboolean);
 
 #ifdef __cplusplus
 }

--- a/common/main/java/com/couchbase/lite/AbstractQuery.java
+++ b/common/main/java/com/couchbase/lite/AbstractQuery.java
@@ -65,7 +65,7 @@ abstract class AbstractQuery implements Listenable<QueryChange, QueryChangeListe
         public void start(@NonNull ChangeListenerToken<QueryChange> token) {
             synchronized (liveQueries) {
                 final C4QueryObserver observer = liveQueries.get(token);
-                if (observer != null) { observer.setEnabled(true); }
+                if (observer != null) { observer.enable(); }
             }
         }
 

--- a/common/main/java/com/couchbase/lite/internal/core/impl/NativeC4QueryObserver.java
+++ b/common/main/java/com/couchbase/lite/internal/core/impl/NativeC4QueryObserver.java
@@ -10,7 +10,6 @@
 //
 package com.couchbase.lite.internal.core.impl;
 
-import com.couchbase.lite.LiteCoreException;
 import com.couchbase.lite.internal.core.C4QueryObserver;
 
 
@@ -20,12 +19,7 @@ public final class NativeC4QueryObserver implements C4QueryObserver.NativeImpl {
     public long nCreate(long token, long c4Query) { return create(token, c4Query); }
 
     @Override
-    public void nSetEnabled(long peer, boolean enabled) { setEnabled(peer, enabled); }
-
-    @Override
-    public long nGetEnumerator(long observer, boolean forget) throws LiteCoreException {
-        return getEnumerator(observer, forget);
-    }
+    public void nEnable(long peer) { enable(peer); }
 
     @Override
     public void nFree(long peer) { free(peer); }
@@ -36,9 +30,7 @@ public final class NativeC4QueryObserver implements C4QueryObserver.NativeImpl {
 
     private static native long create(long token, long c4Query);
 
-    private static native void setEnabled(long peer, boolean enabled);
-
-    private static native long getEnumerator(long peer, boolean forget) throws LiteCoreException;
+    private static native void enable(long peer);
 
     private static native void free(long peer);
 }

--- a/common/test/java/com/couchbase/lite/LoadTest.kt
+++ b/common/test/java/com/couchbase/lite/LoadTest.kt
@@ -39,7 +39,7 @@ class LoadTest : BaseDbTest() {
             "starqlteue" to 150,
             "dandelion_global" to 100,
             "cheetah" to 100,
-            "sunfish" to 75,
+            "sunfish" to 80,
             "taimen" to 55,
             "shamu" to 200,
             "hammerhead" to 150,

--- a/common/test/java/com/couchbase/lite/internal/core/C4TestUtils.java
+++ b/common/test/java/com/couchbase/lite/internal/core/C4TestUtils.java
@@ -18,7 +18,6 @@ package com.couchbase.lite.internal.core;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 
 import com.couchbase.lite.CBLError;


### PR DESCRIPTION
I removed that Java call to getEnumerator and am now passing results and any error in the callback.

Also added a call to enable(false) in the free method, to guarantee that only the thread-safe version gets called.