### PR TITLE
CBL-5672: Prevent unlikely indefinite loop

### DIFF
--- a/common/main/java/com/couchbase/lite/Expression.java
+++ b/common/main/java/com/couchbase/lite/Expression.java
@@ -843,7 +843,7 @@ public abstract class Expression {
      */
     @NonNull
     public Expression in(@NonNull List<Expression> expressions) {
-        if (expressions.size() <= 0) { throw new IllegalArgumentException("empty 'IN'."); }
+        if (expressions.isEmpty()) { throw new IllegalArgumentException("empty 'IN'."); }
         final Expression aggr = new AggregateExpression(expressions);
         return new BinaryExpression(this, aggr, BinaryExpression.OP_IN);
     }

--- a/common/main/java/com/couchbase/lite/internal/core/peers/WeakPeerBinding.java
+++ b/common/main/java/com/couchbase/lite/internal/core/peers/WeakPeerBinding.java
@@ -56,15 +56,19 @@ public abstract class WeakPeerBinding<T> extends PeerBinding<T> {
     @Override
     protected void remove(long key) { bindings.remove(key); }
 
+    @GuardedBy("this")
     @Override
     protected boolean exists(long key) { return bindings.containsKey(key); }
 
+    @GuardedBy("this")
     @VisibleForTesting
     public final synchronized int size() { return bindings.size(); }
 
+    @GuardedBy("this")
     @VisibleForTesting
     public final synchronized void clear() { bindings.clear(); }
 
+    @GuardedBy("this")
     @NonNull
     @VisibleForTesting
     public final synchronized Set<Long> keySet() { return bindings.keySet(); }

--- a/common/main/java/com/couchbase/lite/internal/exec/ClientTask.java
+++ b/common/main/java/com/couchbase/lite/internal/exec/ClientTask.java
@@ -18,7 +18,6 @@ package com.couchbase.lite.internal.exec;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
@@ -78,7 +77,7 @@ public class ClientTask<T> {
 
     private void setFailure(@Nullable Throwable t) {
         if ((t == null) || (err != null)) { return; }
-        if (!(t instanceof Exception)) { throw new IllegalStateException("Client task failed catastrophically", t); }
+        if (!(t instanceof Exception)) { throw new IllegalStateException("Client task error", t); }
         err = (Exception) t;
     }
 }


### PR DESCRIPTION
Fix up ClientTask a bit:
- in the unlikely case that we run out of integer tags, throw an exception
- use tags in the range 3 <= tag < Integer.MAX_VALUE - 1.  Those other numbers are just too easy to find, lying around.
- Fix some annotations and some visibility stuff