### PR TITLE
CBL-5280: Delete LocalRefs

### DIFF
--- a/android-ktx/main/kotlin/com/couchbase/lite/internal/ReplicatorWorker.kt
+++ b/android-ktx/main/kotlin/com/couchbase/lite/internal/ReplicatorWorker.kt
@@ -39,14 +39,15 @@ import kotlinx.coroutines.runBlocking
  *
  * Android does not support daemon processes. Although it is less likely to happen on modern phones
  * with lots of memory, Android will still kill off a running application if it needs the memory space
- * to run a new app. Under these circumstance, CouchbaseLite continuous replication makes sense only
+ * to run a new app. Under these circumstance, CouchbaseLite's continuous replication makes sense only
  * while an application is in the foreground. Once an application is put in the background, it will,
  * eventually, get killed and replicators will be stopped with prejudice. They will not be restarted
  * until a user manually restarts the app and the replication.
  *
  * In addition to this issue, continuous replication is incredibly wasteful of battery. It will force
  * a mobile device to keep its radio on: the second most expensive thing a device can do, battery-wise.
- * Android provides a facility managing long running processes: the `WorkManager`. Jobs scheduled
+ *
+ * Android provides a facility for managing long running processes: the `WorkManager`. Jobs scheduled
  * with the `WorkManager` are persistent. They are also batched across applications in order to
  * optimize radio use. This package integrates replication into the `WorkManage`. It works like this:
  * Client code schedules replication work using normal `WorkManager` code, like this:

--- a/common/main/cpp/com_couchbase_lite_internal_core_impl_NativeC4Listener.h
+++ b/common/main/cpp/com_couchbase_lite_internal_core_impl_NativeC4Listener.h
@@ -34,14 +34,6 @@ JNIEXPORT void JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4Listen
 
 /*
  * Class:     com_couchbase_lite_internal_core_impl_NativeC4Listener
- * Method:    shareDb
- * Signature: (JLjava/lang/String;J)V
- */
-JNIEXPORT void JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4Listener_shareDb
-  (JNIEnv *, jclass, jlong, jstring, jlong);
-
-/*
- * Class:     com_couchbase_lite_internal_core_impl_NativeC4Listener
  * Method:    shareCollection
  * Signature: (JLjava/lang/String;J[J)V
  */

--- a/common/main/cpp/native_c4.cc
+++ b/common/main/cpp/native_c4.cc
@@ -99,6 +99,7 @@ static void logCallback(C4LogDomain domain, C4LogLevel level, const char *fmt, v
 
     JNIEnv *env = nullptr;
     jint getEnvStat = gJVM->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6);
