### PR TITLE
CBL-5653: Improved ClientTask executor

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/exec/CBLExecutor.java
+++ b/common/main/java/com/couchbase/lite/internal/exec/CBLExecutor.java
@@ -30,8 +30,8 @@ import com.couchbase.lite.internal.support.Log;
 
 
 public class CBLExecutor extends ThreadPoolExecutor {
-    private static final int CPU_COUNT = Runtime.getRuntime().availableProcessors();
-    private static final int POOL_SIZE = Math.max(4, CPU_COUNT - 1);
+    public static final int CPU_COUNT = Runtime.getRuntime().availableProcessors();
+    public static final int POOL_SIZE = Math.max(4, CPU_COUNT - 1);
 
     @NonNull
     private final String name;


### PR DESCRIPTION
Several improvements:
- probably room for as many tasks as the replicator can run at once
- Less hysterical error messages
- *ALL* recoverable errors are now passed to the client  (unfortunately, however, in the case of a replication filter, not all the way to the client)