### PR TITLE
CBL-5597: Add ResultContext to ResultSet

### DIFF
--- a/common/main/java/com/couchbase/lite/Result.java
+++ b/common/main/java/com/couchbase/lite/Result.java
@@ -26,7 +26,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import com.couchbase.lite.internal.DbContext;
 import com.couchbase.lite.internal.core.C4QueryEnumerator;
 import com.couchbase.lite.internal.fleece.FLArrayIterator;
 import com.couchbase.lite.internal.fleece.FLEncoder;
@@ -49,21 +48,18 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
     // member variables
     //---------------------------------------------
     @NonNull
-    private final ResultSet rs;
+    private final ResultContext context;
     @NonNull
     private final List<FLValue> values;
-    @NonNull
-    private final DbContext context;
     private final long missingColumns;
 
     //---------------------------------------------
     // constructors
     //---------------------------------------------
-    Result(@NonNull ResultSet rs, @NonNull C4QueryEnumerator c4enum, @NonNull DbContext context) {
-        this.rs = rs;
+    Result(@NonNull ResultContext context, @NonNull C4QueryEnumerator c4enum) {
+        this.context = context;
         this.values = extractColumns(c4enum.getColumns());
         this.missingColumns = c4enum.getMissingColumns();
-        this.context = context;
     }
 
     //---------------------------------------------
@@ -80,7 +76,7 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
     @Override
     public int count() {
         assertOpen();
-        return rs.getColumnCount();
+        return getColumnCount();
     }
 
     //---------------------------------------------
@@ -284,7 +280,7 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
     @Override
     public List<String> getKeys() {
         assertOpen();
-        return rs.getColumnNames();
+        return getColumnNames();
     }
 
     /**
@@ -474,7 +470,7 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
         assertOpen();
         final int nVals = values.size();
         final Map<String, Object> dict = new HashMap<>(nVals);
-        for (String name: rs.getColumnNames()) {
+        for (String name: getColumnNames()) {
             final int i = indexForColumnName(name);
             if ((i < 0) || (i >= nVals)) { continue; }
             dict.put(name, values.get(i).asObject());
@@ -497,7 +493,7 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
 
         try (FLEncoder.JSONEncoder enc = FLEncoder.getJSONEncoder()) {
             enc.beginDict(nVals);
-            for (String columnName: rs.getColumnNames()) {
+            for (String columnName: getColumnNames()) {
                 final int i = indexForColumnName(columnName);
                 if ((i < 0) || (i >= nVals)) { continue; }
 
@@ -541,17 +537,11 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
     // private access
     //---------------------------------------------
 
-    private int indexForColumnName(@NonNull String name) {
-        final int index = rs.getColumnIndex(name);
-        if (index < 0) { return -1; }
-        return ((missingColumns & (1L << index)) == 0) ? index : -1;
-    }
-
     @Nullable
     private Object fleeceValueToObject(int index) {
         final FLValue value = values.get(index);
         if (value == null) { return null; }
-        final AbstractDatabase db = Preconditions.assertNotNull(rs.getQuery().getDatabase(), "db");
+        final AbstractDatabase db = Preconditions.assertNotNull(context.getResultSet().getQuery().getDatabase(), "db");
         final MRoot root = new MRoot(context, value, false);
         synchronized (db.getDbLock()) { return root.asNative(); }
     }
@@ -559,10 +549,22 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
     @NonNull
     private List<FLValue> extractColumns(@NonNull FLArrayIterator columns) {
         final List<FLValue> values = new ArrayList<>();
-        final int count = rs.getColumnCount();
+        final int count = getColumnCount();
         for (int i = 0; i < count; i++) { values.add(columns.getValueAt(i)); }
         return values;
     }
+
+    private int getColumnCount() { return context.getResultSet().getColumnCount(); }
+
+    @NonNull
+    private List<String> getColumnNames() { return context.getResultSet().getColumnNames(); }
+
+    private int indexForColumnName(@NonNull String name) {
+        final int index = context.getResultSet().getColumnIndex(name);
+        if (index < 0) { return -1; }
+        return ((missingColumns & (1L << index)) == 0) ? index : -1;
+    }
+
 
     private boolean isInBounds(int index) { return (index >= 0) && (index < count()); }
 
@@ -578,7 +580,7 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
     }
 
     private void assertOpen() {
-        if (rs.isClosed()) {
+        if (context.getResultSet().isClosed()) {
             throw new CouchbaseLiteError("Attempt to use a result after its containing ResultSet has been closed");
         }
     }

--- a/common/main/java/com/couchbase/lite/ResultContext.java
+++ b/common/main/java/com/couchbase/lite/ResultContext.java
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2024 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package com.couchbase.lite;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.couchbase.lite.internal.DbContext;
+
+
+public class ResultContext extends DbContext {
+    @NonNull
+    private final ResultSet rs;
+
+    public ResultContext(@Nullable BaseDatabase db, @NonNull ResultSet rs) {
+        super(db);
+        this.rs = rs;
+    }
+
+    @NonNull
+    public ResultSet getResultSet() { return rs; }
+}

--- a/common/main/java/com/couchbase/lite/ResultSet.java
+++ b/common/main/java/com/couchbase/lite/ResultSet.java
@@ -25,7 +25,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import com.couchbase.lite.internal.DbContext;
 import com.couchbase.lite.internal.core.C4QueryEnumerator;
 import com.couchbase.lite.internal.logging.Log;
 import com.couchbase.lite.internal.utils.Preconditions;
@@ -68,7 +67,7 @@ public class ResultSet implements Iterable<Result>, AutoCloseable {
     @NonNull
     private final Map<String, Integer> columnNames;
     @NonNull
-    private final DbContext context;
+    private final ResultContext context;
 
     @GuardedBy("lock")
     @Nullable
@@ -88,7 +87,7 @@ public class ResultSet implements Iterable<Result>, AutoCloseable {
         @NonNull Map<String, Integer> cols) {
         this.query = query;
         this.columnNames = cols;
-        this.context = new DbContext(query.getDatabase());
+        this.context = new ResultContext(query.getDatabase(), this);
         this.c4enum = c4enum;
     }
 
@@ -120,7 +119,7 @@ public class ResultSet implements Iterable<Result>, AutoCloseable {
                     return null;
                 }
 
-                return new Result(this, c4enum, context);
+                return new Result(context, c4enum);
             }
             catch (LiteCoreException e) { err = e; }
         }


### PR DESCRIPTION
A new context, the ResultContext, assures that ResultSet components hold references to the ResultSet they comprise.

This is is for the Beta 2 release