+
     if (getEnvStat == JNI_EDETACHED) {
         if (attachCurrentThread(&env) != 0) {
             logError("logCallback(): Failed to attach the current thread to a Java VM)");
@@ -124,8 +125,6 @@ static void logCallback(C4LogDomain domain, C4LogLevel level, const char *fmt, v
     jstring domainName = UTF8ToJstring(env, domainNameRaw, strlen(domainNameRaw));
     env->CallStaticVoidMethod(cls_C4Log, m_C4Log_logCallback, domainName, (jint) level, message);
 
-    // Because this method might run on a thread that was previously attached
-    // but was called from some long running method, we need to release the local refs.
     env->DeleteLocalRef(message);
     if (domainName)
         env->DeleteLocalRef(domainName);

--- a/common/main/cpp/native_c4listener.cc
+++ b/common/main/cpp/native_c4listener.cc
@@ -241,10 +241,8 @@ static bool doSignCallback(JNIEnv *env, void *extKey, C4SignatureDigestAlgorithm
         return false;
 
     jsize sigSize = env->GetArrayLength(sig);
-    if (sigSize > 16384) {// !!! We need a real size limit here!!
-        env->DeleteLocalRef(sig);
-        return false;
-    }
+    // The signature is the same size as the key.
+    // This check happens in Java
 
     jbyte *sigData = env->GetByteArrayElements(sig, nullptr);
     memcpy(outSig, sigData, sigSize);

--- a/common/main/cpp/native_c4socket.cc
+++ b/common/main/cpp/native_c4socket.cc
@@ -77,19 +77,31 @@ bool litecore::jni::initC4Socket(JNIEnv *env) {
 // ----------------------------------------------------------------------------
 // C4SocketFactory implementation
 // ----------------------------------------------------------------------------
+
 static void socket_open(C4Socket *socket, const C4Address *addr, C4Slice options, void *token) {
     JNIEnv *env = nullptr;
     jint getEnvStat = gJVM->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6);
+
     if (getEnvStat == JNI_OK) {
+        jstring _scheme = toJString(env, addr->scheme);
+        jstring _host = toJString(env, addr->hostname);
+        jstring _path = toJString(env, addr->path);
+        jbyteArray _options = toJByteArray(env, options);
+
         env->CallStaticVoidMethod(cls_C4Socket,
                                   m_C4Socket_open,
                                   (jlong) socket,
                                   (jlong) token,
-                                  toJString(env, addr->scheme),
-                                  toJString(env, addr->hostname),
+                                  _scheme,
+                                  _host,
                                   addr->port,
-                                  toJString(env, addr->path),
-                                  toJByteArray(env, options));
+                                  _path,
+                                  _options);
+
+        env->DeleteLocalRef(_scheme);
+        env->DeleteLocalRef(_host);
+        env->DeleteLocalRef(_path);
+        env->DeleteLocalRef(_options);
     } else if (getEnvStat == JNI_EDETACHED) {
         if (attachCurrentThread(&env) == 0) {
             env->CallStaticVoidMethod(cls_C4Socket,
@@ -101,6 +113,7 @@ static void socket_open(C4Socket *socket, const C4Address *addr, C4Slice options
                                       addr->port,
                                       toJString(env, addr->path),
                                       toJByteArray(env, options));
+
             if (gJVM->DetachCurrentThread() != 0) {
                 C4Warn("socket_open(): Failed to detach the current thread from a Java VM");
             }
@@ -112,20 +125,22 @@ static void socket_open(C4Socket *socket, const C4Address *addr, C4Slice options
     }
 }
 
+static void do_socket_write(JNIEnv *env, C4Socket *socket, C4SliceResult data) {
+    jbyteArray _data = toJByteArray(env, data);
+    c4slice_free(data);
+    env->CallStaticVoidMethod(cls_C4Socket, m_C4Socket_write, (jlong) socket, _data);
+    env->DeleteLocalRef(_data);
+}
+
 static void socket_write(C4Socket *socket, C4SliceResult allocatedData) {
     JNIEnv *env = nullptr;
     jint getEnvStat = gJVM->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6);
+
     if (getEnvStat == JNI_OK) {
-        env->CallStaticVoidMethod(cls_C4Socket,
-                                  m_C4Socket_write,
-                                  (jlong) socket,
-                                  toJByteArray(env, allocatedData));
+        do_socket_write(env, socket, allocatedData);
     } else if (getEnvStat == JNI_EDETACHED) {
         if (attachCurrentThread(&env) == 0) {
-            env->CallStaticVoidMethod(cls_C4Socket,
-                                      m_C4Socket_write,
-                                      (jlong) socket,
-                                      toJByteArray(env, allocatedData));
+            do_socket_write(env, socket, allocatedData);
             if (gJVM->DetachCurrentThread() != 0) {
                 C4Warn("socket_write(): Failed to detach the current thread from a Java VM");
             }
@@ -135,23 +150,17 @@ static void socket_write(C4Socket *socket, C4SliceResult allocatedData) {
     } else {
         C4Warn("socket_write(): Failed to get the environment: getEnvStat -> %d", getEnvStat);
     }
-    c4slice_free(allocatedData);
 }
 
 static void socket_completedReceive(C4Socket *socket, size_t byteCount) {
     JNIEnv *env = nullptr;
     jint getEnvStat = gJVM->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6);
+
     if (getEnvStat == JNI_OK) {
-        env->CallStaticVoidMethod(cls_C4Socket,
-                                  m_C4Socket_completedReceive,
-                                  (jlong) socket,
-                                  (jlong) byteCount);
+        env->CallStaticVoidMethod(cls_C4Socket, m_C4Socket_completedReceive, (jlong) socket, (jlong) byteCount);
     } else if (getEnvStat == JNI_EDETACHED) {
         if (attachCurrentThread(&env) == 0) {
-            env->CallStaticVoidMethod(cls_C4Socket,
-                                      m_C4Socket_completedReceive,
-                                      (jlong) socket,
-                                      (jlong) byteCount);
+            env->CallStaticVoidMethod(cls_C4Socket, m_C4Socket_completedReceive, (jlong) socket, (jlong) byteCount);
             if (gJVM->DetachCurrentThread() != 0) {
                 C4Warn("socket_completedReceive(): Failed to detach the current thread from a Java VM");
             }
@@ -159,27 +168,25 @@ static void socket_completedReceive(C4Socket *socket, size_t byteCount) {
             C4Warn("socket_completedReceive(): Failed to attaches the current thread to a Java VM");
         }
     } else {
-        C4Warn("socket_completedReceive(): Failed to get the environment: getEnvStat -> %d",
-               getEnvStat);
+        C4Warn("socket_completedReceive(): Failed to get the environment: getEnvStat -> %d", getEnvStat);
     }
+}
+
+static void do_socket_requestClose(JNIEnv *env, C4Socket *socket, int status, C4String message) {
+    jstring _message = toJString(env, message);
+    env->CallStaticVoidMethod(cls_C4Socket, m_C4Socket_requestClose, (jlong) socket, (jint) status, _message);
+    env->DeleteLocalRef(_message);
 }
 
 static void socket_requestClose(C4Socket *socket, int status, C4String messageSlice) {
     JNIEnv *env = nullptr;
     jint getEnvStat = gJVM->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6);
+
     if (getEnvStat == JNI_OK) {
-        env->CallStaticVoidMethod(cls_C4Socket,
-                                  m_C4Socket_requestClose,
-                                  (jlong) socket,
-                                  (jint) status,
-                                  toJString(env, messageSlice));
+        do_socket_requestClose(env, socket, status, messageSlice);
     } else if (getEnvStat == JNI_EDETACHED) {
         if (attachCurrentThread(&env) == 0) {
-            env->CallStaticVoidMethod(cls_C4Socket,
-                                      m_C4Socket_requestClose,
-                                      (jlong) socket,
-                                      (jint) status,
-                                      toJString(env, messageSlice));
+            do_socket_requestClose(env, socket, status, messageSlice);
             if (gJVM->DetachCurrentThread() != 0) {
                 C4Warn("socket_requestClose(): Failed to detach the current thread from a Java VM");
             }
@@ -194,6 +201,7 @@ static void socket_requestClose(C4Socket *socket, int status, C4String messageSl
 static void socket_close(C4Socket *socket) {
     JNIEnv *env = nullptr;
     jint getEnvStat = gJVM->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6);
+
     if (getEnvStat == JNI_OK) {
         env->CallStaticVoidMethod(cls_C4Socket, m_C4Socket_close, (jlong) socket);
     } else if (getEnvStat == JNI_EDETACHED) {

--- a/common/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/common/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -87,11 +87,11 @@ abstract class AbstractDatabase extends BaseDatabase
     //---------------------------------------------
     private static final String ERROR_RESOLVER_FAILED = "Conflict resolution failed for document '%s': %s";
     private static final String WARN_WRONG_ID
-        = "A conflict resolution for document for document '%s' produced a new document whose id not match"
-        + " the ID of the conflicting documents (%s)";
+        = "Conflict resolution for a document produced a new document with ID '%s', "
+        + "which does not match the IDs of the conflicting documents (%s)";
     private static final String WARN_WRONG_COLLECTION
-        = "A conflict resolution for document '%s' produced a new document that belongs to collection '%s',"
-        + " which is not the one in which it would be stored (%s)";
+        = "Conflict resolution for document '%s' produced a new document belonging to collection '%s', "
+        + "not the collection into which it would be stored (%s)";
 
     private static final LogDomain DOMAIN = LogDomain.DATABASE;
 

--- a/common/main/java/com/couchbase/lite/AbstractReplicator.java
+++ b/common/main/java/com/couchbase/lite/AbstractReplicator.java
@@ -428,7 +428,7 @@ public abstract class AbstractReplicator extends BaseReplicator
         }
 
         // there is the potential for a race here...
-        super.close();
+        closeC4Replicator();
 
         if ((listeners == null) || listeners.isEmpty()) { return; }
 

--- a/common/main/java/com/couchbase/lite/internal/core/C4BlobStore.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4BlobStore.java
@@ -112,7 +112,8 @@ public class C4BlobStore extends C4NativePeer {
      */
     @NonNull
     public FLSliceResult getContents(@NonNull C4BlobKey blobKey) throws LiteCoreException {
-        return withPeerOrThrow(peer -> impl.nGetContents(peer, blobKey.getHandle()));
+        return this.<FLSliceResult, LiteCoreException>withPeerOrThrow(peer ->
+            impl.nGetContents(peer, blobKey.getHandle()));
     }
 
     /**
@@ -149,7 +150,9 @@ public class C4BlobStore extends C4NativePeer {
      */
     @NonNull
     public C4BlobReadStream openReadStream(@NonNull C4BlobKey blobKey) throws LiteCoreException {
-        return new C4BlobReadStream(impl, withPeerOrThrow(peer -> impl.nOpenReadStream(peer, blobKey.getHandle())));
+        return new C4BlobReadStream(
+            impl,
+            this.<Long, LiteCoreException>withPeerOrThrow(peer -> impl.nOpenReadStream(peer, blobKey.getHandle())));
     }
 
     /**

--- a/common/main/java/com/couchbase/lite/internal/core/C4BlobWriteStream.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4BlobWriteStream.java
@@ -74,7 +74,7 @@ public class C4BlobWriteStream extends C4NativePeer {
      */
     @NonNull
     public C4BlobKey computeBlobKey() throws LiteCoreException {
-        return C4BlobKey.create(this.<Long, LiteCoreException>withPeerOrThrow(impl::nComputeBlobKey));
+        return C4BlobKey.create(withPeerOrThrow(impl::nComputeBlobKey));
     }
 
     /**

--- a/common/main/java/com/couchbase/lite/internal/core/C4Collection.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Collection.java
@@ -197,13 +197,15 @@ public final class C4Collection extends C4NativePeer {
 
     @NonNull
     public C4CollectionObserver createCollectionObserver(@NonNull Runnable listener) throws LiteCoreException {
-        return withPeerOrThrow(peer -> C4CollectionObserver.newObserver(peer, listener));
+        return this.<C4CollectionObserver, LiteCoreException>withPeerOrThrow(peer ->
+            C4CollectionObserver.newObserver(peer, listener));
     }
 
     @NonNull
     public C4DocumentObserver createDocumentObserver(@NonNull String docID, @NonNull Runnable listener)
         throws LiteCoreException {
-        return withPeerOrThrow(peer -> C4CollectionDocObserver.newObserver(peer, docID, listener));
+        return this.<C4DocumentObserver, LiteCoreException>withPeerOrThrow(peer ->
+            C4CollectionDocObserver.newObserver(peer, docID, listener));
     }
 
     // - Indexes

--- a/common/main/java/com/couchbase/lite/internal/core/C4CollectionObserver.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4CollectionObserver.java
@@ -110,7 +110,8 @@ public final class C4CollectionObserver
     @Override
     @Nullable
     public List<C4DocumentChange> getChanges(int maxChanges) {
-        final C4DocumentChange[] changes = withPeerOrThrow((peer) -> impl.nGetChanges(peer, maxChanges));
+        final C4DocumentChange[] changes = this.<C4DocumentChange[], RuntimeException>withPeerOrThrow(peer ->
+            impl.nGetChanges(peer, maxChanges));
         return (changes.length <= 0) ? null : Arrays.asList(changes);
     }
 

--- a/common/main/java/com/couchbase/lite/internal/core/C4Document.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Document.java
@@ -179,12 +179,16 @@ public final class C4Document extends C4NativePeer {
     public long getTimestamp() { return withPeerOrDefault(-1L, impl::nGetTimestamp); }
 
     public void selectNextLeafRevision(boolean includeDeleted, boolean withBody) throws LiteCoreException {
-        impl.nSelectNextLeafRevision(getPeer(), includeDeleted, withBody);
+        this.<LiteCoreException>withPeerOrThrow(peer ->
+            impl.nSelectNextLeafRevision(peer, includeDeleted, withBody)
+        );
     }
 
     public void resolveConflict(String winningRevID, String losingRevID, byte[] mergeBody, int mergedFlags)
         throws LiteCoreException {
-        impl.nResolveConflict(getPeer(), winningRevID, losingRevID, mergeBody, mergedFlags);
+        this.<LiteCoreException>withPeerOrThrow(peer ->
+            impl.nResolveConflict(peer, winningRevID, losingRevID, mergeBody, mergedFlags)
+        );
     }
 
     @Nullable
@@ -199,7 +203,9 @@ public final class C4Document extends C4NativePeer {
         return (newDoc == 0) ? null : new C4Document(impl, newDoc);
     }
 
-    public void save(int maxRevTreeDepth) throws LiteCoreException { impl.nSave(getPeer(), maxRevTreeDepth); }
+    public void save(int maxRevTreeDepth) throws LiteCoreException {
+        this.<LiteCoreException>withPeerOrThrow(peer -> impl.nSave(peer, maxRevTreeDepth));
+    }
 
     // - Fleece
 

--- a/common/main/java/com/couchbase/lite/internal/core/C4NativePeer.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4NativePeer.java
@@ -134,6 +134,18 @@ public abstract class C4NativePeer implements AutoCloseable {
         return def;
     }
 
+    protected final <E extends Exception> void withPeerOrThrow(@NonNull Fn.ConsumerThrows<Long, E> fn) throws E {
+        synchronized (getPeerLock()) {
+            if (open) {
+                fn.accept(this.peer);
+                return;
+            }
+        }
+
+        logBadCall();
+        throw new IllegalStateException("Closed peer");
+    }
+
     @NonNull
     protected final <R, E extends Exception> R withPeerOrThrow(@NonNull Fn.FunctionThrows<Long, R, E> fn) throws E {
         synchronized (getPeerLock()) {

--- a/common/main/java/com/couchbase/lite/internal/core/C4Replicator.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Replicator.java
@@ -16,7 +16,6 @@
 
 package com.couchbase.lite.internal.core;
 
-import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -646,9 +645,8 @@ public abstract class C4Replicator extends C4NativePeer {
 
     public void stop() { withPeer(impl::nStop); }
 
-    @CallSuper
     @Override
-    public void close() {
+    public final void close() {
         for (ReplicationCollection coll: colls) { coll.close(); }
         closePeer(null);
     }

--- a/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
+++ b/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
@@ -405,7 +405,7 @@ public abstract class AbstractCBLWebSocket implements SocketFromCore, SocketFrom
     @Override
     public final void coreWrites(@NonNull byte[] data) {
         final int len = data.length;
-        Log.d(LOG_DOMAIN, "%s.coreWrites(%d)", this, len);
+        Log.d(LOG_DOMAIN, "%s.coreWrites: %d", this, len);
         if (!assertState(SocketState.OPEN, SocketState.CLOSING)) { return; }
         if (toRemote.writeToRemote(data)) {
             toCore.ackWriteToCore(len);
@@ -421,7 +421,7 @@ public abstract class AbstractCBLWebSocket implements SocketFromCore, SocketFrom
     // Core wants to break the connection
     @Override
     public final void coreRequestsClose(@NonNull CloseStatus status) {
-        Log.d(LOG_DOMAIN, "%s.coreRequestsClose%s", this, status);
+        Log.d(LOG_DOMAIN, "%s.coreRequestsClose: %s", this, status);
 
         if (!assertState(SocketState.OPEN, SocketState.CLOSING)) { return; }
 
@@ -494,7 +494,7 @@ public abstract class AbstractCBLWebSocket implements SocketFromCore, SocketFrom
 
     @Override
     public void remoteWrites(@NonNull byte[] data) {
-        Log.d(LOG_DOMAIN, "%s.remoteWrites(%d)", this, data.length);
+        Log.d(LOG_DOMAIN, "%s.remoteWrites: %d", this, data.length);
         if (!assertState(SocketState.OPEN, SocketState.CLOSING)) { return; }
         toCore.writeToCore(data);
     }

--- a/common/main/java/com/couchbase/lite/internal/replicator/BaseReplicator.java
+++ b/common/main/java/com/couchbase/lite/internal/replicator/BaseReplicator.java
@@ -36,15 +36,7 @@ public abstract class BaseReplicator implements AutoCloseable {
 
     protected BaseReplicator() { }
 
-    @Override
-    public void close() { setC4ReplicatorInternal(null); }
-
-    @Nullable
-    public C4Replicator getC4Replicator() {
-        synchronized (getReplicatorLock()) { return c4Replicator; }
-    }
-
-    protected void setC4Replicator(@NonNull C4Replicator newC4Repl) {
+    protected final void setC4Replicator(@NonNull C4Replicator newC4Repl) {
         Log.d(
             LogDomain.REPLICATOR,
             "Setting c4 replicator %s for replicator %s",
@@ -52,8 +44,15 @@ public abstract class BaseReplicator implements AutoCloseable {
         setC4ReplicatorInternal(newC4Repl);
     }
 
+    @Nullable
+    protected final C4Replicator getC4Replicator() {
+        synchronized (getReplicatorLock()) { return c4Replicator; }
+    }
+
+    protected final void closeC4Replicator() { setC4ReplicatorInternal(null); }
+
     @NonNull
-    protected Object getReplicatorLock() { return lock; }
+    protected final Object getReplicatorLock() { return lock; }
 
     private void setC4ReplicatorInternal(@Nullable C4Replicator newC4Repl) {
         final C4Replicator oldC4Repl;

--- a/common/test/java/com/couchbase/lite/DocumentTest.java
+++ b/common/test/java/com/couchbase/lite/DocumentTest.java
@@ -2785,7 +2785,7 @@ public class DocumentTest extends BaseDbTest {
         try {
             if (validator != null) { validator.accept(mDoc); }
             Document doc = saveDocInCollection(mDoc, getTestCollection());
-            if (validator != null) { validator.accept(mDoc); }
+            if (validator != null) { validator.accept(doc); }
             return doc;
         }
         catch (Exception e) {


### PR DESCRIPTION
There are several small changes here:
- Fix test bug (found by Jeff Lockhart)
- Improved handling of Replicator.close()
- a new version of C4NativePeer that is void
- test WorkManagerReplicator with the new UniqueWork facility

The big thing, though, is CBL-5280.  There are two conditions under which a JNI LocalRef is released.  The most common one is when a thread returns to the JVM from a call to a native function.  The functions use by LiteCore to call back into Java code *NEVER* do that.  Because they never do it, the LocalRefs are never released.  Apparently, most of callbacks have been made by LiteCore threads which are attached before the callback and then detached after the callback. Fortunately, the second condition under which LocalRefs are released is when a thread is detached.

This change addresses the threads that are not detached, and releases other LocalRefs as soon as they are irrelevant.