### PR TITLE
Enable logging during initialization

### DIFF
--- a/android/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
+++ b/android/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
@@ -36,6 +36,7 @@ import org.json.JSONObject;
 import com.couchbase.lite.CouchbaseLiteError;
 import com.couchbase.lite.LiteCoreException;
 import com.couchbase.lite.LogDomain;
+import com.couchbase.lite.LogLevel;
 import com.couchbase.lite.R;
 import com.couchbase.lite.internal.connectivity.AndroidConnectivityManager;
 import com.couchbase.lite.internal.core.C4;
@@ -97,7 +98,7 @@ public final class CouchbaseLiteInternal {
 
         C4.debug(debugging);
 
-        Log.initLogging(loadErrorMessages(ctxt));
+        Log.initLogging(loadErrorMessages(ctxt), debugging ? LogLevel.DEBUG : LogLevel.WARNING);
 
         setC4TmpDirPath(FileUtils.verifyDir(scratchDir));
 

--- a/common/main/java/com/couchbase/lite/internal/logging/Log.java
+++ b/common/main/java/com/couchbase/lite/internal/logging/Log.java
@@ -65,7 +65,7 @@ public final class Log {
     /**
      * Setup logging.
      */
-    public static void initLogging(@NonNull Map<String, String> errorMessages) {
+    public static void initLogging(@NonNull Map<String, String> errorMessages, @NonNull LogLevel initLogLevel) {
         initLoggingInternal();
 
         setStandardErrorMessages(Collections.unmodifiableMap(errorMessages));
@@ -74,7 +74,7 @@ public final class Log {
         final ConsoleLogger logger = Database.log.getConsole();
         logger.setLevel(LogLevel.INFO);
         Log.i(LogDomain.DATABASE, CouchbaseLiteInternal.PLATFORM + " Initialized: " + CBLVersion.getVersionInfo());
-        logger.setLevel(LogLevel.WARNING);
+        logger.setLevel(initLogLevel);
     }
 
     /**

--- a/java/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
+++ b/java/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import com.couchbase.lite.CouchbaseLiteError;
 import com.couchbase.lite.LiteCoreException;
 import com.couchbase.lite.LogDomain;
+import com.couchbase.lite.LogLevel;
 import com.couchbase.lite.internal.core.C4;
 import com.couchbase.lite.internal.exec.ExecutionService;
 import com.couchbase.lite.internal.logging.Log;
@@ -79,7 +80,7 @@ public final class CouchbaseLiteInternal {
 
         C4.debug(debugging);
 
-        Log.initLogging(loadErrorMessages());
+        Log.initLogging(loadErrorMessages(), debugging ? LogLevel.DEBUG : LogLevel.WARNING);
 
         setC4TmpDirPath(tmpDir);
 

--- a/java/main/java/com/couchbase/lite/internal/NativeLibrary.java
+++ b/java/main/java/com/couchbase/lite/internal/NativeLibrary.java
@@ -33,6 +33,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.couchbase.lite.CouchbaseLiteError;
+import com.couchbase.lite.LogDomain;
+import com.couchbase.lite.internal.logging.Log;
 
 
 /**
@@ -234,6 +236,8 @@ final class NativeLibrary {
         @NonNull String resDirPath,
         @NonNull File targetDir)
         throws IOException {
+        Log.i(LogDomain.DATABASE, "Copying lib %s from %s to %s", lib, resDirPath, targetDir);
+
         if (!targetDir.exists() && !targetDir.mkdirs()) {
             throw new IOException("Cannot create target directory: " + targetDir.getCanonicalPath());
         }
@@ -241,7 +245,10 @@ final class NativeLibrary {
         final File targetFile = new File(targetDir, lib);
         final String targetPath = targetFile.getCanonicalPath();
 
-        if (targetFile.exists()) { return targetPath; }
+        if (targetFile.exists()) {
+            Log.i(LogDomain.DATABASE, "Extension library previously installed at: %s", targetPath);
+            return targetPath;
+        }
 
         final String resPath = resDirPath + JAVA_PATH_SEPARATOR + lib;
         try (InputStream in = NativeLibrary.class.getResourceAsStream(resPath)) {
@@ -254,6 +261,7 @@ final class NativeLibrary {
             }
         }
 
+        Log.i(LogDomain.DATABASE, "Extension library installed at: %s", targetPath);
         return targetPath;
     }
 


### PR DESCRIPTION
Log Extension Library extraction: debugging Windows and MacOS library load failure for Java