### PR TITLE
Android/vf/3.1.6 vf001

### DIFF
--- a/common/main/cpp/native_flencoder.cc
+++ b/common/main/cpp/native_flencoder.cc
@@ -298,6 +298,9 @@ Java_com_couchbase_lite_internal_fleece_JSONEncoder_finishJSON(JNIEnv *env, jcla
 
     FLSliceResult_Release(result);
 
+    if (json == nullptr)
+        throwError(env, {LiteCoreDomain, kC4ErrorCorruptData});
+
     return json;
 }
 }

--- a/common/main/java/com/couchbase/lite/Array.java
+++ b/common/main/java/com/couchbase/lite/Array.java
@@ -312,6 +312,9 @@ public class Array implements ArrayInterface, FLEncodable, Iterable<Object> {
             internalArray.encodeTo(encoder);
             return encoder.finishJSON();
         }
+        catch (LiteCoreException e) {
+            throw new IllegalStateException("Cannot encode array: " + this, e);
+        }
     }
 
     //---------------------------------------------

--- a/common/main/java/com/couchbase/lite/Dictionary.java
+++ b/common/main/java/com/couchbase/lite/Dictionary.java
@@ -351,6 +351,9 @@ public class Dictionary implements DictionaryInterface, FLEncodable, Iterable<St
             internalDict.encodeTo(encoder);
             return encoder.finishJSON();
         }
+        catch (LiteCoreException e) {
+            throw new IllegalStateException("Cannot encode array: " + this, e);
+        }
     }
 
     //---------------------------------------------

--- a/common/main/java/com/couchbase/lite/Result.java
+++ b/common/main/java/com/couchbase/lite/Result.java
@@ -26,7 +26,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import com.couchbase.lite.internal.DbContext;
 import com.couchbase.lite.internal.core.C4QueryEnumerator;
 import com.couchbase.lite.internal.fleece.FLArrayIterator;
 import com.couchbase.lite.internal.fleece.FLValue;
