### PR TITLE
JAK 3.2.0 beta.2 candidate 2

### DIFF
--- a/android/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
+++ b/android/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
@@ -97,7 +97,7 @@ public final class CouchbaseLiteInternal {
 
         C4.debug(debugging);
 
-        Log.initLogging(loadErrorMessages(ctxt));
+        Log.initLogging(debugging, loadErrorMessages(ctxt));
 
         setC4TmpDirPath(FileUtils.verifyDir(scratchDir));
 

--- a/common/main/java/com/couchbase/lite/internal/logging/Log.java
+++ b/common/main/java/com/couchbase/lite/internal/logging/Log.java
@@ -65,7 +65,7 @@ public final class Log {
     /**
      * Setup logging.
      */
-    public static void initLogging(@NonNull Map<String, String> errorMessages) {
+    public static void initLogging(boolean debugging, @NonNull Map<String, String> errorMessages) {
         initLoggingInternal();
 
         setStandardErrorMessages(Collections.unmodifiableMap(errorMessages));
@@ -74,7 +74,7 @@ public final class Log {
         final ConsoleLogger logger = Database.log.getConsole();
         logger.setLevel(LogLevel.INFO);
         Log.i(LogDomain.DATABASE, CouchbaseLiteInternal.PLATFORM + " Initialized: " + CBLVersion.getVersionInfo());
-        logger.setLevel(LogLevel.WARNING);
+        logger.setLevel(debugging ? LogLevel.DEBUG : LogLevel.WARNING);
     }
 
     /**

--- a/common/test/java/com/couchbase/lite/BaseDbTest.kt
+++ b/common/test/java/com/couchbase/lite/BaseDbTest.kt
@@ -136,16 +136,16 @@ fun readJSONResource(name: String?): String {
 
 abstract class BaseDbTest : BaseTest() {
     protected val testDatabase: Database
-        get() = testDb
+        get() = testDb!!
     protected val testCollection: Collection
-        get() = testCol
+        get() = testCol!!
     protected val testTag: String
-        get() = testTg
+        get() = testTg!!
 
 
-    private lateinit var testDb: Database
-    private lateinit var testCol: Collection
-    private lateinit var testTg: String
+    private var testDb: Database? = null
+    private var testCol: Collection? = null
+    private var testTg: String? = null
 
     @Before
     fun setUpBaseDbTest() {
@@ -153,18 +153,22 @@ abstract class BaseDbTest : BaseTest() {
         Report.log("Created base test DB: $testDatabase")
         assertNotNull(testDatabase)
         assertTrue(testDatabase.isOpen)
-        testCol =
-            testDatabase.createCollection(getUniqueName("test_collection"), getUniqueName("test_scope"))
+        testCol = testDatabase.createCollection(getUniqueName("test_collection"), getUniqueName("test_scope"))
         Report.log("Created base test Collection: $testCollection")
         testTg = getUniqueName("db_test_tag")
     }
 
     @After
     fun tearDownBaseDbTest() {
-        testCol.close()
-        Report.log("Test collection closed: ${testCol.fullName}")
-        eraseDb(testDb)
-        Report.log("Test db erased: ${testDb.name}")
+        testCol?.let {
+            it.close()
+            Report.log("Test collection closed: ${it.fullName}")
+        }
+
+        testDb?.let {
+            eraseDb(it)
+            Report.log("Test db erased: ${it.name}")
+        }
     }
 
     protected fun reopenTestDb() {
@@ -175,7 +179,7 @@ abstract class BaseDbTest : BaseTest() {
         testDb = reopenDb(testDatabase)
 
         testCol = testDatabase.getCollection(cName, cScope)
-            ?: throw AssertionError("Could not create collection ${cScope}.${cName} in database ${testDb.name}")
+            ?: throw AssertionError("Could not create collection ${cScope}.${cName} in database ${testDb!!.name}")
     }
 
     protected fun recreateTestDb() {
@@ -188,7 +192,7 @@ abstract class BaseDbTest : BaseTest() {
         testDb = createDb("base_db")
 
         testCol = testDatabase.getCollection(cName, cScope)
-            ?: throw AssertionError("Could not create collection ${cScope}.${cName} in database ${testDb.name}")
+            ?: throw AssertionError("Could not create collection ${cScope}.${cName} in database ${testDb!!.name}")
     }
 
     protected fun duplicateTestDb(): Pair<Database, Collection> {

--- a/java/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
+++ b/java/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
@@ -79,7 +79,7 @@ public final class CouchbaseLiteInternal {
 
         C4.debug(debugging);
 
-        Log.initLogging(loadErrorMessages());
+        Log.initLogging(debugging, loadErrorMessages());
 
         setC4TmpDirPath(tmpDir);
 


### PR DESCRIPTION
Minor but useful changes used in debugging the VS extension library loader.
- Set initial log level to DEBUG when debugging
- Don't crash tests on @Before method failure