### PR TITLE
Replace IllegalStateException with CouchbaseLiteError

### DIFF
--- a/android-ktx/main/kotlin/com/couchbase/lite/internal/ReplicatorWorker.kt
+++ b/android-ktx/main/kotlin/com/couchbase/lite/internal/ReplicatorWorker.kt
@@ -21,6 +21,7 @@ import androidx.work.Data
 import androidx.work.WorkerParameters
 import com.couchbase.lite.AbstractReplicatorConfiguration
 import com.couchbase.lite.CBLError
+import com.couchbase.lite.CouchbaseLiteError
 import com.couchbase.lite.CouchbaseLiteException
 import com.couchbase.lite.LogDomain
 import com.couchbase.lite.Replicator
@@ -169,7 +170,7 @@ class ReplicatorWorker(appContext: Context, params: WorkerParameters) : Coroutin
         try {
             return (Class.forName(factoryClass).getDeclaredConstructor().newInstance() as WorkManagerReplicatorFactory)
         } catch (e: Exception) {
-            throw IllegalStateException("Failed creating factory ${factoryClass}", e)
+            throw CouchbaseLiteError("Failed creating factory ${factoryClass}", e)
         }
     }
 

--- a/android/main/java/com/couchbase/lite/CouchbaseLite.java
+++ b/android/main/java/com/couchbase/lite/CouchbaseLite.java
@@ -32,7 +32,7 @@ public final class CouchbaseLite {
      * Initialize CouchbaseLite library. This method MUST be called before using CouchbaseLite.
      *
      * @param ctxt the ApplicationContext.
-     * @throws IllegalStateException on initialization failure
+     * @throws CouchbaseLiteError on initialization failure
      */
     public static void init(@NonNull Context ctxt) { init(ctxt, BuildConfig.CBL_DEBUG); }
 
@@ -42,7 +42,7 @@ public final class CouchbaseLite {
      * so by Couchbase Support Engineering
      *
      * @param debug true to enable debugging (Unsupported)
-     * @throws IllegalStateException on initialization failure
+     * @throws CouchbaseLiteError on initialization failure
      */
     public static void init(@NonNull Context ctxt, boolean debug) {
         init(ctxt, debug, ctxt.getFilesDir(), new File(ctxt.getFilesDir(), CouchbaseLiteInternal.SCRATCH_DIR_NAME));
@@ -59,7 +59,7 @@ public final class CouchbaseLite {
      * @param debug      to enable debugging
      * @param rootDir    default directory for databases
      * @param scratchDir scratch directory for SQLite
-     * @throws IllegalStateException on initialization failure
+     * @throws CouchbaseLiteError on initialization failure
      */
     public static void init(@NonNull Context ctxt, boolean debug, @NonNull File rootDir, @NonNull File scratchDir) {
         CouchbaseLiteInternal.init(ctxt, debug, rootDir, scratchDir);

--- a/android/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
+++ b/android/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import com.couchbase.lite.CouchbaseLiteError;
 import com.couchbase.lite.LiteCoreException;
 import com.couchbase.lite.LogDomain;
 import com.couchbase.lite.R;
@@ -109,7 +110,7 @@ public final class CouchbaseLiteInternal {
         final SoftReference<Context> contextRef = CONTEXT.get();
 
         final Context ctxt = contextRef.get();
-        if (ctxt == null) { throw new IllegalStateException("Context is null"); }
+        if (ctxt == null) { throw new CouchbaseLiteError("Context is null"); }
 
         return ctxt;
     }
@@ -134,7 +135,7 @@ public final class CouchbaseLiteInternal {
 
     public static void requireInit(String message) {
         if (!INITIALIZED.get()) {
-            throw new IllegalStateException(message + ".  Did you forget to call CouchbaseLite.init()?");
+            throw new CouchbaseLiteError(message + ".  Did you forget to call CouchbaseLite.init()?");
         }
     }
 

--- a/common/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/common/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -639,7 +639,7 @@ abstract class AbstractDatabase extends BaseDatabase
             synchronized (getDbLock()) { defaultCollection = getDefaultCollectionLocked(); }
         }
         catch (CouchbaseLiteException e) {
-            throw new IllegalStateException("Failed getting default collection", e);
+            throw new CouchbaseLiteError("Failed getting default collection", e);
         }
 
         return (defaultCollection == null) ? 0 : defaultCollection.getCount();
@@ -657,11 +657,11 @@ abstract class AbstractDatabase extends BaseDatabase
      * Gets an existing Document with the given ID from the default collection.
      * If the document with the given ID doesn't exist in the default collection,
      * the method will return null.  If the default collection does not exist or if
-     * the database is closed, the method will throw an IllegalStateException
+     * the database is closed, the method will throw an CouchbaseLiteError
      *
      * @param id the document ID
      * @return the Document object or null
-     * @throws IllegalStateException when the database is closed or the default collection has been deleted
+     * @throws CouchbaseLiteError when the database is closed or the default collection has been deleted
      * @deprecated Use getDefaultCollection().getDocument()
      */
     @SuppressWarnings("PMD.PreserveStackTrace")
@@ -724,7 +724,7 @@ abstract class AbstractDatabase extends BaseDatabase
         try { return getDefaultCollectionOrThrow().save(document, conflictHandler); }
         catch (CouchbaseLiteException e) {
             if (!(CBLError.Domain.CBLITE.equals(e.getDomain()) && (CBLError.Code.NOT_OPEN == e.getCode()))) { throw e; }
-            else { throw new IllegalStateException(Log.lookupStandardMessage("DBClosedOrCollectionDeleted"), e); }
+            else { throw new CouchbaseLiteError(Log.lookupStandardMessage("DBClosedOrCollectionDeleted"), e); }
         }
     }
 
@@ -1023,7 +1023,7 @@ abstract class AbstractDatabase extends BaseDatabase
     Set<Collection> getDefaultCollectionAsSet() {
         final Collection defaultCollection;
         try { defaultCollection = Collection.getDefaultCollection(this.getDatabase()); }
-        catch (CouchbaseLiteException e) { throw new IllegalStateException("Can't get default collection", e); }
+        catch (CouchbaseLiteException e) { throw new CouchbaseLiteError("Can't get default collection", e); }
         if (defaultCollection == null) {
             throw new IllegalArgumentException("Database " + getName() + "has no default collection");
         }
@@ -1308,7 +1308,7 @@ abstract class AbstractDatabase extends BaseDatabase
         }
         catch (CouchbaseLiteException e) { err = e; }
 
-        throw new IllegalStateException(Log.lookupStandardMessage("DBClosedOrCollectionDeleted"), err);
+        throw new CouchbaseLiteError(Log.lookupStandardMessage("DBClosedOrCollectionDeleted"), err);
     }
 
     @Nullable
@@ -1422,7 +1422,7 @@ abstract class AbstractDatabase extends BaseDatabase
 
         final Collection localCollection = localDoc.getCollection();
         if (localCollection == null) {
-            throw new IllegalStateException("Local doc does not belong to any collection: " + docID);
+            throw new CouchbaseLiteError("Local doc does not belong to any collection: " + docID);
         }
 
         final Document resolvedDoc = runClientResolver(resolver, docID, localDoc, remoteDoc);

--- a/common/main/java/com/couchbase/lite/AbstractDatabaseConfiguration.java
+++ b/common/main/java/com/couchbase/lite/AbstractDatabaseConfiguration.java
@@ -55,11 +55,11 @@ abstract class AbstractDatabaseConfiguration {
     /**
      * Set the canonical path of the directory in which to store the database.
      * If the directory doesn't already exist it will be created.
-     * If it cannot be created an IllegalStateException will be thrown.
+     * If it cannot be created an CouchbaseLiteError will be thrown.
      *
      * @param directory the directory
      * @return this.
-     * @throws IllegalStateException if the directory does not exist and cannot be created
+     * @throws CouchbaseLiteError if the directory does not exist and cannot be created
      */
     @NonNull
     public DatabaseConfiguration setDirectory(@NonNull String directory) {

--- a/common/main/java/com/couchbase/lite/AbstractQuery.java
+++ b/common/main/java/com/couchbase/lite/AbstractQuery.java
@@ -126,7 +126,7 @@ abstract class AbstractQuery implements Listenable<QueryChange, QueryChangeListe
      * Set query parameters.
      * Setting new parameters will re-execute a query if there is at least one listener listening for changes.
      *
-     * @throws IllegalStateException    on failure to create the query (e.g., database closed)
+     * @throws CouchbaseLiteError    on failure to create the query (e.g., database closed)
      * @throws IllegalArgumentException on failure to encode the parameters (e.g., parameter value not supported)
      */
     @Override
@@ -139,7 +139,7 @@ abstract class AbstractQuery implements Listenable<QueryChange, QueryChangeListe
             if (parameters == null) { return; }
 
             try { getC4QueryLocked().setParameters(parameters.encode()); }
-            catch (CouchbaseLiteException e) { throw new IllegalStateException("Failed creating query", e); }
+            catch (CouchbaseLiteException e) { throw new CouchbaseLiteError("Failed creating query", e); }
             catch (LiteCoreException e) { throw new IllegalArgumentException("Failed encoding parameters", e); }
         }
     }
@@ -226,7 +226,7 @@ abstract class AbstractQuery implements Listenable<QueryChange, QueryChangeListe
      * @param executor The executor object that calls listener. If null, use default executor.
      * @param listener The listener to post changes.
      * @return An opaque listener token object for removing the listener.
-     * @throws IllegalStateException on failure to create the query (e.g., database closed)
+     * @throws CouchbaseLiteError on failure to create the query (e.g., database closed)
      */
     @NonNull
     @Override
@@ -276,7 +276,7 @@ abstract class AbstractQuery implements Listenable<QueryChange, QueryChangeListe
         if (c4query != null) { return c4query; }
 
         final AbstractDatabase db = getDatabase();
-        if (db == null) { throw new IllegalStateException("Attempt to prep query with no database"); }
+        if (db == null) { throw new CouchbaseLiteError("Attempt to prep query with no database"); }
 
         final C4Query c4Q = prepQueryLocked(db);
 
@@ -325,7 +325,7 @@ abstract class AbstractQuery implements Listenable<QueryChange, QueryChangeListe
     private C4QueryObserver getObserver(@NonNull ChangeListenerToken<QueryChange> token) {
         synchronized (lock) {
             try { return C4QueryObserver.create(getC4QueryLocked(), (r, err) -> onQueryChanged(token, r, err)); }
-            catch (CouchbaseLiteException e) { throw new IllegalStateException("Failed creating query listener", e); }
+            catch (CouchbaseLiteException e) { throw new CouchbaseLiteError("Failed creating query listener", e); }
         }
     }
 
@@ -345,6 +345,6 @@ abstract class AbstractQuery implements Listenable<QueryChange, QueryChangeListe
     private Object getDbLock() {
         final BaseDatabase db = getDatabase();
         if (db != null) { return db.getDbLock(); }
-        throw new IllegalStateException("Cannot seize DB lock");
+        throw new CouchbaseLiteError("Cannot seize DB lock");
     }
 }

--- a/common/main/java/com/couchbase/lite/AbstractReplicator.java
+++ b/common/main/java/com/couchbase/lite/AbstractReplicator.java
@@ -409,7 +409,7 @@ public abstract class AbstractReplicator extends BaseReplicator
      * We recommend the use of this method on Replicators that are in the STOPPED state.  If the
      * replicator is not stopped, this method will make a best effort attempt to stop it but
      * will not wait to confirm that it was stopped cleanly.
-     * Any attempt to restart a closed replicator will result in an IllegalStateException.
+     * Any attempt to restart a closed replicator will result in an CouchbaseLiteError.
      * This includes calls to getPendingDocIds and isDocPending.
      */
     public void close() {
@@ -685,7 +685,7 @@ public abstract class AbstractReplicator extends BaseReplicator
     private C4Replicator getOrCreateC4Replicator() {
         // createReplicatorForTarget is going to seize this lock anyway: force in-order seizure
         synchronized (getDatabase().getDbLock()) {
-            if (closed) { throw new IllegalStateException("Attempt to operate on a closed replicator"); }
+            if (closed) { throw new CouchbaseLiteError("Attempt to operate on a closed replicator"); }
 
             C4Replicator c4Repl = getC4Replicator();
 
@@ -707,7 +707,7 @@ public abstract class AbstractReplicator extends BaseReplicator
                 return c4Repl;
             }
             catch (LiteCoreException e) {
-                throw new IllegalStateException(
+                throw new CouchbaseLiteError(
                     "Could not create replicator",
                     CouchbaseLiteException.convertException(e));
             }
@@ -862,7 +862,7 @@ public abstract class AbstractReplicator extends BaseReplicator
     @NonNull
     private Database getDatabase() {
         final Database db = config.getDatabase();
-        if (db == null) { throw new IllegalStateException("No database in Replicator"); }
+        if (db == null) { throw new CouchbaseLiteError("No database in Replicator"); }
         return db;
     }
 

--- a/common/main/java/com/couchbase/lite/AbstractReplicatorConfiguration.java
+++ b/common/main/java/com/couchbase/lite/AbstractReplicatorConfiguration.java
@@ -81,11 +81,11 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
         final Collection defaultCollection;
         try { defaultCollection = db.getDefaultCollection(); }
         catch (CouchbaseLiteException e) {
-            throw new IllegalStateException(Log.lookupStandardMessage("NoDefaultCollectionInConfig"), e);
+            throw new CouchbaseLiteError(Log.lookupStandardMessage("NoDefaultCollectionInConfig"), e);
         }
 
         if (defaultCollection == null) {
-            throw new IllegalStateException(Log.lookupStandardMessage("NoDefaultCollectionInConfig"));
+            throw new CouchbaseLiteError(Log.lookupStandardMessage("NoDefaultCollectionInConfig"));
         }
 
         final Map<Collection, CollectionConfiguration> collections = new HashMap<>();
@@ -456,7 +456,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
                 type = com.couchbase.lite.ReplicatorType.PULL;
                 break;
             default:
-                throw new IllegalStateException("Unrecognized replicator type: " + replicatorType);
+                throw new CouchbaseLiteError("Unrecognized replicator type: " + replicatorType);
         }
         return setType(type);
     }
@@ -707,7 +707,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
             case PULL:
                 return AbstractReplicatorConfiguration.ReplicatorType.PULL;
             default:
-                throw new IllegalStateException("Unrecognized replicator type: " + type);
+                throw new CouchbaseLiteError("Unrecognized replicator type: " + type);
         }
     }
 
@@ -722,7 +722,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
     public final byte[] getPinnedServerCertificate() {
         try { return (pinnedServerCertificate == null) ? null : pinnedServerCertificate.getEncoded(); }
         catch (CertificateEncodingException e) {
-            throw new IllegalStateException("Unrecognized certificate encoding", e);
+            throw new CouchbaseLiteError("Unrecognized certificate encoding", e);
         }
     }
 
@@ -736,7 +736,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
     public final Database getDatabase() {
         if (database != null) { return database; }
         // Can't change the nullity of this method: it has to throw.
-        throw new IllegalStateException("No database or collections provided for replication configuration");
+        throw new CouchbaseLiteError("No database or collections provided for replication configuration");
     }
 
     /**

--- a/common/main/java/com/couchbase/lite/Array.java
+++ b/common/main/java/com/couchbase/lite/Array.java
@@ -312,7 +312,7 @@ public class Array implements ArrayInterface, FLEncodable, Iterable<Object> {
             return encoder.finishJSON();
         }
         catch (LiteCoreException e) {
-            throw new IllegalStateException("Cannot encode array: " + this, e);
+            throw new CouchbaseLiteError("Cannot encode array: " + this, e);
         }
     }
 

--- a/common/main/java/com/couchbase/lite/BaseDatabase.java
+++ b/common/main/java/com/couchbase/lite/BaseDatabase.java
@@ -69,7 +69,7 @@ public abstract class BaseDatabase {
     @GuardedBy("dbLock")
     protected void assertOpenUnchecked() {
         if (!isOpenLocked()) {
-            throw new IllegalStateException(Log.lookupStandardMessage("DBClosedOrCollectionDeleted"));
+            throw new CouchbaseLiteError(Log.lookupStandardMessage("DBClosedOrCollectionDeleted"));
         }
     }
 

--- a/common/main/java/com/couchbase/lite/Blob.java
+++ b/common/main/java/com/couchbase/lite/Blob.java
@@ -409,7 +409,7 @@ public final class Blob implements FLEncodable {
     @NonNull
     public String toJSON() {
         if (blobDigest == null) {
-            throw new IllegalStateException("A Blob may be encoded as JSON only after it has been saved in a database");
+            throw new CouchbaseLiteError("A Blob may be encoded as JSON only after it has been saved in a database");
         }
 
         final Map<String, Object> json = new HashMap<>();
@@ -420,7 +420,7 @@ public final class Blob implements FLEncodable {
         json.put(PROP_CONTENT_TYPE, contentType);
 
         try { return JSONUtils.toJSON(json).toString(); }
-        catch (JSONException e) { throw new IllegalStateException("Could not parse Blob JSON", e); }
+        catch (JSONException e) { throw new CouchbaseLiteError("Could not parse Blob JSON", e); }
     }
 
     /**
@@ -563,11 +563,11 @@ public final class Blob implements FLEncodable {
         if (database != null) {
             // attempt to save the blob in the wrong db;
             if ((db != null) && (!database.equals(db))) {
-                throw new IllegalStateException(Log.lookupStandardMessage("BlobDifferentDatabase"));
+                throw new CouchbaseLiteError(Log.lookupStandardMessage("BlobDifferentDatabase"));
             }
 
             // saved but no digest???
-            if (blobDigest == null) { throw new IllegalStateException("Blob has no digest"); }
+            if (blobDigest == null) { throw new CouchbaseLiteError("Blob has no digest"); }
 
             // blob has already been saved.
             return;
@@ -584,7 +584,7 @@ public final class Blob implements FLEncodable {
         catch (Exception e) {
             database = null;
             blobDigest = null;
-            throw new IllegalStateException("Failed reading blob content from database", e);
+            throw new CouchbaseLiteError("Failed reading blob content from database", e);
         }
     }
 
@@ -611,7 +611,7 @@ public final class Blob implements FLEncodable {
     private void installInDatabase(@Nullable Object dbArg) {
         // blob has not been saved: dbArg must be a db in which to save it.
         if ((database == null) && (!(dbArg instanceof Database))) {
-            throw new IllegalStateException("No database for Blob save");
+            throw new CouchbaseLiteError("No database for Blob save");
         }
         installInDatabase((Database) dbArg);
     }
@@ -627,7 +627,7 @@ public final class Blob implements FLEncodable {
         catch (LiteCoreException e) {
             final String msg = "Failed to read content from database for digest: " + blobDigest;
             Log.e(DOMAIN, msg, e);
-            throw new IllegalStateException(msg, e);
+            throw new CouchbaseLiteError(msg, e);
         }
 
         // cache content if less than 8K
@@ -640,7 +640,7 @@ public final class Blob implements FLEncodable {
     private InputStream getStreamFromDatabase(@NonNull BaseDatabase db) {
         try { return new BlobInputStream(C4BlobKey.create(blobDigest), db.getBlobStore()); }
         catch (IllegalArgumentException | LiteCoreException e) {
-            throw new IllegalStateException("Failed opening blobContent stream.", e);
+            throw new CouchbaseLiteError("Failed opening blobContent stream.", e);
         }
     }
 
@@ -648,7 +648,7 @@ public final class Blob implements FLEncodable {
     private C4BlobKey getBlobKey(@NonNull C4BlobStore store) throws LiteCoreException, IOException {
         if (blobContent != null) { return store.create(blobContent); }
         if (blobContentStream != null) { return writeDatabaseFromInitStream(store); }
-        throw new IllegalStateException(Log.lookupStandardMessage("BlobContentNull"));
+        throw new CouchbaseLiteError(Log.lookupStandardMessage("BlobContentNull"));
     }
 
     @SuppressFBWarnings("DE_MIGHT_IGNORE")
@@ -660,7 +660,7 @@ public final class Blob implements FLEncodable {
             while ((n = in.read(buff)) >= 0) { out.write(buff, 0, n); }
         }
         catch (IOException e) {
-            throw new IllegalStateException("Failed reading blob content stream", e);
+            throw new CouchbaseLiteError("Failed reading blob content stream", e);
         }
         finally {
             blobContentStream = null;
@@ -673,7 +673,7 @@ public final class Blob implements FLEncodable {
     @SuppressFBWarnings("DE_MIGHT_IGNORE")
     @NonNull
     private C4BlobKey writeDatabaseFromInitStream(@NonNull C4BlobStore store) throws LiteCoreException, IOException {
-        if (blobContentStream == null) { throw new IllegalStateException("Blob stream is null"); }
+        if (blobContentStream == null) { throw new CouchbaseLiteError("Blob stream is null"); }
 
         final C4BlobKey key;
 

--- a/common/main/java/com/couchbase/lite/Collection.java
+++ b/common/main/java/com/couchbase/lite/Collection.java
@@ -68,11 +68,11 @@ import com.couchbase.lite.internal.utils.Preconditions;
  *
  * <code>Collection</code> objects are only valid during the time the database that
  * contains them is open.  An attempt to use a collection that belongs to a closed
- * database will throw an <code>IllegalStateException</code>.
+ * database will throw an <code>CouchbaseLiteError</code>.
  * An application can hold references to multiple instances of a single database.
  * Under these circumstances, it is possible that a collection will be deleted in
  * one instance before an attempt to use it in another.  Such an attempt will
- * also cause an <code>IllegalStateException</code> to be thrown.
+ * also cause an <code>CouchbaseLiteError</code> to be thrown.
  * <p><code>Collection</code>s are <code>AutoCloseable</code>.  While garbage
  * collection will manage them correctly, developers are strongly encouraged to
  * to use them in try-with-resources blocks or to close them explicitly, after use.
@@ -898,7 +898,7 @@ public final class Collection extends BaseCollection
             else {
                 final Collection collection = document.getCollection();
                 if (collection == null) {
-                    throw new IllegalStateException("Attempt to save document in null collection");
+                    throw new CouchbaseLiteError("Attempt to save document in null collection");
                 }
                 c4Doc = collection.createC4Document(document.getId(), body, revFlags);
             }

--- a/common/main/java/com/couchbase/lite/DatabaseChange.java
+++ b/common/main/java/com/couchbase/lite/DatabaseChange.java
@@ -36,7 +36,7 @@ public class DatabaseChange {
             if (defaultCollection != null) { return defaultCollection; }
         }
         catch (CouchbaseLiteException e) { fail = e; }
-        throw new IllegalStateException("Database " + database.getName() + " has no default collection", fail);
+        throw new CouchbaseLiteError("Database " + database.getName() + " has no default collection", fail);
     }
 
     @NonNull

--- a/common/main/java/com/couchbase/lite/Dictionary.java
+++ b/common/main/java/com/couchbase/lite/Dictionary.java
@@ -351,7 +351,7 @@ public class Dictionary implements DictionaryInterface, FLEncodable, Iterable<St
             return encoder.finishJSON();
         }
         catch (LiteCoreException e) {
-            throw new IllegalStateException("Cannot encode dictionary: " + this, e);
+            throw new CouchbaseLiteError("Cannot encode dictionary: " + this, e);
         }
     }
 

--- a/common/main/java/com/couchbase/lite/Document.java
+++ b/common/main/java/com/couchbase/lite/Document.java
@@ -572,7 +572,7 @@ public class Document implements DictionaryInterface, Iterable<String> {
     @NonNull
     final FLSliceResult encode() throws LiteCoreException {
         final Database db = getDatabase();
-        if (db == null) { throw new IllegalStateException("encode called with null database"); }
+        if (db == null) { throw new CouchbaseLiteError("encode called with null database"); }
 
         try (FLEncoder encoder = db.getSharedFleeceEncoder()) {
             encoder.setArg(Blob.ENCODER_ARG_DB, getDatabase());
@@ -617,7 +617,7 @@ public class Document implements DictionaryInterface, Iterable<String> {
         }
 
         final Database db = getDatabase();
-        if (db == null) { throw new IllegalStateException("document has not been saved to a database"); }
+        if (db == null) { throw new CouchbaseLiteError("document has not been saved to a database"); }
 
         final MRoot newRoot = new MRoot(new DocContext(db, c4Document), data.toFLValue(), mutable);
         internalDict = (Dictionary) Preconditions.assertNotNull(newRoot.asNative(), "root dictionary");

--- a/common/main/java/com/couchbase/lite/Expression.java
+++ b/common/main/java/com/couchbase/lite/Expression.java
@@ -254,7 +254,7 @@ public abstract class Expression {
                     break;
 
                 default:
-                    throw new IllegalStateException("Unexpected unary type: " + op);
+                    throw new CouchbaseLiteError("Unexpected unary type: " + op);
             }
 
             return json;

--- a/common/main/java/com/couchbase/lite/FileLogger.java
+++ b/common/main/java/com/couchbase/lite/FileLogger.java
@@ -65,7 +65,7 @@ public final class FileLogger implements Logger {
      * @param level The maximum level to include in the logs
      */
     public void setLevel(@NonNull LogLevel level) {
-        if (config == null) { throw new IllegalStateException(Log.lookupStandardMessage("CannotSetLogLevel")); }
+        if (config == null) { throw new CouchbaseLiteError(Log.lookupStandardMessage("CannotSetLogLevel")); }
 
         if (logLevel == level) { return; }
 

--- a/common/main/java/com/couchbase/lite/LogFileConfiguration.java
+++ b/common/main/java/com/couchbase/lite/LogFileConfiguration.java
@@ -108,7 +108,7 @@ public final class LogFileConfiguration {
      */
     @NonNull
     public LogFileConfiguration setMaxSize(long maxSize) {
-        if (readonly) { throw new IllegalStateException("LogFileConfiguration is readonly mode."); }
+        if (readonly) { throw new CouchbaseLiteError("LogFileConfiguration is readonly mode."); }
 
         this.maxSize = Preconditions.assertNotNegative(maxSize, "max size");
         return this;
@@ -125,7 +125,7 @@ public final class LogFileConfiguration {
      */
     @NonNull
     public LogFileConfiguration setMaxRotateCount(int maxRotateCount) {
-        if (readonly) { throw new IllegalStateException("LogFileConfiguration is readonly mode."); }
+        if (readonly) { throw new CouchbaseLiteError("LogFileConfiguration is readonly mode."); }
 
         this.maxRotateCount = Preconditions.assertNotNegative(maxRotateCount, "max rotation count");
         return this;
@@ -141,7 +141,7 @@ public final class LogFileConfiguration {
      */
     @NonNull
     public LogFileConfiguration setUsePlaintext(boolean usePlaintext) {
-        if (readonly) { throw new IllegalStateException("LogFileConfiguration is readonly mode."); }
+        if (readonly) { throw new CouchbaseLiteError("LogFileConfiguration is readonly mode."); }
 
         this.usePlaintext = usePlaintext;
         return this;

--- a/common/main/java/com/couchbase/lite/MValueConverter.java
+++ b/common/main/java/com/couchbase/lite/MValueConverter.java
@@ -77,7 +77,7 @@ public abstract class MValueConverter {
     @NonNull
     private NativeValue<?> mValueToDictionary(@NonNull MValue mv, @NonNull MCollection parent) {
         final MContext ctxt = parent.getContext();
-        if (!(ctxt instanceof DbContext)) { throw new IllegalStateException("Context is not DbContext: " + ctxt); }
+        if (!(ctxt instanceof DbContext)) { throw new CouchbaseLiteError("Context is not DbContext: " + ctxt); }
         final DbContext context = (DbContext) ctxt;
 
         final FLDict flDict = Preconditions.assertNotNull(mv.getValue(), "MValue").asFLDict();

--- a/common/main/java/com/couchbase/lite/MutableArray.java
+++ b/common/main/java/com/couchbase/lite/MutableArray.java
@@ -555,7 +555,7 @@ public final class MutableArray extends Array implements MutableArrayInterface {
 
     @NonNull
     @Override
-    public String toJSON() { throw new IllegalStateException("Mutable objects may not be encoded as JSON"); }
+    public String toJSON() { throw new CouchbaseLiteError("Mutable objects may not be encoded as JSON"); }
 
     @Nullable
     private Object checkSelf(@Nullable Object value) {

--- a/common/main/java/com/couchbase/lite/MutableDictionary.java
+++ b/common/main/java/com/couchbase/lite/MutableDictionary.java
@@ -295,7 +295,7 @@ public final class MutableDictionary extends Dictionary implements MutableDictio
 
     @NonNull
     @Override
-    public String toJSON() { throw new IllegalStateException("Mutable objects may not be encoded as JSON"); }
+    public String toJSON() { throw new CouchbaseLiteError("Mutable objects may not be encoded as JSON"); }
 
     @VisibleForTesting
     boolean isChanged() {

--- a/common/main/java/com/couchbase/lite/MutableDocument.java
+++ b/common/main/java/com/couchbase/lite/MutableDocument.java
@@ -345,11 +345,11 @@ public final class MutableDocument extends Document implements MutableDictionary
      * Unimplemented: Mutable objects may not be encoded as JSON
      *
      * @return never
-     * @throws IllegalStateException always
+     * @throws CouchbaseLiteError always
      */
     @NonNull
     @Override
-    public String toJSON() { throw new IllegalStateException("Mutable objects may not be encoded as JSON"); }
+    public String toJSON() { throw new CouchbaseLiteError("Mutable objects may not be encoded as JSON"); }
 
     //---------------------------------------------
     // Private access

--- a/common/main/java/com/couchbase/lite/Parameters.java
+++ b/common/main/java/com/couchbase/lite/Parameters.java
@@ -199,7 +199,7 @@ public final class Parameters {
     @NonNull
     public Parameters setValue(@NonNull String name, @Nullable Object value) {
         Preconditions.assertNotNull(name, "name");
-        if (readonly) { throw new IllegalStateException("Parameters is readonly mode."); }
+        if (readonly) { throw new CouchbaseLiteError("Parameters is readonly mode."); }
         map.put(name, value);
         return this;
     }

--- a/common/main/java/com/couchbase/lite/Result.java
+++ b/common/main/java/com/couchbase/lite/Result.java
@@ -41,7 +41,7 @@ import com.couchbase.lite.internal.utils.Preconditions;
  * <p>
  * A Result may be referenced <b>only</b> while the ResultSet that contains it is open.
  * An attempt to reference a Result after calling ResultSet.close on the ResultSet that
- * contains it will throw an IllegalStateException
+ * contains it will throw an CouchbaseLiteError
  */
 public final class Result implements ArrayInterface, DictionaryInterface, Iterable<String> {
 
@@ -502,7 +502,7 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
             return enc.finishJSON();
         }
         catch (LiteCoreException e) {
-            throw new IllegalStateException("Cannot encode result: " + this, e);
+            throw new CouchbaseLiteError("Cannot encode result: " + this, e);
         }
     }
 
@@ -573,7 +573,7 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
 
     private void assertOpen() {
         if (rs.isClosed()) {
-            throw new IllegalStateException("Attempt to use a result after its containing ResultSet has been closed");
+            throw new CouchbaseLiteError("Attempt to use a result after its containing ResultSet has been closed");
         }
     }
 }

--- a/common/main/java/com/couchbase/lite/ResultSet.java
+++ b/common/main/java/com/couchbase/lite/ResultSet.java
@@ -203,7 +203,7 @@ public class ResultSet implements Iterable<Result>, AutoCloseable {
             final AbstractDatabase db = q.getDatabase();
             if (db != null) { return db.getDbLock(); }
         }
-        throw new IllegalStateException("Could not obtain db lock");
+        throw new CouchbaseLiteError("Could not obtain db lock");
     }
 }
 

--- a/common/main/java/com/couchbase/lite/internal/core/C4NativePeer.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4NativePeer.java
@@ -19,6 +19,7 @@ import androidx.annotation.GuardedBy;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.couchbase.lite.CouchbaseLiteError;
 import com.couchbase.lite.LogDomain;
 import com.couchbase.lite.internal.CouchbaseLiteInternal;
 import com.couchbase.lite.internal.logging.Log;
@@ -85,7 +86,7 @@ public abstract class C4NativePeer implements AutoCloseable {
      * can use it after the peer has been disposed.
      *
      * @return the handle to the native peer.
-     * @throws IllegalStateException if the peer has been closed.
+     * @throws CouchbaseLiteError if the peer has been closed.
      */
     protected final long getPeer() {
         synchronized (getPeerLock()) {
@@ -93,7 +94,7 @@ public abstract class C4NativePeer implements AutoCloseable {
         }
 
         logBadCall();
-        throw new IllegalStateException("Operation on closed peer");
+        throw new CouchbaseLiteError("Operation on closed peer");
     }
 
     protected final <E extends Exception> void withPeer(@NonNull Fn.ConsumerThrows<Long, E> fn) throws E {
@@ -143,7 +144,7 @@ public abstract class C4NativePeer implements AutoCloseable {
         }
 
         logBadCall();
-        throw new IllegalStateException("Closed peer");
+        throw new CouchbaseLiteError("Closed peer");
     }
 
     @NonNull
@@ -153,7 +154,7 @@ public abstract class C4NativePeer implements AutoCloseable {
         }
 
         logBadCall();
-        throw new IllegalStateException("Closed peer");
+        throw new CouchbaseLiteError("Closed peer");
     }
 
     /**

--- a/common/main/java/com/couchbase/lite/internal/core/peers/PeerBinding.java
+++ b/common/main/java/com/couchbase/lite/internal/core/peers/PeerBinding.java
@@ -22,6 +22,8 @@ import androidx.annotation.VisibleForTesting;
 
 import java.util.Set;
 
+import com.couchbase.lite.CouchbaseLiteError;
+
 
 abstract class PeerBinding<T> {
     /**
@@ -41,7 +43,7 @@ abstract class PeerBinding<T> {
             return;
         }
 
-        throw new IllegalStateException("Attempt to rebind peer @x" + Long.toHexString(key));
+        throw new CouchbaseLiteError("Attempt to rebind peer @x" + Long.toHexString(key));
     }
 
     /**

--- a/common/main/java/com/couchbase/lite/internal/core/peers/TaggedWeakPeerBinding.java
+++ b/common/main/java/com/couchbase/lite/internal/core/peers/TaggedWeakPeerBinding.java
@@ -12,6 +12,7 @@ package com.couchbase.lite.internal.core.peers;
 
 import androidx.annotation.NonNull;
 
+import com.couchbase.lite.CouchbaseLiteError;
 import com.couchbase.lite.internal.utils.MathUtils;
 
 
@@ -61,7 +62,7 @@ public class TaggedWeakPeerBinding<T> extends WeakPeerBinding<T> {
      */
     @Override
     public void preBind(long key, @NonNull T obj) {
-        if (!exists(key)) { throw new IllegalStateException("attempt to use un-reserved key"); }
+        if (!exists(key)) { throw new CouchbaseLiteError("attempt to use un-reserved key"); }
     }
 
     /**

--- a/common/main/java/com/couchbase/lite/internal/exec/InstrumentedTask.java
+++ b/common/main/java/com/couchbase/lite/internal/exec/InstrumentedTask.java
@@ -20,6 +20,8 @@ import androidx.annotation.Nullable;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.couchbase.lite.CouchbaseLiteError;
+
 
 public class InstrumentedTask implements Runnable {
     private static final AtomicLong ID = new AtomicLong(0);
@@ -51,7 +53,7 @@ public class InstrumentedTask implements Runnable {
     public void run() {
         synchronized (this) {
             if (startedAt != 0L) {
-                throw new IllegalStateException("Attempt to execute a task multiple times");
+                throw new CouchbaseLiteError("Attempt to execute a task multiple times");
             }
             startedAt = System.currentTimeMillis();
         }

--- a/common/main/java/com/couchbase/lite/internal/fleece/MArray.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/MArray.java
@@ -21,6 +21,8 @@ import androidx.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.couchbase.lite.CouchbaseLiteError;
+
 
 /**
  * Please see the comments in MValue
@@ -95,12 +97,12 @@ public final class MArray extends MCollection {
     }
 
     public boolean append(Object value) {
-        if (!isMutable()) { throw new IllegalStateException("Cannot append items to a non-mutable MArray"); }
+        if (!isMutable()) { throw new CouchbaseLiteError("Cannot append items to a non-mutable MArray"); }
         return insert(count(), value);
     }
 
     public boolean set(long index, Object value) {
-        if (!isMutable()) { throw new IllegalStateException("Cannot set items in a non-mutable MArray"); }
+        if (!isMutable()) { throw new CouchbaseLiteError("Cannot set items in a non-mutable MArray"); }
 
         if ((index < 0) || (index >= count())) { return false; }
 
@@ -111,7 +113,7 @@ public final class MArray extends MCollection {
     }
 
     public boolean insert(long index, Object value) {
-        if (!isMutable()) { throw new IllegalStateException("Cannot insert items in a non-mutable MArray"); }
+        if (!isMutable()) { throw new CouchbaseLiteError("Cannot insert items in a non-mutable MArray"); }
 
         if ((index < 0) || (index > count())) { return false; }
 
@@ -124,7 +126,7 @@ public final class MArray extends MCollection {
     }
 
     public boolean remove(long start, long num) {
-        if (!isMutable()) { throw new IllegalStateException("Cannot remove items in a non-mutable MArray"); }
+        if (!isMutable()) { throw new CouchbaseLiteError("Cannot remove items in a non-mutable MArray"); }
 
         final long end = start + num;
         if (end <= start) { return end == start; }
@@ -141,7 +143,7 @@ public final class MArray extends MCollection {
     }
 
     public void clear() {
-        if (!isMutable()) { throw new IllegalStateException("Cannot clear items in a non-mutable MArray"); }
+        if (!isMutable()) { throw new CouchbaseLiteError("Cannot clear items in a non-mutable MArray"); }
 
         if (values.isEmpty()) { return; }
 

--- a/common/main/java/com/couchbase/lite/internal/fleece/MDict.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/MDict.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.couchbase.lite.CouchbaseLiteError;
+
 
 /**
  * Please see the comments in MValue
@@ -128,7 +130,7 @@ public final class MDict extends MCollection {
     }
 
     public void set(String key, @NonNull MValue value) {
-        if (!isMutable()) { throw new IllegalStateException("Cannot set items in a non-mutable MDict"); }
+        if (!isMutable()) { throw new CouchbaseLiteError("Cannot set items in a non-mutable MDict"); }
 
         final boolean hasVal = !value.isEmpty();
 
@@ -161,12 +163,12 @@ public final class MDict extends MCollection {
     }
 
     public void remove(String key) {
-        if (!isMutable()) { throw new IllegalStateException("Cannot remove items in a non-mutable MDict"); }
+        if (!isMutable()) { throw new CouchbaseLiteError("Cannot remove items in a non-mutable MDict"); }
         set(key, MValue.EMPTY);
     }
 
     public void clear() {
-        if (!isMutable()) { throw new IllegalStateException("Cannot clear items from a non-mutable MDict"); }
+        if (!isMutable()) { throw new CouchbaseLiteError("Cannot clear items from a non-mutable MDict"); }
 
         if (valCount == 0) { return; }
 

--- a/common/main/java/com/couchbase/lite/internal/fleece/MValue.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/MValue.java
@@ -18,6 +18,7 @@ package com.couchbase.lite.internal.fleece;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.couchbase.lite.CouchbaseLiteError;
 import com.couchbase.lite.MValueConverter;
 import com.couchbase.lite.internal.utils.Preconditions;
 
@@ -86,7 +87,7 @@ public class MValue extends MValueConverter implements Encodable {
 
     @Override
     public void encodeTo(@NonNull FLEncoder enc) {
-        if (isEmpty()) { throw new IllegalStateException("MValue is empty."); }
+        if (isEmpty()) { throw new CouchbaseLiteError("MValue is empty."); }
 
         if (flValue != null) { enc.writeValue(flValue); }
         else if (value != null) { enc.writeValue(value); }

--- a/common/main/java/com/couchbase/lite/internal/sockets/OkHttpSocket.java
+++ b/common/main/java/com/couchbase/lite/internal/sockets/OkHttpSocket.java
@@ -40,6 +40,7 @@ import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
 import okio.ByteString;
 
+import com.couchbase.lite.CouchbaseLiteError;
 import com.couchbase.lite.LogDomain;
 import com.couchbase.lite.internal.core.C4Constants;
 import com.couchbase.lite.internal.core.C4Replicator;
@@ -394,7 +395,7 @@ public final class OkHttpSocket extends WebSocketListener implements SocketToRem
     private SocketFromRemote getOpenCore() {
         final SocketFromRemote core = toCore.get();
         if (SocketFromRemote.Constants.NULL.equals(core)) {
-            throw new IllegalStateException("Attempt to use socket before initialization");
+            throw new CouchbaseLiteError("Attempt to use socket before initialization");
         }
         return core;
     }

--- a/common/main/java/com/couchbase/lite/internal/utils/FileUtils.java
+++ b/common/main/java/com/couchbase/lite/internal/utils/FileUtils.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import com.couchbase.lite.CouchbaseLiteError;
 import com.couchbase.lite.LogDomain;
 import com.couchbase.lite.internal.logging.Log;
 
@@ -46,7 +47,7 @@ public final class FileUtils {
         }
         catch (IOException e) { err = e; }
 
-        throw new IllegalStateException("Cannot create or access directory at " + dir, err);
+        throw new CouchbaseLiteError("Cannot create or access directory at " + dir, err);
     }
 
     public static void copyFile(InputStream in, OutputStream out) throws IOException {
@@ -100,7 +101,7 @@ public final class FileUtils {
     @NonNull
     public static File getCurrentDirectory() {
         try { return new File("").getCanonicalFile(); }
-        catch (IOException e) { throw new IllegalStateException("Can't open current directory", e); }
+        catch (IOException e) { throw new CouchbaseLiteError("Can't open current directory", e); }
     }
 
     private static boolean deleteRecursive(File fileOrDirectory) {

--- a/common/test/java/com/couchbase/lite/ArrayTest.java
+++ b/common/test/java/com/couchbase/lite/ArrayTest.java
@@ -1829,7 +1829,7 @@ public class ArrayTest extends BaseDbTest {
     // JSON 3.7.?
     @Test
     public void testArrayToJSONBeforeSave() {
-        assertThrows(IllegalStateException.class, () -> new MutableArray().toJSON());
+        assertThrows(CouchbaseLiteError.class, () -> new MutableArray().toJSON());
     }
 
     // JSON 3.7.a-b

--- a/common/test/java/com/couchbase/lite/BaseDbTest.kt
+++ b/common/test/java/com/couchbase/lite/BaseDbTest.kt
@@ -213,7 +213,7 @@ abstract class BaseDbTest : BaseTest() {
         collection.database.inBatch<CouchbaseLiteException> {
             docs = mDocs.map { saveDocInCollection(it, collection) }
         }
-        return docs ?: throw IllegalStateException("doc list is null")
+        return docs ?: throw CouchbaseLiteError("doc list is null")
     }
 
     protected fun createDocInCollection(

--- a/common/test/java/com/couchbase/lite/BlobTest.java
+++ b/common/test/java/com/couchbase/lite/BlobTest.java
@@ -358,7 +358,7 @@ public class BlobTest extends BaseDbTest {
     // 3.1.c
     @Test
     public void testUnsavedBlobToJSON() {
-        assertThrows(IllegalStateException.class, () -> makeBlob().toJSON());
+        assertThrows(CouchbaseLiteError.class, () -> makeBlob().toJSON());
     }
 
     // 3.1.d

--- a/common/test/java/com/couchbase/lite/ConflictResolutionTest.kt
+++ b/common/test/java/com/couchbase/lite/ConflictResolutionTest.kt
@@ -276,7 +276,7 @@ class ConflictResolutionTests : BaseReplicatorTest() {
         var succeeded = false
         try {
             succeeded = testCollection.save(doc1b) { _: MutableDocument, _: Document? ->
-                throw IllegalStateException("freak out!")
+                throw CouchbaseLiteError("freak out!")
             }
             fail("save should not succeed!")
         } catch (err: CouchbaseLiteException) {

--- a/common/test/java/com/couchbase/lite/DatabaseTest.kt
+++ b/common/test/java/com/couchbase/lite/DatabaseTest.kt
@@ -558,7 +558,7 @@ class DatabaseTest : BaseDbTest() {
         assertNotNull(blob)
 
         // trying to get the content, however, should fail
-        assertThrows(java.lang.IllegalStateException::class.java) { blob!!.content }
+        assertThrows(CouchbaseLiteError::class.java) { blob!!.content }
     }
 
     @Test
@@ -584,7 +584,7 @@ class DatabaseTest : BaseDbTest() {
         assertTrue(testDatabase.isOpen)
         testDatabase.close()
         assertFalse(testDatabase.isOpen)
-        assertThrows(java.lang.IllegalStateException::class.java) {
+        assertThrows(CouchbaseLiteError::class.java) {
             testDatabase.inBatch<RuntimeException> { }
         }
     }
@@ -602,7 +602,7 @@ class DatabaseTest : BaseDbTest() {
         assertTrue(testDatabase.isOpen)
         testDatabase.close()
         assertFalse(testDatabase.isOpen)
-        assertThrows(java.lang.IllegalStateException::class.java) { testDatabase.delete() }
+        assertThrows(CouchbaseLiteError::class.java) { testDatabase.delete() }
     }
 
     //---------------------------------------------
@@ -626,7 +626,7 @@ class DatabaseTest : BaseDbTest() {
         assertFalse(path.exists())
 
         // second delete should fail
-        assertThrows(java.lang.IllegalStateException::class.java) { testDatabase.delete() }
+        assertThrows(CouchbaseLiteError::class.java) { testDatabase.delete() }
     }
 
     @Test
@@ -704,7 +704,7 @@ class DatabaseTest : BaseDbTest() {
         assertTrue(path.exists())
         testDatabase.delete()
         assertFalse(path.exists())
-        assertThrows(java.lang.IllegalStateException::class.java) {
+        assertThrows(CouchbaseLiteError::class.java) {
             testDatabase.inBatch<RuntimeException> { }
         }
     }

--- a/common/test/java/com/couchbase/lite/DictionaryTest.java
+++ b/common/test/java/com/couchbase/lite/DictionaryTest.java
@@ -717,7 +717,7 @@ public class DictionaryTest extends BaseDbTest {
     // JSON 3.6.?
     @Test
     public void testDictToJSONBeforeSave() {
-        assertThrows(IllegalStateException.class, () -> new MutableDictionary().toJSON());
+        assertThrows(CouchbaseLiteError.class, () -> new MutableDictionary().toJSON());
     }
 
     // JSON 3.5.a-b

--- a/common/test/java/com/couchbase/lite/DocumentTest.java
+++ b/common/test/java/com/couchbase/lite/DocumentTest.java
@@ -2668,7 +2668,7 @@ public class DocumentTest extends BaseDbTest {
     // JSON 3.5.?
     @Test
     public void testMutableDocToJSONBeforeSave() {
-        assertThrows(IllegalStateException.class, () -> new MutableDocument().toJSON());
+        assertThrows(CouchbaseLiteError.class, () -> new MutableDocument().toJSON());
     }
 
     // JSON 3.5.a

--- a/common/test/java/com/couchbase/lite/LogTest.kt
+++ b/common/test/java/com/couchbase/lite/LogTest.kt
@@ -461,9 +461,9 @@ class LogTest : BaseDbTest() {
     @Test
     fun testEditReadOnlyLogFileConfiguration() {
         testWithConfiguration(LogLevel.DEBUG, LogFileConfiguration(scratchDirPath!!)) {
-            assertThrows(IllegalStateException::class.java) { Database.log.file.config!!.maxSize = 1024 }
-            assertThrows(IllegalStateException::class.java) { Database.log.file.config!!.maxRotateCount = 3 }
-            assertThrows(IllegalStateException::class.java) { Database.log.file.config!!.setUsePlaintext(true) }
+            assertThrows(CouchbaseLiteError::class.java) { Database.log.file.config!!.maxSize = 1024 }
+            assertThrows(CouchbaseLiteError::class.java) { Database.log.file.config!!.maxRotateCount = 3 }
+            assertThrows(CouchbaseLiteError::class.java) { Database.log.file.config!!.setUsePlaintext(true) }
         }
     }
 

--- a/common/test/java/com/couchbase/lite/PreInitTest.java
+++ b/common/test/java/com/couchbase/lite/PreInitTest.java
@@ -31,21 +31,21 @@ public class PreInitTest extends BaseTest {
 
     @Test
     public void testCreateDatabaseBeforeInit() {
-        assertThrows(IllegalStateException.class, () -> new Database("fail"));
+        assertThrows(CouchbaseLiteError.class, () -> new Database("fail"));
     }
 
     @Test
     public void testGetConsoleBeforeInit() {
-        assertThrows(IllegalStateException.class, () -> new Log().getConsole());
+        assertThrows(CouchbaseLiteError.class, () -> new Log().getConsole());
     }
 
     @Test
     public void testGetFileBeforeInit() {
-        assertThrows(IllegalStateException.class, () -> new Log().getFile());
+        assertThrows(CouchbaseLiteError.class, () -> new Log().getFile());
     }
 
     @Test
     public void testCreateDBConfigBeforeInit() {
-        assertThrows(IllegalStateException.class, DatabaseConfiguration::new);
+        assertThrows(CouchbaseLiteError.class, DatabaseConfiguration::new);
     }
 }

--- a/common/test/java/com/couchbase/lite/ReplicatorConfigurationTest.kt
+++ b/common/test/java/com/couchbase/lite/ReplicatorConfigurationTest.kt
@@ -35,9 +35,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     }
 
     @Test
-    fun testMaxAttemptsZero() {
-        makeSimpleReplConfig(maxAttempts = 0)
-    }
+    fun testMaxAttemptsZero() { makeSimpleReplConfig(maxAttempts = 0) }
 
     @Test
     fun testIllegalAttemptsWaitTime() {
@@ -45,9 +43,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     }
 
     @Test
-    fun testMaxAttemptsWaitTimeZero() {
-        makeSimpleReplConfig(maxAttemptWaitTime = 0)
-    }
+    fun testMaxAttemptsWaitTimeZero() { makeSimpleReplConfig(maxAttemptWaitTime = 0) }
 
     @Test
     fun testIllegalHeartbeatMin() {
@@ -55,9 +51,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     }
 
     @Test
-    fun testHeartbeatZero() {
-        makeSimpleReplConfig().heartbeat = 0
-    }
+    fun testHeartbeatZero() { makeSimpleReplConfig().heartbeat = 0 }
 
     @Test
     fun testIllegalHeartbeatMax() {
@@ -403,7 +397,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     @Test
     fun testCreateConfigWithEndpointOnly2() {
         val replConfig1 = ReplicatorConfiguration(mockURLEndpoint)
-        assertThrows(IllegalStateException::class.java) { replConfig1.database }
+        assertThrows(CouchbaseLiteError::class.java) { replConfig1.database }
     }
 
     // 8.13.7 Create Collection "colA" and "colB" in the scope "scopeA".

--- a/common/test/java/com/couchbase/lite/ReplicatorMiscTest.java
+++ b/common/test/java/com/couchbase/lite/ReplicatorMiscTest.java
@@ -303,7 +303,7 @@ public class ReplicatorMiscTest extends BaseReplicatorTest {
 
         closeDb(getTestDatabase());
 
-        assertThrows(IllegalStateException.class, repl::start);
+        assertThrows(CouchbaseLiteError.class, repl::start);
     }
 
     // CBL-1218
@@ -313,7 +313,7 @@ public class ReplicatorMiscTest extends BaseReplicatorTest {
 
         deleteDb(getTestDatabase());
 
-        assertThrows(IllegalStateException.class, () -> repl.getPendingDocumentIds(getTestCollection()));
+        assertThrows(CouchbaseLiteError.class, () -> repl.getPendingDocumentIds(getTestCollection()));
     }
 
     // CBL-1218
@@ -323,7 +323,7 @@ public class ReplicatorMiscTest extends BaseReplicatorTest {
 
         closeDb(getTestDatabase());
 
-        assertThrows(IllegalStateException.class, () -> repl.isDocumentPending("who-cares", getTestCollection()));
+        assertThrows(CouchbaseLiteError.class, () -> repl.isDocumentPending("who-cares", getTestCollection()));
     }
 
     // CBL-1441

--- a/common/test/java/com/couchbase/lite/internal/ExecutionServiceTest.kt
+++ b/common/test/java/com/couchbase/lite/internal/ExecutionServiceTest.kt
@@ -16,6 +16,7 @@
 package com.couchbase.lite.internal
 
 import com.couchbase.lite.BaseTest
+import com.couchbase.lite.CouchbaseLiteError
 import com.couchbase.lite.LogDomain
 import com.couchbase.lite.internal.exec.CBLExecutor
 import com.couchbase.lite.internal.exec.ClientTask
@@ -349,7 +350,7 @@ class ExecutionServiceTest : BaseTest() {
         barrier.reset()
         exec.execute(runnable)
         barrier.await()
-        assertTrue(fail is IllegalStateException)
+        assertTrue(fail is CouchbaseLiteError)
     }
 
     // If this test fails, it may bring down the entire test process

--- a/common/test/java/com/couchbase/lite/internal/core/C4BaseTest.java
+++ b/common/test/java/com/couchbase/lite/internal/core/C4BaseTest.java
@@ -34,6 +34,7 @@ import org.junit.After;
 import org.junit.Before;
 
 import com.couchbase.lite.BaseTest;
+import com.couchbase.lite.CouchbaseLiteError;
 import com.couchbase.lite.CouchbaseLiteException;
 import com.couchbase.lite.LiteCoreException;
 import com.couchbase.lite.internal.CouchbaseLiteInternal;
@@ -126,7 +127,7 @@ public class C4BaseTest extends BaseTest {
             }
         }
         catch (LiteCoreException e) { throw CouchbaseLiteException.convertException(e); }
-        catch (IOException e) { throw new IllegalStateException("IO error setting up directories", e); }
+        catch (IOException e) { throw new CouchbaseLiteError("IO error setting up directories", e); }
     }
 
     @After

--- a/common/test/java/com/couchbase/lite/internal/core/C4BlobStoreTest.java
+++ b/common/test/java/com/couchbase/lite/internal/core/C4BlobStoreTest.java
@@ -26,6 +26,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.couchbase.lite.CouchbaseLiteError;
 import com.couchbase.lite.CouchbaseLiteException;
 import com.couchbase.lite.LiteCoreException;
 import com.couchbase.lite.internal.fleece.FLSliceResult;
@@ -55,7 +56,7 @@ public class C4BlobStoreTest extends C4BaseTest {
             bogusKey = C4BlobKey.create("sha1-VVVVVVVVVVVVVVVVVVVVVVVVVVU=");
         }
         catch (LiteCoreException e) { throw CouchbaseLiteException.convertException(e); }
-        catch (IOException e) { throw new IllegalStateException("IO error setting up directories", e); }
+        catch (IOException e) { throw new CouchbaseLiteError("IO error setting up directories", e); }
     }
 
     @After

--- a/common/test/java/com/couchbase/lite/internal/core/C4TestUtils.java
+++ b/common/test/java/com/couchbase/lite/internal/core/C4TestUtils.java
@@ -21,6 +21,7 @@ import androidx.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
 
 import com.couchbase.lite.CBLError;
+import com.couchbase.lite.CouchbaseLiteError;
 import com.couchbase.lite.CouchbaseLiteException;
 import com.couchbase.lite.LiteCoreException;
 import com.couchbase.lite.LogDomain;
@@ -87,7 +88,7 @@ public class C4TestUtils {
         catch (LiteCoreException e) {
             try { store.close(); }
             catch (Exception ignore) { }
-            throw new IllegalStateException("Failed deleting blob store", e);
+            throw new CouchbaseLiteError("Failed deleting blob store", e);
         }
     }
 

--- a/common/test/java/com/couchbase/lite/internal/core/PeerBindingTest.kt
+++ b/common/test/java/com/couchbase/lite/internal/core/PeerBindingTest.kt
@@ -12,6 +12,7 @@ package com.couchbase.lite.internal.core
 
 
 import com.couchbase.lite.BaseTest
+import com.couchbase.lite.CouchbaseLiteError
 import com.couchbase.lite.internal.core.peers.TaggedWeakPeerBinding
 import org.junit.Assert
 import org.junit.Test
@@ -51,7 +52,7 @@ class PeerBindingTest {
     fun testBindWithoutKey() {
         val binding = TaggedWeakPeerBinding<Any>()
         try {
-            BaseTest.assertThrows(IllegalStateException::class.java) { binding.bind(4345, object {}) }
+            BaseTest.assertThrows(CouchbaseLiteError::class.java) { binding.bind(4345, object {}) }
         } finally {
             binding.clear()
         }
@@ -67,7 +68,7 @@ class PeerBindingTest {
             val object2 = object {}
 
             binding.bind(keyReserve, object1)
-            BaseTest.assertThrows(IllegalStateException::class.java) { binding.bind(keyReserve, object2) }
+            BaseTest.assertThrows(CouchbaseLiteError::class.java) { binding.bind(keyReserve, object2) }
         } finally {
             binding.clear()
         }

--- a/common/test/java/com/couchbase/lite/internal/sockets/OkHttpSocketTest.kt
+++ b/common/test/java/com/couchbase/lite/internal/sockets/OkHttpSocketTest.kt
@@ -16,6 +16,7 @@
 package com.couchbase.lite.internal.sockets
 
 import com.couchbase.lite.BaseTest
+import com.couchbase.lite.CouchbaseLiteError
 import com.couchbase.lite.internal.core.C4Constants
 import com.couchbase.lite.internal.utils.Fn.TaskThrows
 import okhttp3.MediaType.Companion.toMediaType
@@ -133,7 +134,7 @@ class OkHttpSocketTest : BaseTest() {
     // Core request to open a socket before it is initialized, fails
     @Test
     fun testOpenRemoteBeforeInit() {
-        assertThrows(IllegalStateException::class.java) {
+        assertThrows(CouchbaseLiteError::class.java) {
             OkHttpSocket().openRemote(URI("https://foo.com"), null)
         }
     }
@@ -217,7 +218,7 @@ class OkHttpSocketTest : BaseTest() {
     // Core request to write to a socket before it is initialized, fails
     @Test
     fun testWriteToRemoteBeforeInit() {
-        assertThrows(java.lang.IllegalStateException::class.java) {
+        assertThrows(CouchbaseLiteError::class.java) {
             OkHttpSocket().writeToRemote(ByteArray(1))
         }
     }
@@ -333,7 +334,7 @@ class OkHttpSocketTest : BaseTest() {
     // Core request to close a socket before it is initialized, fails
     @Test
     fun testCloseRemoteBeforeInit() {
-        assertThrows(java.lang.IllegalStateException::class.java) {
+        assertThrows(CouchbaseLiteError::class.java) {
             OkHttpSocket().closeRemote(CloseStatus(1, ""))
         }
     }
@@ -585,7 +586,7 @@ class OkHttpSocketTest : BaseTest() {
     // Remote attempt to open an uninitialized socket fails
     @Test
     fun testOnOpenBeforeInit() {
-        assertThrows(java.lang.IllegalStateException::class.java) {
+        assertThrows(CouchbaseLiteError::class.java) {
             OkHttpSocket().onOpen(MockWS(), mockResponse)
         }
     }
@@ -698,7 +699,7 @@ class OkHttpSocketTest : BaseTest() {
     // Remote attempt to send to an uninitialized socket fails
     @Test
     fun testOnMessageBeforeInit() {
-        assertThrows(IllegalStateException::class.java) {
+        assertThrows(CouchbaseLiteError::class.java) {
             OkHttpSocket().onMessage(MockWS(), "booya")
         }
     }
@@ -847,7 +848,7 @@ class OkHttpSocketTest : BaseTest() {
     // Remote request to close an uninitialized socket fails
     @Test
     fun testOnClosingBeforeInit() {
-        assertThrows(IllegalStateException::class.java) {
+        assertThrows(CouchbaseLiteError::class.java) {
             OkHttpSocket().onClosing(MockWS(), 47, "xyzzy")
         }
     }
@@ -961,7 +962,7 @@ class OkHttpSocketTest : BaseTest() {
     // Remote confirm close on an uninitialized socket fails
     @Test
     fun testOnClosedBeforeInit() {
-        assertThrows(java.lang.IllegalStateException::class.java) {
+        assertThrows(CouchbaseLiteError::class.java) {
             OkHttpSocket().onClosed(MockWS(), 47, "xyzzy")
         }
     }
@@ -1086,7 +1087,7 @@ class OkHttpSocketTest : BaseTest() {
     // Remote failure on an uninitialized socket fails
     @Test
     fun testOnFailureBeforeInit() {
-        assertThrows(java.lang.IllegalStateException::class.java) {
+        assertThrows(CouchbaseLiteError::class.java) {
             OkHttpSocket().onFailure(MockWS(), Exception(), null)
         }
     }

--- a/java/main/java/com/couchbase/lite/CouchbaseLite.java
+++ b/java/main/java/com/couchbase/lite/CouchbaseLite.java
@@ -34,10 +34,10 @@ public final class CouchbaseLite {
      * Initialize CouchbaseLite library. This method MUST be called before using CouchbaseLite.
      * <p>
      * This method expects the current directory to be writeable
-     * and will throw an <code>IllegalStateException</code> if it is not.
+     * and will throw an <code>CouchbaseLiteError</code> if it is not.
      * Use <code>init(boolean, File, File)</code> to specify alternative root and scratch directories.
      *
-     * @throws IllegalStateException on initialization failure
+     * @throws CouchbaseLiteError on initialization failure
      */
     public static void init() { init(false); }
 
@@ -45,13 +45,13 @@ public final class CouchbaseLite {
      * Initialize CouchbaseLite library. This method MUST be called before using CouchbaseLite.
      * <p>
      * This method expects the current directory to be writeable
-     * and will throw an <code>IllegalStateException</code> if it is not.
+     * and will throw an <code>CouchbaseLiteError</code> if it is not.
      * Use <code>init(boolean, File, File)</code> to specify alternative root and scratch directories.
      * Debugging mode is not supported for client code.  Please use it only when advised to do
      * so by Couchbase Support Engineering
      *
      * @param debug true if debugging
-     * @throws IllegalStateException on initialization failure
+     * @throws CouchbaseLiteError on initialization failure
      */
     public static void init(boolean debug) {
         final File curDir = FileUtils.getCurrentDirectory();
@@ -70,7 +70,7 @@ public final class CouchbaseLite {
      * @param debug      true if debugging
      * @param rootDir    default directory for databases
      * @param scratchDir scratch directory for SQLite
-     * @throws IllegalStateException on initialization failure
+     * @throws CouchbaseLiteError on initialization failure
      */
     public static void init(boolean debug, @NonNull File rootDir, @NonNull File scratchDir) {
         CouchbaseLiteInternal.init(debug, rootDir, scratchDir);

--- a/java/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
+++ b/java/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.couchbase.lite.CouchbaseLiteError;
 import com.couchbase.lite.LiteCoreException;
 import com.couchbase.lite.LogDomain;
 import com.couchbase.lite.internal.core.C4;
@@ -100,7 +101,7 @@ public final class CouchbaseLiteInternal {
 
     public static void requireInit(String message) {
         if (!INITIALIZED.get()) {
-            throw new IllegalStateException(message + ".  Did you forget to call CouchbaseLite.init()?");
+            throw new CouchbaseLiteError(message + ".  Did you forget to call CouchbaseLite.init()?");
         }
     }
 


### PR DESCRIPTION
While this change touches a lot of files, it is simple replacement.  All tests pass.

Because CBLError is, at least for now, a subclass of IllegalStateException, there is no change to the API.  Client code that caught the IllegalState will still catch the new CBLErr.