### PR TITLE
Iterator concurrent modification tests

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/core/C4QueryObserver.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4QueryObserver.java
@@ -55,7 +55,7 @@ public class C4QueryObserver extends C4NativePeer {
     }
 
     @NonNull
-    public static C4QueryObserver create(
+    static C4QueryObserver create(
         @NonNull C4QueryObserver.NativeImpl impl,
         @NonNull Fn.Function<Long, C4QueryEnumerator> queryEnumeratorFactory,
         @NonNull C4Query query,

--- a/common/test/java/com/couchbase/lite/ArrayTest.java
+++ b/common/test/java/com/couchbase/lite/ArrayTest.java
@@ -42,6 +42,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 
+// Tests for the Array Iterator tests are in IteratorTest
 @SuppressWarnings({"ConstantConditions", "SameParameterValue"})
 public class ArrayTest extends BaseDbTest {
 
@@ -548,7 +549,6 @@ public class ArrayTest extends BaseDbTest {
         }
     }
 
-    // ??? Fails on Nexus 4
     @Test
     public void testGetNumber() {
         for (int i = 0; i < 2; i++) {
@@ -1011,46 +1011,6 @@ public class ArrayTest extends BaseDbTest {
             }
             assertEquals(c.toString(), r.toString());
         });
-    }
-
-    @Test
-    public void testArrayEnumerationWithDataModification1() {
-        final MutableArray array = new MutableArray();
-        for (int i = 0; i <= 2; i++) { array.addValue(i); }
-
-        assertEquals(3, array.count());
-        assertArrayEquals(new Object[] {0, 1, 2}, array.toList().toArray());
-
-        assertThrows(
-            ConcurrentModificationException.class,
-            () -> {
-                int n = 0;
-                for (Iterator<Object> itr = array.iterator(); itr.hasNext(); itr.next()) {
-                    if (n++ == 1) { array.addValue(3); }
-                }
-            });
-    }
-
-    @Test
-    public void testArrayEnumerationWithDataModification2() {
-        final MutableArray array = new MutableArray();
-        for (int i = 0; i <= 2; i++) { array.addValue(i); }
-
-        assertEquals(3, array.count());
-        assertArrayEquals(new Object[] {0, 1, 2}, array.toList().toArray());
-
-        MutableDocument doc = new MutableDocument("doc1").setValue("array", array);
-        final MutableArray savedArray = saveDocInTestCollection(doc).toMutable().getArray("array");
-        assertNotNull(savedArray);
-
-        assertThrows(
-            ConcurrentModificationException.class,
-            () -> {
-                int n = 0;
-                for (Iterator<Object> itr = savedArray.iterator(); itr.hasNext(); itr.next()) {
-                    if (n++ == 1) { savedArray.addValue(3); }
-                }
-            });
     }
 
     @Test

--- a/common/test/java/com/couchbase/lite/DictionaryTest.java
+++ b/common/test/java/com/couchbase/lite/DictionaryTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 
+// Tests for the Dictionary Iterator tests are in IteratorTest
 @SuppressWarnings("ConstantConditions")
 public class DictionaryTest extends BaseDbTest {
     @Test
@@ -338,39 +339,6 @@ public class DictionaryTest extends BaseDbTest {
         }
         assertEquals(finalContent.size(), count);
         assertEquals(finalContent, result);
-    }
-
-    @Test
-    public void testDictionaryEnumerationWithDataModification1() {
-        MutableDictionary dict = new MutableDictionary();
-        for (int i = 0; i <= 2; i++) { dict.setValue("key-" + i, i); }
-
-        assertEquals(3, dict.count());
-
-        assertThrows(ConcurrentModificationException.class, () -> {
-            int n = 0;
-            for (Iterator<String> itr = dict.iterator(); itr.hasNext(); itr.next()) {
-                if (n++ == 1) { dict.setValue("key-3", 3); }
-            }
-        });
-    }
-
-    @Test
-    public void testDictionaryEnumerationWithDataModification2() {
-        MutableDictionary dict = new MutableDictionary();
-        for (int i = 0; i <= 2; i++) { dict.setValue("key-" + i, i); }
-
-        assertEquals(3, dict.count());
-
-        MutableDocument doc = new MutableDocument("doc1").setValue("dict", dict);
-        final MutableDictionary savedDict = saveDocInTestCollection(doc).toMutable().getDictionary("dict");
-
-        assertThrows(ConcurrentModificationException.class, () -> {
-            int n = 0;
-            for (Iterator<String> itr = savedDict.iterator(); itr.hasNext(); itr.next()) {
-                if (n++ == 1) { savedDict.setValue("key-3", 3); }
-            }
-        });
     }
 
     // https://github.com/couchbase/couchbase-lite-core/issues/230

--- a/common/test/java/com/couchbase/lite/DocumentTest.java
+++ b/common/test/java/com/couchbase/lite/DocumentTest.java
@@ -51,7 +51,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-
+// Tests for the Document Iterator tests are in IteratorTest
 @SuppressWarnings("ConstantConditions")
 public class DocumentTest extends BaseDbTest {
     @FunctionalInterface

--- a/common/test/java/com/couchbase/lite/IteratorTest.kt
+++ b/common/test/java/com/couchbase/lite/IteratorTest.kt
@@ -1,0 +1,872 @@
+//
+// Copyright (c) 2024 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package com.couchbase.lite
+
+import org.junit.Assert.assertNotNull
+import org.junit.Ignore
+import org.junit.Test
+
+class IteratorTest : BaseDbTest() {
+
+    ///// Array Iterator Tests
+
+    @Test
+    fun testConcurrentModOfMutableArrayIterator() {
+        val array = MutableArray()
+        (0..5).forEach { array.addValue(it) }
+
+        var n = 0
+        val itr = array.iterator()
+        assertThrows(ConcurrentModificationException::class.java) {
+            while (itr.hasNext()) {
+                if (n++ == 3) {
+                    array.addValue(10)
+                }
+                itr.next()
+            }
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfSavedArrayIterator() {
+        val array = MutableArray()
+        (0..5).forEach { array.addValue(it) }
+
+        val sa = saveDocInCollection(MutableDocument().setValue("array", array)).getArray("array")
+        assertNotNull(sa)
+        val savedArray = sa!!.toMutable()
+
+        var n = 0
+        val itr = savedArray.iterator()
+        assertThrows(ConcurrentModificationException::class.java) {
+            while (itr.hasNext()) {
+                if (n++ == 3) {
+                    savedArray.addValue(10)
+                }
+                itr.next()
+            }
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfMutatedSavedArrayIterator() {
+        val array = MutableArray()
+        (0..5).forEach { array.addValue(it) }
+
+        val sa = saveDocInCollection(MutableDocument().setValue("array", array)).getArray("array")
+        assertNotNull(sa)
+        val savedArray = sa!!.toMutable()
+
+        savedArray.addValue(9)
+
+        var n = 0
+        val itr = savedArray.iterator()
+        assertThrows(ConcurrentModificationException::class.java) {
+            while (itr.hasNext()) {
+                if (n++ == 3) {
+                    savedArray.addValue(10)
+                }
+                itr.next()
+            }
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfArrayIteratorArrayMember() {
+        val subArray = MutableArray()
+        val array = MutableArray().addValue(subArray)
+        (1..5).forEach { array.addValue(it) }
+
+        var n = 0
+        val itr = array.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                subArray.addValue(10)
+            }
+            itr.next()
+        }
+    }
+
+    @Ignore("Bug: Inconsistent implementation")
+    @Test
+    fun testConcurrentModOfSavedArrayIteratorArrayMember1() {
+        val array = MutableArray().addValue(MutableArray())
+        (1..5).forEach { array.addValue(it) }
+
+        val sa = saveDocInCollection(MutableDocument().setValue("array", array)).getArray("array")
+        assertNotNull(sa)
+        val savedArray = sa!!.toMutable()
+
+        val ssa = savedArray.getArray(0)
+        assertNotNull(ssa)
+        val savedSubArray = ssa!!
+
+        var n = 0
+        val itr = savedArray.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubArray.addValue(10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfSavedArrayIteratorArrayMember2() {
+        val array = MutableArray().addValue(MutableArray())
+        (1..5).forEach { array.addValue(it) }
+
+        val sa = saveDocInCollection(MutableDocument().setValue("array", array)).getArray("array")
+        assertNotNull(sa)
+        val savedArray = sa!!
+
+        val ssa = savedArray.getArray(0)
+        assertNotNull(ssa)
+        val savedSubArray = ssa!!.toMutable()
+
+        var n = 0
+        val itr = savedArray.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubArray.addValue(1)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfMutatedSavedArrayIteratorArrayMember1() {
+        val array = MutableArray().addValue(MutableArray())
+        (1..5).forEach { array.addValue(it) }
+
+        val sa = saveDocInCollection(MutableDocument().setValue("array", array)).getArray("array")
+        assertNotNull(sa)
+        val savedArray = sa!!.toMutable()
+
+        val ssa = savedArray.getArray(0)
+        assertNotNull(ssa)
+        val savedSubArray = ssa!!
+
+        savedSubArray.addValue(9)
+
+        var n = 0
+        val itr = savedArray.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubArray.addValue(10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfMutatedSavedArrayIteratorArrayMember2() {
+        val array = MutableArray().addValue(MutableArray())
+        (1..5).forEach { array.addValue(it) }
+
+        val sa = saveDocInCollection(MutableDocument().setValue("array", array)).getArray("array")
+        assertNotNull(sa)
+        val savedArray = sa!!
+
+        val ssa = savedArray.getArray(0)
+        assertNotNull(ssa)
+        val savedSubArray = ssa!!.toMutable()
+
+        savedSubArray.addValue(9)
+
+        var n = 0
+        val itr = savedArray.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubArray.addValue(10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfArrayIteratorDictMember() {
+        val subDict = MutableDictionary()
+        val array = MutableArray().addValue(subDict)
+        (1..5).forEach { array.addValue(it) }
+
+        var n = 0
+        val itr = array.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                subDict.setValue("10", 10)
+            }
+            itr.next()
+        }
+    }
+
+    @Ignore("Bug: Inconsistent implementation")
+    @Test
+    fun testConcurrentModOfSavedArrayIteratorDictMember1() {
+        val array = MutableArray().addValue(MutableDictionary())
+        (1..5).forEach { array.addValue(it) }
+
+        val sa = saveDocInCollection(MutableDocument().setValue("array", array)).getArray("array")
+        assertNotNull(sa)
+        val savedArray = sa!!.toMutable()
+
+        val ssd = savedArray.getDictionary(0)
+        assertNotNull(ssd)
+        val savedSubDict = ssd!!
+
+        var n = 0
+        val itr = savedArray.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubDict.setValue("10", 10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfSavedArrayIteratorDictMember2() {
+        val array = MutableArray().addValue(MutableDictionary())
+        (1..5).forEach { array.addValue(it) }
+
+        val sa = saveDocInCollection(MutableDocument().setValue("array", array)).getArray("array")
+        assertNotNull(sa)
+        val savedArray = sa!!
+
+        val ssd = savedArray.getDictionary(0)
+        assertNotNull(ssd)
+        val savedSubDict = ssd!!.toMutable()
+
+        var n = 0
+        val itr = savedArray.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubDict.setValue("10", 10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfMutatedSavedArrayIteratorDictMember1() {
+        val array = MutableArray().addValue(MutableDictionary())
+        (1..5).forEach { array.addValue(it) }
+
+        val sa = saveDocInCollection(MutableDocument().setValue("array", array)).getArray("array")
+        assertNotNull(sa)
+        val savedArray = sa!!.toMutable()
+
+        val ssd = savedArray.getDictionary(0)
+        assertNotNull(ssd)
+        val savedSubDict = ssd!!
+
+        savedSubDict.setValue("9", 9)
+
+        var n = 0
+        val itr = savedArray.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubDict.setValue("10", 10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfMutatedSavedArrayIteratorDictMember2() {
+        val array = MutableArray().addValue(MutableDictionary())
+        (1..5).forEach { array.addValue(it) }
+
+        val sa = saveDocInCollection(MutableDocument().setValue("array", array)).getArray("array")
+        assertNotNull(sa)
+        val savedArray = sa!!
+
+        val ssd = savedArray.getDictionary(0)
+        assertNotNull(ssd)
+        val savedSubDict = ssd!!.toMutable()
+
+        savedSubDict.setValue("9", 9)
+
+        var n = 0
+        val itr = savedArray.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubDict.setValue("10", 10)
+            }
+            itr.next()
+        }
+    }
+
+    ///// Dictionary Iterator Tests
+
+    @Test
+    fun testConcurrentModOfMutableDictionaryIterator() {
+        val dict = MutableDictionary()
+        (0..5).forEach { dict.setValue("${it}", it) }
+
+        var n = 0
+        val itr = dict.iterator()
+        assertThrows(ConcurrentModificationException::class.java) {
+            while (itr.hasNext()) {
+                if (n++ == 3) {
+                    dict.setValue("10", 10)
+                }
+                itr.next()
+            }
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfSavedDictionaryIterator() {
+        val dict = MutableDictionary()
+        (0..5).forEach { dict.setValue("${it}", it) }
+
+        val sd = saveDocInCollection(MutableDocument().setValue("dict", dict)).getDictionary("dict")
+        assertNotNull(sd)
+        val savedDict = sd!!.toMutable()
+
+        var n = 0
+        val itr = savedDict.iterator()
+        assertThrows(ConcurrentModificationException::class.java) {
+            while (itr.hasNext()) {
+                if (n++ == 3) {
+                    savedDict.setValue("10", 10)
+                }
+                itr.next()
+            }
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfMutatedSavedDictionaryIterator() {
+        val dict = MutableDictionary()
+        (0..5).forEach { dict.setValue("${it}", it) }
+
+        val sd = saveDocInCollection(MutableDocument().setValue("dict", dict)).getDictionary("dict")
+        assertNotNull(sd)
+        val savedDict = sd!!.toMutable()
+
+        savedDict.setValue("9", 9)
+
+        var n = 0
+        val itr = savedDict.iterator()
+        assertThrows(ConcurrentModificationException::class.java) {
+            while (itr.hasNext()) {
+                if (n++ == 3) {
+                    savedDict.setValue("10", 10)
+                }
+                itr.next()
+            }
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfDictionaryIteratorArrayMember() {
+        val subArray = MutableArray()
+        val dict = MutableDictionary().setValue("0", subArray)
+        (1..5).forEach { dict.setValue("${it}", it) }
+
+        var n = 0
+        val itr = dict.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                subArray.addValue(10)
+            }
+            itr.next()
+        }
+    }
+
+    @Ignore("Bug: Inconsistent implementation")
+    @Test
+    fun testConcurrentModOfSavedDictionaryIteratorArrayMember1() {
+        val dict = MutableDictionary().setValue("0", MutableArray())
+        (1..5).forEach { dict.setValue("${it}", it) }
+
+        val sd = saveDocInCollection(MutableDocument().setValue("dict", dict)).getDictionary("dict")
+        assertNotNull(sd)
+        val savedDict = sd!!.toMutable()
+
+        val ssa = savedDict.getArray("0")
+        assertNotNull(ssa)
+        val savedSubArray = ssa!!
+
+        var n = 0
+        val itr = savedDict.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubArray.addValue(10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfSavedDictionaryIteratorArrayMember2() {
+        val dict = MutableDictionary().setValue("0", MutableArray())
+        (1..5).forEach { dict.setValue("${it}", it) }
+
+        val sd = saveDocInCollection(MutableDocument().setValue("dict", dict)).getDictionary("dict")
+        assertNotNull(sd)
+        val savedDict = sd!!
+
+        val ssa = savedDict.getArray("0")
+        assertNotNull(ssa)
+        val savedSubArray = ssa!!.toMutable()
+
+        var n = 0
+        val itr = savedDict.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubArray.addValue(10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfMutatedSavedDictionaryIteratorArrayMember1() {
+        val dict = MutableDictionary().setValue("0", MutableArray())
+        (1..5).forEach { dict.setValue("${it}", it) }
+
+        val sd = saveDocInCollection(MutableDocument().setValue("dict", dict)).getDictionary("dict")
+        assertNotNull(sd)
+        val savedDict = sd!!.toMutable()
+
+        val ssa = savedDict.getArray("0")
+        assertNotNull(ssa)
+        val savedSubArray = ssa!!
+
+        savedSubArray.addValue(9)
+
+        var n = 0
+        val itr = savedDict.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubArray.addValue(10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfMutatedSavedDictionaryIteratorArrayMember2() {
+        val dict = MutableDictionary().setValue("0", MutableArray())
+        (1..5).forEach { dict.setValue("${it}", it) }
+
+        val sd = saveDocInCollection(MutableDocument().setValue("dict", dict)).getDictionary("dict")
+        assertNotNull(sd)
+        val savedDict = sd!!
+
+        val ssa = savedDict.getArray("0")
+        assertNotNull(ssa)
+        val savedSubArray = ssa!!.toMutable()
+
+        savedSubArray.addValue(9)
+
+        var n = 0
+        val itr = savedDict.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubArray.addValue(10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfDictionaryIteratorDictMember() {
+        val subDict = MutableDictionary()
+        val dict = MutableDictionary().setValue("0", subDict)
+        (1..5).forEach { dict.setValue("${it}", it) }
+
+        var n = 0
+        val itr = dict.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                subDict.setValue("10", 10)
+            }
+            itr.next()
+        }
+    }
+
+    @Ignore("Bug: Inconsistent implementation")
+    @Test
+    fun testConcurrentModOfSavedDictionaryIteratorDictMember1() {
+        val dict = MutableDictionary().setValue("0", MutableDictionary())
+        (1..5).forEach { dict.setValue("${it}", it) }
+
+        val sd = saveDocInCollection(MutableDocument().setValue("dict", dict)).getDictionary("dict")
+        assertNotNull(sd)
+        val savedDict = sd!!.toMutable()
+
+        val ssd = savedDict.getDictionary("0")
+        assertNotNull(ssd)
+        val savedSubDict = ssd!!
+
+        var n = 0
+        val itr = savedDict.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubDict.setValue("10", 10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfSavedDictionaryIteratorDictMember2() {
+        val dict = MutableDictionary().setValue("0", MutableDictionary())
+        (1..5).forEach { dict.setValue("${it}", it) }
+
+        val sd = saveDocInCollection(MutableDocument().setValue("dict", dict)).getDictionary("dict")
+        assertNotNull(sd)
+        val savedDict = sd!!
+
+        val ssd = savedDict.getDictionary("0")
+        assertNotNull(ssd)
+        val savedSubDict = ssd!!.toMutable()
+
+        var n = 0
+        val itr = savedDict.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubDict.setValue("10", 10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfMutatedSavedDictionaryIteratorDictMember1() {
+        val dict = MutableDictionary().setValue("0", MutableDictionary())
+        (1..5).forEach { dict.setValue("${it}", it) }
+
+        val sd = saveDocInCollection(MutableDocument().setValue("dict", dict)).getDictionary("dict")
+        assertNotNull(sd)
+        val savedDict = sd!!.toMutable()
+
+        val ssd = savedDict.getDictionary("0")
+        assertNotNull(ssd)
+        val savedSubDict = ssd!!
+
+        savedSubDict.setValue("9", 9)
+
+        var n = 0
+        val itr = savedDict.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubDict.setValue("10", 10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfMutatedSavedDictionaryIteratorDictMember2() {
+        val dict = MutableDictionary().setValue("0", MutableDictionary())
+        (1..5).forEach { dict.setValue("${it}", it) }
+
+        val sd = saveDocInCollection(MutableDocument().setValue("dict", dict)).getDictionary("dict")
+        assertNotNull(sd)
+        val savedDict = sd!!
+
+        val ssd = savedDict.getDictionary("0")
+        assertNotNull(ssd)
+        val savedSubDict = ssd!!.toMutable()
+
+        savedSubDict.setValue("9", 9)
+
+        var n = 0
+        val itr = savedDict.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubDict.setValue("10", 10)
+            }
+            itr.next()
+        }
+    }
+
+
+    ///// Document Iterator Tests
+
+    @Ignore("Bug: Inconsistent implementation")
+    @Test
+    fun testConcurrentModOfMutableDocumentIterator() {
+        val doc = MutableDocument()
+        (0..5).forEach { doc.setValue("${it}", it) }
+
+        var n = 0
+        val itr = doc.iterator()
+        assertThrows(ConcurrentModificationException::class.java) {
+            while (itr.hasNext()) {
+                if (n++ == 3) {
+                    doc.setValue("10", 10)
+                }
+                itr.next()
+            }
+        }
+    }
+
+    @Ignore("Bug: Inconsistent implementation")
+    @Test
+    fun testConcurrentModOfSavedDocumentIterator() {
+        val doc = MutableDocument()
+        (0..5).forEach { doc.setValue("${it}", it) }
+
+        val savedDoc = saveDocInCollection(doc).toMutable()
+
+        var n = 0
+        val itr = savedDoc.iterator()
+        assertThrows(ConcurrentModificationException::class.java) {
+            while (itr.hasNext()) {
+                if (n++ == 3) {
+                    savedDoc.setValue("10", 10)
+                }
+                itr.next()
+            }
+        }
+    }
+
+    @Ignore("Bug: Inconsistent implementation")
+    @Test
+    fun testConcurrentModOfMutatedSavedDocumentIterator() {
+        val doc = MutableDocument()
+        (0..5).forEach { doc.setValue("${it}", it) }
+
+        val savedDoc = saveDocInCollection(doc).toMutable()
+
+        savedDoc.setValue("9", 9)
+
+        var n = 0
+        val itr = savedDoc.iterator()
+        assertThrows(ConcurrentModificationException::class.java) {
+            while (itr.hasNext()) {
+                if (n++ == 3) {
+                    savedDoc.setValue("10", 10)
+                }
+                itr.next()
+            }
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfDocumentIteratorArrayMember() {
+        val subArray = MutableArray()
+        val doc = MutableDocument().setValue("0", subArray)
+        (1..5).forEach { doc.setValue("${it}", it) }
+
+        var n = 0
+        val itr = doc.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                subArray.addValue(10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfSavedDocumentIteratorArrayMember1() {
+        val doc = MutableDocument().setValue("0", MutableArray())
+        (1..5).forEach { doc.setValue("${it}", it) }
+
+        val savedDoc = saveDocInCollection(doc).toMutable()
+
+        val ssa = savedDoc.getArray("0")
+        assertNotNull(ssa)
+        val savedSubArray = ssa!!
+
+        var n = 0
+        val itr = savedDoc.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubArray.addValue(10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfSavedDocumentIteratorArrayMember2() {
+        val doc = MutableDocument().setValue("0", MutableArray())
+        (1..5).forEach { doc.setValue("${it}", it) }
+
+        val savedDoc = saveDocInCollection(doc)
+
+        val ssa = savedDoc.getArray("0")
+        assertNotNull(ssa)
+        val savedSubArray = ssa!!.toMutable()
+
+        var n = 0
+        val itr = savedDoc.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubArray.addValue(10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfMutatedSavedDocumentIteratorArrayMember1() {
+        val doc = MutableDocument().setValue("0", MutableArray())
+        (1..5).forEach { doc.setValue("${it}", it) }
+
+        val savedDoc = saveDocInCollection(doc).toMutable()
+
+        val ssa = savedDoc.getArray("0")
+        assertNotNull(ssa)
+        val savedSubArray = ssa!!
+
+        savedSubArray.addValue(9)
+
+        var n = 0
+        val itr = savedDoc.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubArray.addValue(10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfMutatedSavedDocumentIteratorArrayMember2() {
+        val doc = MutableDocument().setValue("0", MutableArray())
+        (1..5).forEach { doc.setValue("${it}", it) }
+
+        val savedDoc = saveDocInCollection(doc)
+
+        val ssa = savedDoc.getArray("0")
+        assertNotNull(ssa)
+        val savedSubArray = ssa!!.toMutable()
+
+        savedSubArray.addValue(9)
+
+        var n = 0
+        val itr = savedDoc.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubArray.addValue(10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfDocumentIteratorDictMember() {
+        val subDict = MutableDictionary()
+        val doc = MutableDocument().setValue("0", subDict)
+        (1..5).forEach { doc.setValue("${it}", it) }
+
+        var n = 0
+        val itr = doc.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                subDict.setValue("10", 10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfSavedDocumentIteratorDictMember1() {
+        val doc = MutableDocument().setValue("0", MutableDictionary())
+        (1..5).forEach { doc.setValue("${it}", it) }
+
+        val savedDoc = saveDocInCollection(doc).toMutable()
+
+        val ssd = savedDoc.getDictionary("0")
+        assertNotNull(ssd)
+        val savedSubDict = ssd!!
+
+        var n = 0
+        val itr = savedDoc.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubDict.setValue("10", 10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfSavedDocumentIteratorDictMember2() {
+        val doc = MutableDocument().setValue("0", MutableDictionary())
+        (1..5).forEach { doc.setValue("${it}", it) }
+
+        val savedDoc = saveDocInCollection(doc)
+
+        val ssd = savedDoc.getDictionary("0")
+        assertNotNull(ssd)
+        val savedSubDict = ssd!!.toMutable()
+
+        var n = 0
+        val itr = savedDoc.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubDict.setValue("10", 10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfMutatedSavedDocumentIteratorDictMember1() {
+        val doc = MutableDocument().setValue("0", MutableDictionary())
+        (1..5).forEach { doc.setValue("${it}", it) }
+
+        val savedDoc = saveDocInCollection(doc).toMutable()
+
+        val ssd = savedDoc.getDictionary("0")
+        assertNotNull(ssd)
+        val savedSubDict = ssd!!
+
+        savedSubDict.setValue("9", 9)
+
+        var n = 0
+        val itr = savedDoc.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubDict.setValue("10", 10)
+            }
+            itr.next()
+        }
+    }
+
+    @Test
+    fun testConcurrentModOfMutatedSavedDocumentIteratorDictMember2() {
+        val doc = MutableDocument().setValue("0", MutableDictionary())
+        (1..5).forEach { doc.setValue("${it}", it) }
+
+        val savedDoc = saveDocInCollection(doc)
+
+        val ssd = savedDoc.getDictionary("0")
+        assertNotNull(ssd)
+        val savedSubDict = ssd!!.toMutable()
+
+        savedSubDict.setValue("9", 9)
+
+        var n = 0
+        val itr = savedDoc.iterator()
+        while (itr.hasNext()) {
+            if (n++ == 3) {
+                savedSubDict.setValue("10", 10)
+            }
+            itr.next()
+        }
+    }
+}


### PR DESCRIPTION
First steps in the process of normalizing the behavior of collection iterators, across platforms.

In creating this group of tests I've discovered that it makes a difference whether the call to toMutable is on the container or its element.  Will have to add more tests to handle these cases.

testConcurrentModOfSavedArrayIteratorMember fails.  I believe this to be a bug in the Iterator, not the test.