### PR TITLE
Fix the FL iterators

### DIFF
--- a/common/main/java/com/couchbase/lite/IndexConfiguration.java
+++ b/common/main/java/com/couchbase/lite/IndexConfiguration.java
@@ -34,7 +34,7 @@ public abstract class IndexConfiguration extends AbstractIndex {
 
     IndexConfiguration(@NonNull List<String> expressions) {
         this.expressions = Preconditions.assertNotEmpty(
-            Fn.filterToList(expressions, i -> (i != null)),
+            Fn.filterToList(expressions, s -> !StringUtils.isEmpty(s)),
             "expression list");
     }
 

--- a/common/main/java/com/couchbase/lite/internal/fleece/FLArray.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/FLArray.java
@@ -101,7 +101,7 @@ public final class FLArray {
             FLValue value;
             while ((value = itr.getValue()) != null) {
                 results.add((T) value.asObject());
-                if (!itr.next()) { break; }
+                itr.next();
             }
         }
 

--- a/common/main/java/com/couchbase/lite/internal/fleece/FLArrayIterator.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/FLArrayIterator.java
@@ -91,7 +91,12 @@ public abstract class FLArrayIterator extends C4NativePeer {
         return hValue == 0L ? null : FLValue.getFLValue(hValue);
     }
 
-    public boolean next() { return impl.nNext(getPeer()); }
+    /**
+     * Advances the iterator to the next value.
+     * NOTE: It is illegal to call this when the iterator is already at the end.
+     * In particular, calling this when the array is empty is always illegal
+     */
+    public void next() { impl.nNext(getPeer()); }
 
     @Nullable
     public FLValue getValue() {

--- a/common/main/java/com/couchbase/lite/internal/fleece/FLDictIterator.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/FLDictIterator.java
@@ -45,7 +45,12 @@ public final class FLDictIterator extends C4NativePeer {
 
     public long getCount() { return impl.nGetCount(getPeer()); }
 
-    public boolean next() { return impl.nNext(getPeer()); }
+    /**
+     * Advances the iterator to the next key/value.
+     * NOTE: It is illegal to call this when the iterator is already at the end.
+     * In particular, calling this when the dict is empty is always illegal
+     */
+    public void next() { impl.nNext(getPeer()); }
 
     @Nullable
     public String getKey() { return impl.nGetKey(getPeer()); }

--- a/common/test/java/com/couchbase/lite/ConflictResolutionTest.kt
+++ b/common/test/java/com/couchbase/lite/ConflictResolutionTest.kt
@@ -384,7 +384,6 @@ class ConflictResolutionTests : BaseReplicatorTest() {
      * Verify that the only docs subject to conflict resolution are conflicted docs that are being pulled
      */
     @Test
-    @Throws(CouchbaseLiteException::class, InterruptedException::class)
     fun testConflictResolutionCriteria() {
         // documentsEnded is going to need this.
         val rc = ReplicationCollection.create(testCollection, null, null, null, null)

--- a/common/test/java/com/couchbase/lite/internal/core/C4QueryTest.java
+++ b/common/test/java/com/couchbase/lite/internal/core/C4QueryTest.java
@@ -475,7 +475,7 @@ public class C4QueryTest extends C4QueryBaseTest {
         while (e.next()) {
             FLArrayIterator itr = e.getColumns();
             assertEquals(itr.getValue().asString(), expectedFirst.get(i));
-            assertTrue(itr.next());
+            itr.next();
             assertEquals(itr.getValue().asString(), expectedLast.get(i));
             i++;
         }
@@ -519,7 +519,7 @@ public class C4QueryTest extends C4QueryBaseTest {
         while (e.next()) {
             FLArrayIterator itr = e.getColumns();
             assertEquals(itr.getValue().asString(), "Aerni");
-            assertTrue(itr.next());
+            itr.next();
             assertEquals(itr.getValue().asString(), "Zirk");
             i++;
         }
@@ -547,9 +547,9 @@ public class C4QueryTest extends C4QueryBaseTest {
             FLArrayIterator itr = e.getColumns();
             if (i < expectedState.size()) {
                 assertEquals(itr.getValue().asString(), expectedState.get(i));
-                assertTrue(itr.next());
+                itr.next();
                 assertEquals(itr.getValue().asString(), expectedMin.get(i));
-                assertTrue(itr.next());
+                itr.next();
                 assertEquals(itr.getValue().asString(), expectedMax.get(i));
             }
             i++;
@@ -582,7 +582,7 @@ public class C4QueryTest extends C4QueryBaseTest {
             FLArrayIterator itr = e.getColumns();
             if (i < expectedState.size()) {
                 assertEquals(itr.getValue().asString(), expectedFirst.get(i));
-                assertTrue(itr.next());
+                itr.next();
                 assertEquals(itr.getValue().asString(), expectedState.get(i));
             }
             i++;

--- a/common/test/java/com/couchbase/lite/internal/replicator/InternalReplicatorTest.java
+++ b/common/test/java/com/couchbase/lite/internal/replicator/InternalReplicatorTest.java
@@ -20,8 +20,10 @@ import androidx.annotation.NonNull;
 import com.couchbase.lite.AbstractReplicator;
 
 
+/**
+ * Exists to make the method BaseReplicator.dispatcher() visible for testing
+ */
 public class InternalReplicatorTest {
-
     public static void enqueueOnDispatcher(@NonNull AbstractReplicator repl, @NonNull Runnable task) {
         repl.dispatcher.execute(task);
     }


### PR DESCRIPTION
FL[Dict,Array] iterators no longer return a value.  According to Jens, it is incorrect to use them as a loop control.
Also added comments noting that it is illegal to call next() on an empty iterator, or after it has reached the end of its container.