### PR TITLE
CBL-5691: Fix client side proxy auth

### DIFF
--- a/android/androidTest/java/com/couchbase/lite/PlatformBaseTest.java
+++ b/android/androidTest/java/com/couchbase/lite/PlatformBaseTest.java
@@ -29,6 +29,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ThreadPoolExecutor;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
 import com.couchbase.lite.internal.AndroidExecutionService;
 import com.couchbase.lite.internal.CBLVariantExtensions;
 import com.couchbase.lite.internal.CouchbaseLiteInternal;
@@ -65,16 +68,19 @@ public abstract class PlatformBaseTest implements PlatformTest {
         PLATFORM_DEPENDENT_TESTS = Collections.unmodifiableMap(m);
     }
 
-    static { CouchbaseLite.init(getAppContext(), true); }
-
     static {
         try { Runtime.getRuntime().exec("logcat --prune /" + android.os.Process.myPid()).waitFor(); }
         catch (Exception e) { android.util.Log.w("TEST", "Failed adding to chatty whitelist", e); }
     }
+
     private static Context getAppContext() { return ApplicationProvider.getApplicationContext(); }
 
-    @Override
-    public final void setupPlatform() { }
+    @BeforeClass
+    public static void setUpPlatformBaseTestSuite() { CouchbaseLite.init(getAppContext(), true); }
+
+    @AfterClass
+    public static void tearDownPlatformBaseTestSuite() { }
+
 
     @Override
     public final File getTmpDir() {

--- a/common/main/java/com/couchbase/lite/LiteCoreException.java
+++ b/common/main/java/com/couchbase/lite/LiteCoreException.java
@@ -22,10 +22,10 @@ import androidx.annotation.Nullable;
 /**
  * Internal error in native code.
  */
-// This class is referenced by name, from native code.
+// This class and its constructor are used by reflection.  Don't change it.
 public class LiteCoreException extends Exception {
 
-    // This method is referenced by name, from native code.
+    // This method is used by reflection.  Don't change its signature.
     public static void throwException(int domain, int code, @Nullable String msg) throws LiteCoreException {
         throw new LiteCoreException(domain, code, msg);
     }

--- a/common/main/java/com/couchbase/lite/MutableArray.java
+++ b/common/main/java/com/couchbase/lite/MutableArray.java
@@ -34,7 +34,7 @@ import com.couchbase.lite.internal.utils.JSONUtils;
 /**
  * Mutable access to array data.
  */
-// This class and its constructor are referenced by name, from native code.
+// This class and its constructor are used by reflection.  Don't change it.
 @SuppressWarnings("PMD.TooManyMethods")
 public final class MutableArray extends Array implements MutableArrayInterface {
     //---------------------------------------------

--- a/common/main/java/com/couchbase/lite/Result.java
+++ b/common/main/java/com/couchbase/lite/Result.java
@@ -568,7 +568,7 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
     private boolean isInBounds(int index) { return (0 <= index) && (index < count()); }
 
     private void assertOpen() {
-        if (context.getResultSet().isClosed()) {
+        if (context.isClosed()) {
             throw new CouchbaseLiteError("Attempt to use a result after its containing ResultSet has been closed");
         }
     }

--- a/common/main/java/com/couchbase/lite/internal/ReplicationCollection.java
+++ b/common/main/java/com/couchbase/lite/internal/ReplicationCollection.java
@@ -96,7 +96,7 @@ public final class ReplicationCollection implements AutoCloseable {
 
     //// Native Callbacks
 
-    // This method is called by reflection.  Don't change its signature.
+    // This method is used by reflection.  Don't change its signature.
     // It is called from a native thread that Java has never even heard of...
     static boolean filterCallback(
         long collToken,
@@ -211,7 +211,7 @@ public final class ReplicationCollection implements AutoCloseable {
     // Member Variables
     //-------------------------------------------------------------------------
 
-    // These fields are accessed by reflection.  Don't change them.
+    // These fields are used by reflection.  Don't change them.
 
     public final long token;
 

--- a/common/main/java/com/couchbase/lite/internal/core/C4CollectionObserver.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4CollectionObserver.java
@@ -49,7 +49,7 @@ public final class C4CollectionObserver
     // JNI callback methods
     //-------------------------------------------------------------------------
 
-    // This method is called by reflection.  Don't change its signature.
+    // This method is used by reflection.  Don't change its signature.
     static void callback(long token) {
         Log.d(LogDomain.DATABASE, "C4CollectionObserver.callback @%x", token);
 

--- a/common/main/java/com/couchbase/lite/internal/core/C4DocumentChange.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4DocumentChange.java
@@ -23,7 +23,7 @@ import com.couchbase.lite.internal.logging.Log;
 
 
 public final class C4DocumentChange {
-    // This method is called by reflection.  Don't change its signature.
+    // This method is used by reflection.  Don't change its signature.
     @Nullable
     public static C4DocumentChange createC4DocumentChange(
         @Nullable String docId,

--- a/common/main/java/com/couchbase/lite/internal/core/C4DocumentObserver.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4DocumentObserver.java
@@ -49,7 +49,7 @@ public class C4DocumentObserver extends C4NativePeer {
     // JNI callback methods
     //-------------------------------------------------------------------------
 
-    // This method is called by reflection.  Don't change its signature.
+    // This method is used by reflection.  Don't change its signature.
     static void callback(long token, long seq, @Nullable String docId) {
         Log.d(
             LogDomain.DATABASE,

--- a/common/main/java/com/couchbase/lite/internal/core/C4Log.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Log.java
@@ -35,6 +35,7 @@ import com.couchbase.lite.internal.core.impl.NativeC4Log;
 
 
 // Not final for testing
+// This class and its constructor are used by reflection.  Don't change it.
 public class C4Log {
     public interface NativeImpl {
         void nLog(String domain, int level, String message);
@@ -117,7 +118,7 @@ public class C4Log {
     @NonNull
     private static final AtomicReference<LogLevel> CALLBACK_LEVEL = new AtomicReference<>(LogLevel.NONE);
 
-    // This class and this method are referenced by name, from native code.
+    // This method is used by reflection.  Don't change its signature.
     public static void logCallback(@Nullable String c4Domain, int c4Level, @Nullable String message) {
         get().logInternal((c4Domain == null) ? "???" : c4Domain, c4Level, (message == null) ? "" : message);
     }

--- a/common/main/java/com/couchbase/lite/internal/core/C4QueryObserver.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4QueryObserver.java
@@ -73,7 +73,7 @@ public final class C4QueryObserver extends C4NativePeer {
     // Native callback method
     //-------------------------------------------------------------------------
 
-    // This method is called by reflection.  Don't change its signature.
+    // This method is used by reflection.  Don't change its signature.
     static void onQueryChanged(long token, long results, int domain, int code, @Nullable String message) {
         final C4QueryObserver observer = QUERY_OBSERVER_CONTEXT.getBinding(token);
         if (observer == null) {

--- a/common/main/java/com/couchbase/lite/internal/core/C4Replicator.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Replicator.java
@@ -56,7 +56,7 @@ import com.couchbase.lite.internal.utils.Preconditions;
  * This object must be careful never to forward a call to a native object once that object has been freed.
  * </ol>
  * <p>
- * This class and its members are referenced by name, from native code.
+ * This class and its members are used by reflection.  Don't change it.
  */
 public abstract class C4Replicator extends C4NativePeer {
 
@@ -348,7 +348,7 @@ public abstract class C4Replicator extends C4NativePeer {
     // Native callback methods
     //-------------------------------------------------------------------------
 
-    // This method is called by reflection.  Don't change its signature.
+    // This method is used by reflection.  Don't change its signature.
     static void statusChangedCallback(long token, @Nullable C4ReplicatorStatus status) {
         final C4Replicator c4Repl = BOUND_REPLICATORS.getBinding(token);
         final String id = (c4Repl == null) ? "???@" + token : c4Repl.getReplId();
@@ -359,7 +359,7 @@ public abstract class C4Replicator extends C4NativePeer {
         c4Repl.statusChanged(c4Repl, status);
     }
 
-    // This method is called by reflection.  Don't change its signature.
+    // This method is used by reflection.  Don't change its signature.
     static void documentEndedCallback(long token, boolean pushing, @Nullable C4DocumentEnded... docEnds) {
         final C4Replicator c4Repl = BOUND_REPLICATORS.getBinding(token);
         final String id = (c4Repl == null) ? "???@" + token : c4Repl.getReplId();

--- a/common/main/java/com/couchbase/lite/internal/core/C4Socket.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Socket.java
@@ -130,7 +130,7 @@ public final class C4Socket extends C4NativePeer implements SocketToCore {
     // JNI callback methods
     //-------------------------------------------------------------------------
 
-    // This method is called by reflection.  Don't change its signature.
+    // This method is used by reflection.  Don't change its signature.
     static void open(
         long peer,
         long token,
@@ -155,7 +155,7 @@ public final class C4Socket extends C4NativePeer implements SocketToCore {
 
     // Apparently SpotBugs can't tel that `data` *is* null-checked
     @SuppressFBWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
-    // This method is called by reflection.  Don't change its signature.
+    // This method is used by reflection.  Don't change its signature.
     static void write(long peer, @Nullable byte[] data) {
         final int nBytes = (data == null) ? 0 : data.length;
         Log.d(LOG_DOMAIN, "^C4Socket.write@%x(%d)", peer, nBytes);
@@ -166,13 +166,13 @@ public final class C4Socket extends C4NativePeer implements SocketToCore {
         withSocket(peer, "write", (s, r) -> r.coreWrites(data));
     }
 
-    // This method is called by reflection.  Don't change its signature.
+    // This method is used by reflection.  Don't change its signature.
     static void completedReceive(long peer, long nBytes) {
         Log.d(LOG_DOMAIN, "^C4Socket.completedReceive@%x(%d)", peer, nBytes);
         withSocket(peer, "completedReceive", (s, r) -> r.coreAcksWrite(nBytes));
     }
 
-    // This method is called by reflection.  Don't change its signature.
+    // This method is used by reflection.  Don't change its signature.
     // Called only in NO_FRAMING mode
     static void requestClose(long peer, int status, @Nullable String message) {
         Log.d(LOG_DOMAIN, "^C4Socket.requestClose@%x(%d): '%s'", peer, status, message);
@@ -182,7 +182,7 @@ public final class C4Socket extends C4NativePeer implements SocketToCore {
             (s, r) -> r.coreRequestsClose(new CloseStatus(C4Constants.ErrorDomain.WEB_SOCKET, status, message)));
     }
 
-    // This method is called by reflection.  Don't change its signature.
+    // This method is used by reflection.  Don't change its signature.
     // Called only when not in NO_FRAMING mode
     static void close(long peer) {
         Log.d(LOG_DOMAIN, "^C4Socket.close@%x", peer);

--- a/common/main/java/com/couchbase/lite/internal/fleece/FLSliceResult.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/FLSliceResult.java
@@ -40,14 +40,14 @@ public class FLSliceResult {
     @NonNull
     private final NativeImpl impl;
 
-    // These fields are accessed by reflection.  Don't change them.
+    // These fields are used by reflection.  Don't change them.
     final long base;
     final long size;
 
     //-------------------------------------------------------------------------
     // Constructors
     //-------------------------------------------------------------------------
-    // This method is called by reflection.  Don't change its signature.
+    // This method is used by reflection.  Don't change its signature.
     public FLSliceResult(long base, long size) { this(NATIVE_IMPL, base, size); }
 
     @VisibleForTesting

--- a/common/main/java/com/couchbase/lite/internal/sockets/OkHttpSocket.java
+++ b/common/main/java/com/couchbase/lite/internal/sockets/OkHttpSocket.java
@@ -119,7 +119,7 @@ public final class OkHttpSocket extends WebSocketListener implements SocketToRem
     // This is the OkHttp connection outbound to the remote.
     // Its value has lifecycle null -> NULL_WS -> valid -> null.
     // It could be a simple final var, if the initialization process happened in the other order...
-    // Whenever this value is non-null, we assume that referenced OkHttp WebSocket
+    // Whenever this value is non-null, we assume that the referenced OkHttp WebSocket
     // will do something reasonable with calls.
     private final AtomicReference<WebSocket> toRemote = new AtomicReference<>();
 
@@ -191,7 +191,7 @@ public final class OkHttpSocket extends WebSocketListener implements SocketToRem
     // Request a remote connections
     @Override
     public boolean openRemote(@NonNull URI uri, @Nullable Map<String, Object> options) {
-        Log.d(LOG_DOMAIN, "%s.open: %s, %s", this, uri, options);
+        Log.d(LOG_DOMAIN, "%s.open: %s", this, uri);
         final SocketFromRemote core = getOpenCore();
         if (core == null) { return false; }
 

--- a/common/test/java/com/couchbase/lite/BaseTest.java
+++ b/common/test/java/com/couchbase/lite/BaseTest.java
@@ -204,8 +204,6 @@ public abstract class BaseTest extends PlatformBaseTest {
     public final void setUpBaseTest() {
         setupLogging(">>>>>>>> Test started: " + testName);
 
-        setupPlatform();
-
         testSerialExecutor = new ExecutionService.CloseableExecutor() {
             final ThreadPoolExecutor executor = new ThreadPoolExecutor(
                 1, 1,

--- a/common/test/java/com/couchbase/lite/PlatformTest.java
+++ b/common/test/java/com/couchbase/lite/PlatformTest.java
@@ -39,9 +39,6 @@ public interface PlatformTest {
         }
     }
 
-    /* initialize the platform */
-    void setupPlatform();
-
     /* get a scratch directory */
     File getTmpDir();
 

--- a/common/test/java/com/couchbase/lite/internal/core/C4BaseTest.java
+++ b/common/test/java/com/couchbase/lite/internal/core/C4BaseTest.java
@@ -68,8 +68,8 @@ public class C4BaseTest extends BaseTest {
             throw new AssertionError("Expected CBL exception (" + domain + ", " + code + ") but got:", e);
         }
         final LiteCoreException err = (LiteCoreException) e;
-        if (domain > 0) { assertEquals(domain, err.getDomain()); }
-        if (code > 0) { assertEquals(code, err.getCode()); }
+        if (domain > 0) { assertEquals(domain, err.domain); }
+        if (code > 0) { assertEquals(code, err.code); }
     }
 
     public static void assertThrowsLiteCoreException(int domain, int code, @NonNull Fn.TaskThrows<Exception> block) {

--- a/java/test/java/com/couchbase/lite/PlatformBaseTest.java
+++ b/java/test/java/com/couchbase/lite/PlatformBaseTest.java
@@ -25,6 +25,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ThreadPoolExecutor;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
 import com.couchbase.lite.internal.CBLVariantExtensions;
 import com.couchbase.lite.internal.CouchbaseLiteInternal;
 import com.couchbase.lite.internal.JavaExecutionService;
@@ -64,12 +67,12 @@ public abstract class PlatformBaseTest implements PlatformTest {
                 () -> !Arrays.asList(Locale.getAvailableLocales()).contains(new Locale("sv"))));
     }
 
-    static { CouchbaseLite.init(true); }
-    // instance methods
+    @BeforeClass
+    public static void setUpPlatformBaseTestSuite() { CouchbaseLite.init(true); }
 
+    @AfterClass
+    public static void tearDownPlatformBaseTestSuite() { }
 
-    @Override
-    public final void setupPlatform() { }
 
     @Override
     public final File getTmpDir() {


### PR DESCRIPTION
Also:
CBL-5689: Don't leak basic auth credentials in logs
- Important note on dbConfig.get/setDirectory
- Fix spelling error in dbChange exception
- Get test initialization right
- Standardize reflection warning

this PR is similar to https://github.com/couchbase/couchbase-lite-java-common/pull/287 but not a cherry-pick