### PR TITLE
CBL-5572: ClientTask executor should not fail on RejectedExecution

### DIFF
--- a/common/main/java/com/couchbase/lite/CouchbaseLiteError.java
+++ b/common/main/java/com/couchbase/lite/CouchbaseLiteError.java
@@ -22,7 +22,7 @@ import androidx.annotation.Nullable;
 public class CouchbaseLiteError extends IllegalStateException {
     public CouchbaseLiteError(@NonNull String msg) { this(msg, null); }
 
-    public CouchbaseLiteError(@NonNull String msg, @Nullable Exception e) {
+    public CouchbaseLiteError(@NonNull String msg, @Nullable Throwable e) {
         super(CouchbaseLiteException.getErrorMessage(msg, e), e);
     }
 }

--- a/common/main/java/com/couchbase/lite/CouchbaseLiteException.java
+++ b/common/main/java/com/couchbase/lite/CouchbaseLiteException.java
@@ -100,12 +100,8 @@ public final class CouchbaseLiteException extends Exception {
     }
 
     @NonNull
-    static String getErrorMessage(@Nullable String msg, @Nullable Exception e) {
-        String errMsg = msg;
-
-        if ((msg == null) && (e != null)) { errMsg = e.getMessage(); }
-
-        return Log.lookupStandardMessage(errMsg);
+    static String getErrorMessage(@Nullable String msg, @Nullable Throwable t) {
+        return Log.lookupStandardMessage(((msg != null) || (t == null)) ? msg : t.getMessage());
     }
 
     private final int code;

--- a/common/main/java/com/couchbase/lite/Expression.java
+++ b/common/main/java/com/couchbase/lite/Expression.java
@@ -832,9 +832,19 @@ public abstract class Expression {
      * @return an IN expression.
      */
     @NonNull
-    public Expression in(@NonNull Expression... expressions) {
-        if (expressions.length <= 0) { throw new IllegalArgumentException("empty 'IN'."); }
-        final Expression aggr = new AggregateExpression(Arrays.asList(expressions));
+    public Expression in(@NonNull Expression... expressions) { return in(Arrays.asList(expressions)); }
+
+    /**
+     * Create an IN expression that evaluates whether or not the current expression is in the
+     * given expressions.
+     *
+     * @param expressions the expression array to evaluate with.
+     * @return an IN expression.
+     */
+    @NonNull
+    public Expression in(@NonNull List<Expression> expressions) {
+        if (expressions.size() <= 0) { throw new IllegalArgumentException("empty 'IN'."); }
+        final Expression aggr = new AggregateExpression(expressions);
         return new BinaryExpression(this, aggr, BinaryExpression.OP_IN);
     }
 

--- a/common/main/java/com/couchbase/lite/internal/exec/ClientTask.java
+++ b/common/main/java/com/couchbase/lite/internal/exec/ClientTask.java
@@ -18,15 +18,11 @@ package com.couchbase.lite.internal.exec;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
-import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import com.couchbase.lite.LogDomain;
-import com.couchbase.lite.internal.logging.Log;
 
 
 /**
@@ -38,9 +34,10 @@ import com.couchbase.lite.internal.logging.Log;
  */
 public class ClientTask<T> {
     private static final CBLExecutor EXECUTOR
-        = new CBLExecutor("Client worker", 4, 8, new SynchronousQueue<>());
+        = new CBLExecutor("Client worker", 1, 4, new ArrayBlockingQueue<>(4, true));
 
     public static void dumpState() {
+        if (AbstractExecutionService.throttled()) { return; }
         EXECUTOR.dumpState();
         AbstractExecutionService.dumpThreads();
     }
@@ -57,24 +54,19 @@ public class ClientTask<T> {
 
     public void execute() { execute(30, TimeUnit.SECONDS); }
 
-    @SuppressWarnings({"PMD.PreserveStackTrace", "PMD.AvoidThrowingRawExceptionTypes"})
     public void execute(long timeout, @NonNull TimeUnit timeUnit) {
         final FutureTask<T> future = new FutureTask<>(task);
         try { EXECUTOR.execute(new InstrumentedTask(future, null)); }
-        catch (RuntimeException e) {
-            Log.w(LogDomain.DATABASE, "Catastrophic executor failure (ClientTask)!", e);
-            if (!AbstractExecutionService.throttled()) { dumpState(); }
-            throw e;
+        catch (Exception e) {
+            dumpState();
+            setFailure(e);
+            return;
         }
 
         // block until complete or timeout
         try { result = future.get(timeout, timeUnit); }
-        catch (InterruptedException | TimeoutException e) { err = e; }
-        catch (ExecutionException e) {
-            final Throwable t = e.getCause();
-            if (!(t instanceof Exception)) { throw new Error("Client task error", t); }
-            err = (Exception) t;
-        }
+        catch (ExecutionException e) { setFailure(e.getCause()); }
+        catch (Exception e) { setFailure(e); }
     }
 
     @Nullable
@@ -82,4 +74,10 @@ public class ClientTask<T> {
 
     @Nullable
     public Exception getFailure() { return err; }
+
+    private void setFailure(@Nullable Throwable t) {
+        if ((t == null) || (err != null)) { return; }
+        if (!(t instanceof Exception)) { throw new IllegalStateException("Client task failed catastrophically", t); }
+        err = (Exception) t;
+    }
 }

--- a/common/test/java/com/couchbase/lite/LiveQueryTest.java
+++ b/common/test/java/com/couchbase/lite/LiveQueryTest.java
@@ -152,7 +152,8 @@ public class LiveQueryTest extends BaseDbTest {
                 }
             });
              ListenerToken ignore2 = query.addChangeListener(
-                 testSerialExecutor, change -> {
+                 testSerialExecutor,
+                 change -> {
                      // even if the other listener finishes running first and iterates through doc-11,
                      // this listener should get an independent rs, thus iterates from the beginning, getting doc-11
                      try (ResultSet rs = change.getResults()) {

--- a/common/test/java/com/couchbase/lite/QueryTest.java
+++ b/common/test/java/com/couchbase/lite/QueryTest.java
@@ -77,6 +77,7 @@ public class QueryTest extends BaseQueryTest {
         }
     }
 
+
     @Test
     public void testQueryGetColumnNameAfter32Items() throws CouchbaseLiteException {
         final String value = getUniqueName("value");


### PR DESCRIPTION
CBL-5574: Less alarming message on ClientTask executor failure
CBL-5573: Replace the SynchronousQueue on the ClientTaskExecutor
Add Expression.in(List<Expression>)
Add "test" for QueryObserver issue