@@ -38,7 +37,7 @@ import com.couchbase.lite.internal.utils.Preconditions;
 
 /**
  * Result represents a row of result set returned by a Query.
- *
+ * <p>
  * A Result may be referenced <b>only</b> while the ResultSet that contains it is open.
  * An Attempt to reference a Result after calling ResultSet.close on the ResultSet that
  * contains it will throw and IllegalStateException
@@ -49,21 +48,18 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
     // member variables
     //---------------------------------------------
     @NonNull
-    private final ResultSet rs;
+    private final ResultContext context;
     @NonNull
     private final List<FLValue> values;
-    @NonNull
-    private final DbContext context;
     private final long missingColumns;
 
     //---------------------------------------------
     // constructors
     //---------------------------------------------
-    Result(@NonNull ResultSet rs, @NonNull C4QueryEnumerator c4enum, @NonNull DbContext context) {
-        this.rs = rs;
+    Result(@NonNull ResultContext context, @NonNull C4QueryEnumerator c4enum) {
+        this.context = context;
         this.values = extractColumns(c4enum.getColumns());
         this.missingColumns = c4enum.getMissingColumns();
-        this.context = context;
     }
 
     //---------------------------------------------
@@ -80,7 +76,7 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
     @Override
     public int count() {
         assertOpen();
-        return rs.getColumnCount();
+        return getColumnCount();
     }
 
     //---------------------------------------------
@@ -284,7 +280,7 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
     @Override
     public List<String> getKeys() {
         assertOpen();
-        return rs.getColumnNames();
+        return getColumnNames();
     }
 
     /**
@@ -474,7 +470,7 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
         assertOpen();
         final int nVals = values.size();
         final Map<String, Object> dict = new HashMap<>(nVals);
-        for (String name: rs.getColumnNames()) {
+        for (String name: getColumnNames()) {
             final int i = indexForColumnName(name);
             if ((i < 0) || (i >= nVals)) { continue; }
             dict.put(name, values.get(i).asObject());
@@ -491,7 +487,7 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
 
         try (JSONEncoder enc = new JSONEncoder()) {
             enc.beginDict(nVals);
-            for (String columnName: rs.getColumnNames()) {
+            for (String columnName: getColumnNames()) {
                 final int i = indexForColumnName(columnName);
                 if ((i < 0) || (i >= nVals)) { continue; }
 
@@ -500,6 +496,9 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
             }
             enc.endDict();
             return enc.finishJSON();
+        }
+        catch (LiteCoreException e) {
+            throw new IllegalStateException("Cannot encode array: " + this, e);
         }
     }
 
@@ -532,17 +531,12 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
     // private access
     //---------------------------------------------
 
-    private int indexForColumnName(@NonNull String name) {
-        final int index = rs.getColumnIndex(name);
-        if (index < 0) { return -1; }
-        return ((missingColumns & (1L << index)) == 0) ? index : -1;
-    }
 
     @Nullable
     private Object fleeceValueToObject(int index) {
         final FLValue value = values.get(index);
         if (value == null) { return null; }
-        final AbstractDatabase db = Preconditions.assertNotNull(rs.getQuery().getDatabase(), "db");
+        final AbstractDatabase db = Preconditions.assertNotNull(context.getResultSet().getQuery().getDatabase(), "db");
         final MRoot root = new MRoot(context, value, false);
         synchronized (db.getDbLock()) { return root.asNative(); }
     }
@@ -550,9 +544,20 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
     @NonNull
     private List<FLValue> extractColumns(@NonNull FLArrayIterator columns) {
         final List<FLValue> values = new ArrayList<>();
-        final int count = rs.getColumnCount();
+        final int count = getColumnCount();
         for (int i = 0; i < count; i++) { values.add(columns.getValueAt(i)); }
         return values;
+    }
+
+    private int getColumnCount() { return context.getResultSet().getColumnCount(); }
+
+    @NonNull
+    private List<String> getColumnNames() { return context.getResultSet().getColumnNames(); }
+
+    private int indexForColumnName(@NonNull String name) {
+        final int index = context.getResultSet().getColumnIndex(name);
+        if (index < 0) { return -1; }
+        return ((missingColumns & (1L << index)) == 0) ? index : -1;
     }
 
     private boolean isInBounds(int index) { return (index >= 0) && (index < count()); }
@@ -569,7 +574,7 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
     }
 
     private void assertOpen() {
-        if (rs.isClosed()) {
+        if (context.getResultSet().isClosed()) {
             throw new IllegalStateException("Attempt to use a result after its containing ResultSet has been closed");
         }
     }

--- a/common/main/java/com/couchbase/lite/ResultContext.java
+++ b/common/main/java/com/couchbase/lite/ResultContext.java
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2024 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package com.couchbase.lite;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.couchbase.lite.internal.DbContext;
+
+
+public class ResultContext extends DbContext {
+    @NonNull
+    private final ResultSet rs;
+
+    public ResultContext(@Nullable BaseDatabase db, @NonNull ResultSet rs) {
+        super(db);
+        this.rs = rs;
+    }
+
+    @NonNull
+    public ResultSet getResultSet() { return rs; }
+}

--- a/common/main/java/com/couchbase/lite/internal/fleece/JSONEncoder.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/JSONEncoder.java
@@ -17,13 +17,15 @@ package com.couchbase.lite.internal.fleece;
 
 import androidx.annotation.NonNull;
 
+import com.couchbase.lite.LiteCoreException;
+
 
 public final class JSONEncoder extends FLEncoder.ManagedFLEncoder {
 
     public JSONEncoder() { super(newJSONEncoder()); }
 
     @NonNull
-    public String finishJSON() { return withPeerOrThrow(JSONEncoder::finishJSON); }
+    public String finishJSON() throws LiteCoreException { return withPeerOrThrow(JSONEncoder::finishJSON); }
 
     @NonNull
     public byte[] finish() {
@@ -44,5 +46,5 @@ public final class JSONEncoder extends FLEncoder.ManagedFLEncoder {
     static native long newJSONEncoder();
 
     @NonNull
-    static native String finishJSON(long peer);
+    static native String finishJSON(long peer) throws LiteCoreException;
 }


### PR DESCRIPTION
This is the VF for CBSE-16470
I would very much appreciate additional eyes on it.  It does three things:

1. Native JSONEncoder_finishJSON now throws a LiteCore exception instead of returning null.  All of the methods that use it wrap the (checked) exception in (unchecked) IllegalStateException.  No API change; Container toJSON methods cannot return null.
1. The context object that becomes the parent of the tree of children belonging to a ResultSet, now holds a reference to the ResultSet.  There will be references to the ResultSet until the last child goes away
1. The close() method on ResultSet no longer does anything.  Instead the Fleece object is freed by a finalizer.  The finalizer code is insane because Android does not appear to handle the use of locks correctly.