### PR TITLE
Clean up some code:

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractQuery.java
+++ b/common/main/java/com/couchbase/lite/AbstractQuery.java
@@ -41,7 +41,7 @@ abstract class AbstractQuery implements Listenable<QueryChange, QueryChangeListe
     protected static final LogDomain DOMAIN = LogDomain.QUERY;
 
     // This class has two reasons for existence:
-    // - put/remove execute onFirst and onLast lambdas, respectively
+    // - put and remove execute the onFirst and onLast Runnables, respectively
     // - it prevents starting an observer that has been removed.
     private static class LiveQueries {
         private final Map<ListenerToken, C4QueryObserver> liveQueries = new HashMap<>();

--- a/common/main/java/com/couchbase/lite/Query.java
+++ b/common/main/java/com/couchbase/lite/Query.java
@@ -65,9 +65,9 @@ public interface Query {
      * As currently implemented, the result is two or more lines separated by newline characters:
      * * The first line is the SQLite SELECT statement.
      * * The subsequent lines are the output of SQLite's "EXPLAIN QUERY PLAN" command applied to that
-     * statement; for help interpreting this, see https://www.sqlite.org/eqp.html . The most
-     * important thing to know is that if you see "SCAN TABLE", it means that SQLite is doing a
-     * slow linear scan of the documents instead of using an index.
+     * statement; for help interpreting this, see <a href="https://www.sqlite.org/eqp.html">eqp</a>.
+     * The most important thing to know is that if you see "SCAN TABLE", it means that SQLite is
+     * doing a slow linear scan of the documents instead of using an index.
      *
      * @return a string describing the implementation of the compiled query.
      * @throws CouchbaseLiteException if an error occurs

--- a/common/main/java/com/couchbase/lite/internal/core/C4BlobKey.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4BlobKey.java
@@ -15,7 +15,6 @@
 //
 package com.couchbase.lite.internal.core;
 
-import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -30,7 +29,7 @@ import com.couchbase.lite.internal.core.impl.NativeC4Blob;
  * <p>
  * A raw SHA-1 digest used as the unique identifier of a blob.
  */
-public class C4BlobKey extends C4NativePeer {
+public final class C4BlobKey extends C4NativePeer {
     public interface NativeImpl {
         long nFromString(@Nullable String str) throws LiteCoreException;
         @Nullable
@@ -80,7 +79,6 @@ public class C4BlobKey extends C4NativePeer {
     // public methods
     //-------------------------------------------------------------------------
 
-    @CallSuper
     @Override
     public void close() { closePeer(null); }
 

--- a/common/main/java/com/couchbase/lite/internal/core/C4BlobReadStream.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4BlobReadStream.java
@@ -15,7 +15,6 @@
 //
 package com.couchbase.lite.internal.core;
 
-import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -26,7 +25,7 @@ import com.couchbase.lite.LogDomain;
 /**
  * An open stream for reading data from a blob.
  */
-public class C4BlobReadStream extends C4NativePeer {
+public final class C4BlobReadStream extends C4NativePeer {
     @NonNull
     private final C4BlobStore.NativeImpl impl;
 
@@ -66,7 +65,6 @@ public class C4BlobReadStream extends C4NativePeer {
     /**
      * Closes a read-stream.
      */
-    @CallSuper
     @Override
     public void close() { closePeer(null); }
 

--- a/common/main/java/com/couchbase/lite/internal/core/C4BlobStore.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4BlobStore.java
@@ -27,7 +27,7 @@ import com.couchbase.lite.internal.fleece.FLSliceResult;
 /**
  * Blob Store API
  */
-public class C4BlobStore extends C4NativePeer {
+public abstract class C4BlobStore extends C4NativePeer {
     public interface NativeImpl {
         long nGetBlobStore(long db) throws LiteCoreException;
         long nGetSize(long peer, long key);

--- a/common/main/java/com/couchbase/lite/internal/core/C4BlobWriteStream.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4BlobWriteStream.java
@@ -15,7 +15,6 @@
 //
 package com.couchbase.lite.internal.core;
 
-import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -27,7 +26,7 @@ import com.couchbase.lite.internal.utils.Preconditions;
 /**
  * An open stream for writing data to a blob.
  */
-public class C4BlobWriteStream extends C4NativePeer {
+public final class C4BlobWriteStream extends C4NativePeer {
     @NonNull
     private final C4BlobStore.NativeImpl impl;
 
@@ -89,7 +88,6 @@ public class C4BlobWriteStream extends C4NativePeer {
      * Closes a blob write-stream. If c4stream_install was not already called, the temporary file
      * will be deleted without adding the blob to the store.
      */
-    @CallSuper
     @Override
     public void close() { closePeer(null); }
 

--- a/common/main/java/com/couchbase/lite/internal/core/C4CollectionObserver.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4CollectionObserver.java
@@ -15,7 +15,6 @@
 //
 package com.couchbase.lite.internal.core;
 
-import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -115,7 +114,6 @@ public final class C4CollectionObserver
         return (changes.length <= 0) ? null : Arrays.asList(changes);
     }
 
-    @CallSuper
     @Override
     public void close() { closePeer(null); }
 

--- a/common/main/java/com/couchbase/lite/internal/core/C4CollectionSpec.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4CollectionSpec.java
@@ -19,7 +19,7 @@ package com.couchbase.lite.internal.core;
 import androidx.annotation.NonNull;
 
 
-public class C4CollectionSpec {
+public final class C4CollectionSpec {
     @NonNull
     private final String scopeName;
     @NonNull

--- a/common/main/java/com/couchbase/lite/internal/core/C4DocumentEnded.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4DocumentEnded.java
@@ -22,7 +22,7 @@ import androidx.annotation.NonNull;
  * WARNING!
  * This class and its members are referenced by name, from native code.
  */
-public class C4DocumentEnded {
+public final class C4DocumentEnded {
     public final long token;
     @NonNull
     public final String scope;

--- a/common/main/java/com/couchbase/lite/internal/core/C4Query.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Query.java
@@ -15,10 +15,8 @@
 //
 package com.couchbase.lite.internal.core;
 
-import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 
 import com.couchbase.lite.AbstractIndex;
 import com.couchbase.lite.LiteCoreException;
@@ -42,17 +40,7 @@ public final class C4Query extends C4NativePeer {
     }
 
     @NonNull
-    @VisibleForTesting
-    private static final NativeImpl NATIVE_IMPL = new NativeC4Query();
-
-    @NonNull
-    public static C4Query create(
-        @NonNull C4Collection collection,
-        @NonNull AbstractIndex.QueryLanguage language,
-        @NonNull String expression)
-        throws LiteCoreException {
-        return create(collection.getDb(), language, expression);
-    }
+     private static final NativeImpl NATIVE_IMPL = new NativeC4Query();
 
     @NonNull
     public static C4Query create(
@@ -88,12 +76,9 @@ public final class C4Query extends C4NativePeer {
     // public methods
     //-------------------------------------------------------------------------
 
-    @CallSuper
+    // Documentation recommends that this call be made while holding the database lock
     @Override
-    public void close() {
-        // ??? Documentation recommends that this call be made while holding the database lock
-        closePeer(null);
-    }
+    public void close() { closePeer(null); }
 
     public void setParameters(@NonNull FLSliceResult params) {
         impl.nSetParameters(getPeer(), params.getBase(), params.getSize());
@@ -104,8 +89,7 @@ public final class C4Query extends C4NativePeer {
 
     @Nullable
     public C4QueryEnumerator run(@NonNull FLSliceResult params) throws LiteCoreException {
-        return withPeerOrNull(h -> C4QueryEnumerator.create(
-            impl.nRun(h, params.getBase(), params.getSize())));
+        return withPeerOrNull(h -> C4QueryEnumerator.create(impl.nRun(h, params.getBase(), params.getSize())));
     }
 
     public int getColumnCount() { return withPeerOrDefault(0, impl::nColumnCount); }

--- a/common/main/java/com/couchbase/lite/internal/core/C4QueryEnumerator.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4QueryEnumerator.java
@@ -15,7 +15,6 @@
 //
 package com.couchbase.lite.internal.core;
 
-import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -35,7 +34,7 @@ import com.couchbase.lite.internal.utils.Preconditions;
  * The fields of this struct represent the current matched index row.
  * They are valid until the next call to c4queryenum_next or c4queryenum_free.
  */
-public class C4QueryEnumerator extends C4NativePeer {
+public final class C4QueryEnumerator extends C4NativePeer {
     public interface NativeImpl {
         boolean nNext(long peer) throws LiteCoreException;
         void nFree(long peer);
@@ -97,7 +96,6 @@ public class C4QueryEnumerator extends C4NativePeer {
      */
     public long getMissingColumns() { return impl.nGetMissingColumns(getPeer()); }
 
-    @CallSuper
     @Override
     public void close() { closePeer(null); }
 

--- a/common/main/java/com/couchbase/lite/internal/core/C4QueryObserver.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4QueryObserver.java
@@ -10,7 +10,6 @@
 //
 package com.couchbase.lite.internal.core;
 
-import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
@@ -25,7 +24,7 @@ import com.couchbase.lite.internal.utils.ClassUtils;
 import com.couchbase.lite.internal.utils.Fn;
 
 
-public class C4QueryObserver extends C4NativePeer {
+public final class C4QueryObserver extends C4NativePeer {
     @FunctionalInterface
     public interface QueryChangeCallback {
         void onQueryChanged(@Nullable C4QueryEnumerator results, @Nullable LiteCoreException err);
@@ -107,7 +106,6 @@ public class C4QueryObserver extends C4NativePeer {
         this.callback = callback;
     }
 
-    @CallSuper
     @Override
     public void close() {
         QUERY_OBSERVER_CONTEXT.unbind(token);

--- a/common/main/java/com/couchbase/lite/internal/core/C4Socket.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Socket.java
@@ -81,16 +81,22 @@ public final class C4Socket extends C4NativePeer implements SocketToCore {
 
     /**
      * Email exchange, 2022/5/17
-     *
+     * <p>
      * Blake:
      * Is the reference that the JNI gets when it creates [such an] object (which the Java code stores as
      * a `long`) *always* the same reference that that object will pass as a parameter when it does a callback
      * to the Java code e.g. kSocketFactory.write or C4ReplicatorParameters.C4ReplicatorDocumentsEndedCallback.
-     *
+     * <p>
      * Jim:
      * Yes this is a safe assumption
      */
-    public static class NativeRefPeerBinding<T> extends WeakPeerBinding<T> { }
+    public static class NativeRefPeerBinding<T> extends WeakPeerBinding<T> {
+        @Override
+        protected void preBind(long key, @NonNull T obj) { }
+
+        @Override
+        protected void preGetBinding(long key) { }
+    }
 
     //-------------------------------------------------------------------------
     // Static fields

--- a/common/main/java/com/couchbase/lite/internal/core/peers/TaggedWeakPeerBinding.java
+++ b/common/main/java/com/couchbase/lite/internal/core/peers/TaggedWeakPeerBinding.java
@@ -11,7 +11,6 @@
 package com.couchbase.lite.internal.core.peers;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.couchbase.lite.internal.utils.MathUtils;
 
@@ -61,9 +60,8 @@ public class TaggedWeakPeerBinding<T> extends WeakPeerBinding<T> {
      * @param obj the object to be bound to the token.
      */
     @Override
-    public synchronized void bind(long key, @NonNull T obj) {
+    public void preBind(long key, @NonNull T obj) {
         if (!exists(key)) { throw new IllegalStateException("attempt to use un-reserved key"); }
-        super.bind(key, obj);
     }
 
     /**
@@ -74,13 +72,10 @@ public class TaggedWeakPeerBinding<T> extends WeakPeerBinding<T> {
      * @param key a token created by <code>reserveKey()</code>
      * @return the bound object, or null if none exists.
      */
-    @Nullable
     @Override
-    public synchronized T getBinding(long key) {
+    public void preGetBinding(long key) {
         if ((key < 0) || (key > Integer.MAX_VALUE)) {
             throw new IllegalArgumentException("Key out of bounds: " + key);
         }
-
-        return super.getBinding(key);
     }
 }

--- a/common/main/java/com/couchbase/lite/internal/fleece/FLArrayIterator.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/FLArrayIterator.java
@@ -15,7 +15,6 @@
 //
 package com.couchbase.lite.internal.fleece;
 
-import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -43,7 +42,6 @@ public abstract class FLArrayIterator extends C4NativePeer {
             this.array = array;
         }
 
-        @CallSuper
         @Override
         public void close() { closePeer(null); }
 

--- a/common/main/java/com/couchbase/lite/internal/fleece/FLDictIterator.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/FLDictIterator.java
@@ -15,7 +15,6 @@
 //
 package com.couchbase.lite.internal.fleece;
 
-import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -54,7 +53,6 @@ public final class FLDictIterator extends C4NativePeer {
     @NonNull
     public FLValue getValue() { return FLValue.getFLValue(impl.nGetValue(getPeer())); }
 
-    @CallSuper
     @Override
     public void close() { closePeer(null); }
 

--- a/common/test/java/com/couchbase/lite/ArrayTest.java
+++ b/common/test/java/com/couchbase/lite/ArrayTest.java
@@ -18,10 +18,8 @@ package com.couchbase.lite;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.ConcurrentModificationException;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -1805,7 +1803,7 @@ public class ArrayTest extends BaseDbTest {
 
     ///////////////  Error Case test
 
-    private class Unserializable{}
+    private static class Unserializable{}
 
     @Test
     public void testAddValueUnexpectedObject() {

--- a/common/test/java/com/couchbase/lite/BaseDbTest.kt
+++ b/common/test/java/com/couchbase/lite/BaseDbTest.kt
@@ -15,7 +15,6 @@
 //
 package com.couchbase.lite
 
-import com.couchbase.lite.internal.fleece.FLEncoder
 import com.couchbase.lite.internal.utils.JSONUtils
 import com.couchbase.lite.internal.utils.PlatformUtils
 import com.couchbase.lite.internal.utils.Report

--- a/common/test/java/com/couchbase/lite/DictionaryTest.java
+++ b/common/test/java/com/couchbase/lite/DictionaryTest.java
@@ -16,9 +16,7 @@
 package com.couchbase.lite;
 
 import java.util.ArrayList;
-import java.util.ConcurrentModificationException;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;


### PR DESCRIPTION
- C4 classes should be abstract or final
- Get rid of funky @CallSuper annotations

@CallSuper is not well enforced and basically admits that the design is flaky.  It is obviously unnecessary if the class containing the method is final.  Using the template pattern is another way to get rid of it.