### PR TITLE
Several fixes

### DIFF
--- a/common/main/cpp/native_c4observer.cc
+++ b/common/main/cpp/native_c4observer.cc
@@ -118,11 +118,11 @@ bool litecore::jni::initC4Observer(JNIEnv *env) {
 
 /**
  * Callback method from LiteCore C4CollectionObserver
- * @param observer reference to the C4CollectionObserver
- * @param context the token bound to the observer instance.
+ * @param ignore ignored
+ * @param context the token bound to the java C4CollectionObserver instance.
  */
 static void
-c4CollectionObsCallback(C4CollectionObserver *observer, void *context) {
+c4CollectionObsCallback(C4CollectionObserver *ignore, void *context) {
     JNIEnv *env = nullptr;
     jint getEnvStat = gJVM->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6);
 

--- a/common/main/cpp/native_glue.cc
+++ b/common/main/cpp/native_glue.cc
@@ -80,6 +80,7 @@ std::string litecore::jni::JstringToUTF8(JNIEnv *env, jstring jstr) {
     env->ReleaseStringChars(jstr, chars);
     return ret;
 }
+
 // ??? Callers can't handle exceptions so we just ignore errors and return an empty string.
 std::string litecore::jni::JcharArrayToUTF8(JNIEnv *env, jcharArray jcharArray) {
     jsize len = env->GetArrayLength(jcharArray);

--- a/common/main/cpp/native_glue.hh
+++ b/common/main/cpp/native_glue.hh
@@ -59,7 +59,7 @@ namespace litecore {
 
         std::string JcharArrayToUTF8(JNIEnv *env, const jcharArray jcharArray);
 
-        std::string JcharsToUTF8(JNIEnv *env, const jchar * jchars, jsize len);
+        std::string JcharsToUTF8(JNIEnv *env, const jchar *jchars, jsize len);
 
         jstring UTF8ToJstring(JNIEnv *env, const char *s, size_t size);
 

--- a/common/main/java/com/couchbase/lite/FileLogger.java
+++ b/common/main/java/com/couchbase/lite/FileLogger.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import com.couchbase.lite.internal.core.C4Log;
 import com.couchbase.lite.internal.core.CBLVersion;
 import com.couchbase.lite.internal.logging.Log;
+import com.couchbase.lite.internal.utils.Preconditions;
 
 
 /**
@@ -51,6 +52,8 @@ public final class FileLogger implements Logger {
 
     @Override
     public void log(@NonNull LogLevel level, @NonNull LogDomain domain, @NonNull String message) {
+        Preconditions.assertNotNull(level, "level");
+        Preconditions.assertNotNull(domain, "domain");
         if ((config == null) || (level.compareTo(logLevel) < 0)) { return; }
         c4Log.logToCore(domain, level, message);
     }

--- a/common/main/java/com/couchbase/lite/MutableArray.java
+++ b/common/main/java/com/couchbase/lite/MutableArray.java
@@ -34,7 +34,6 @@ import com.couchbase.lite.internal.utils.JSONUtils;
 /**
  * Mutable access to array data.
  */
-// This class and its constructor are used by reflection.  Don't change it.
 @SuppressWarnings("PMD.TooManyMethods")
 public final class MutableArray extends Array implements MutableArrayInterface {
     //---------------------------------------------

--- a/common/main/java/com/couchbase/lite/internal/ReplicationCollection.java
+++ b/common/main/java/com/couchbase/lite/internal/ReplicationCollection.java
@@ -211,22 +211,27 @@ public final class ReplicationCollection implements AutoCloseable {
     // Member Variables
     //-------------------------------------------------------------------------
 
-    // These fields are used by reflection.  Don't change them.
-
+    // This field is used by reflection.  Don't change it.
     public final long token;
 
+    // This field is used by reflection.  Don't change it.
     @NonNull
     public final String scope;
+    // This field is used by reflection.  Don't change it.
     @NonNull
     public final String name;
 
+    // This field is used by reflection.  Don't change it.
     @Nullable
     public final C4Filter c4PushFilter;
+    // This field is used by reflection.  Don't change it.
     @Nullable
     public final C4Filter c4PullFilter;
+
     @Nullable
     public final ConflictResolver resolver;
 
+    // This field is used by reflection.  Don't change it.
     @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
     @VisibleForTesting
     @Nullable

--- a/common/main/java/com/couchbase/lite/internal/core/C4Log.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Log.java
@@ -38,8 +38,8 @@ import com.couchbase.lite.internal.core.impl.NativeC4Log;
 // This class and its constructor are used by reflection.  Don't change it.
 public class C4Log {
     public interface NativeImpl {
-        void nLog(String domain, int level, String message);
-        void nSetLevel(String domain, int level);
+        void nLog(@NonNull String domain, int level, @NonNull String message);
+        void nSetLevel(@NonNull String domain, int level);
         void nSetCallbackLevel(int level);
         int nGetBinaryFileLevel();
         void nSetBinaryFileLevel(int level);
@@ -111,9 +111,8 @@ public class C4Log {
         LOG_LEVEL_TO_C4 = Collections.unmodifiableMap(m);
     }
 
-    @VisibleForTesting
-    @NonNull
-    public static final AtomicReference<C4Log> LOGGER = new AtomicReference<>(new C4Log(new NativeC4Log()));
+     @NonNull
+    private static final AtomicReference<C4Log> LOGGER = new AtomicReference<>(new C4Log(new NativeC4Log()));
 
     @NonNull
     private static final AtomicReference<LogLevel> CALLBACK_LEVEL = new AtomicReference<>(LogLevel.NONE);
@@ -126,13 +125,17 @@ public class C4Log {
         get().logInternal((c4Domain == null) ? "???" : c4Domain, c4Level, (message == null) ? "" : message);
     }
 
+    @VisibleForTesting
+    @NonNull
+    public static C4Log swap(C4Log logger) { return LOGGER.getAndSet(logger); }
+
 
     @NonNull
     private final C4Log.NativeImpl impl;
 
     protected C4Log(@NonNull NativeImpl impl) { this.impl = impl; }
 
-    public final void logToCore(LogDomain domain, LogLevel level, String message) {
+    public final void logToCore(@NonNull LogDomain domain, @NonNull LogLevel level, @NonNull String message) {
         impl.nLog(getC4DomainForLoggingDomain(domain), getC4LevelForLogLevel(level), message);
     }
 
@@ -152,7 +155,9 @@ public class C4Log {
 
     public final void setLevels(int level, @Nullable String... domains) {
         if ((domains == null) || (domains.length <= 0)) { return; }
-        for (String domain: domains) { impl.nSetLevel(domain, level); }
+        for (String domain: domains) {
+            if (domain != null) { impl.nSetLevel(domain, level); }
+        }
     }
 
     @NonNull

--- a/common/main/java/com/couchbase/lite/internal/core/C4Log.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Log.java
@@ -118,13 +118,13 @@ public class C4Log {
     @NonNull
     private static final AtomicReference<LogLevel> CALLBACK_LEVEL = new AtomicReference<>(LogLevel.NONE);
 
+    @NonNull
+    public static C4Log get() { return LOGGER.get(); }
+
     // This method is used by reflection.  Don't change its signature.
     public static void logCallback(@Nullable String c4Domain, int c4Level, @Nullable String message) {
         get().logInternal((c4Domain == null) ? "???" : c4Domain, c4Level, (message == null) ? "" : message);
     }
-
-    @NonNull
-    public static C4Log get() { return LOGGER.get(); }
 
 
     @NonNull

--- a/common/main/java/com/couchbase/lite/internal/core/C4QueryObserver.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4QueryObserver.java
@@ -132,6 +132,9 @@ public final class C4QueryObserver extends C4NativePeer {
             (code == 0) ? null : new LiteCoreException(domain, code, message));
     }
 
+    @VisibleForTesting
+    long getToken() { return token; }
+
     private void closePeer(@Nullable LogDomain domain) {
         releasePeer(
             domain,

--- a/common/main/java/com/couchbase/lite/internal/core/C4Replicator.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Replicator.java
@@ -55,8 +55,6 @@ import com.couchbase.lite.internal.utils.Preconditions;
  * <li/> Calls to the native object:  These should work as long as the peer handle is non-zero.
  * This object must be careful never to forward a call to a native object once that object has been freed.
  * </ol>
- * <p>
- * This class and its members are used by reflection.  Don't change it.
  */
 public abstract class C4Replicator extends C4NativePeer {
 

--- a/common/main/java/com/couchbase/lite/internal/core/C4Socket.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Socket.java
@@ -153,9 +153,9 @@ public final class C4Socket extends C4NativePeer implements SocketToCore {
             });
     }
 
+    // This method is used by reflection.  Don't change its signature.
     // Apparently SpotBugs can't tel that `data` *is* null-checked
     @SuppressFBWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
-    // This method is used by reflection.  Don't change its signature.
     static void write(long peer, @Nullable byte[] data) {
         final int nBytes = (data == null) ? 0 : data.length;
         Log.d(LOG_DOMAIN, "^C4Socket.write@%x(%d)", peer, nBytes);

--- a/common/main/java/com/couchbase/lite/internal/core/impl/NativeC4Log.java
+++ b/common/main/java/com/couchbase/lite/internal/core/impl/NativeC4Log.java
@@ -1,15 +1,17 @@
 package com.couchbase.lite.internal.core.impl;
 
+import androidx.annotation.NonNull;
+
 import com.couchbase.lite.internal.core.C4Log;
 
 
 public final class NativeC4Log implements C4Log.NativeImpl {
 
     @Override
-    public void nLog(String domain, int level, String message) { log(domain, level, message); }
+    public void nLog(@NonNull String domain, int level, @NonNull String message) { log(domain, level, message); }
 
     @Override
-    public void nSetLevel(String domain, int level) { setLevel(domain, level); }
+    public void nSetLevel(@NonNull String domain, int level) { setLevel(domain, level); }
 
     @Override
     public void nSetCallbackLevel(int level) { setCallbackLevel(level); }

--- a/common/main/java/com/couchbase/lite/internal/exec/InstrumentedTask.java
+++ b/common/main/java/com/couchbase/lite/internal/exec/InstrumentedTask.java
@@ -51,18 +51,16 @@ public class InstrumentedTask implements Runnable {
 
     @SuppressWarnings("PMD.AvoidCatchingThrowable")
     public void run() {
+        final long t;
         synchronized (this) {
-            if (startedAt != 0L) {
-                throw new CouchbaseLiteError("Attempt to execute a task multiple times");
-            }
+            t = startedAt;
             startedAt = System.currentTimeMillis();
         }
+        if (t != 0L) { throw new CouchbaseLiteError("This task was started previously at: " + t); }
 
-        try {
-            task.run();
-            finishedAt = System.currentTimeMillis();
-        }
+        try { task.run(); }
         finally {
+            finishedAt = System.currentTimeMillis();
             final Runnable completionTask = onComplete;
             if (completionTask != null) { completionTask.run(); }
             completedAt = System.currentTimeMillis();
@@ -72,11 +70,11 @@ public class InstrumentedTask implements Runnable {
     @NonNull
     @Override
     public String toString() {
-        return "task[#" + id
+        return "task{#" + id
             + " @" + createdAt
-            + "(" + startedAt
-            + "<" + finishedAt
-            + "<" + completedAt
-            + "):" + task + "]";
+            + " (" + startedAt
+            + " >" + finishedAt
+            + " >" + completedAt
+            + "): " + task + "}";
     }
 }

--- a/common/main/java/com/couchbase/lite/internal/exec/SerialExecutor.java
+++ b/common/main/java/com/couchbase/lite/internal/exec/SerialExecutor.java
@@ -145,7 +145,7 @@ class SerialExecutor implements ExecutionService.CloseableExecutor {
         final CountDownLatch latch;
         synchronized (this) {
             executeTask(pendingTasks.remove());
-            latch = (pendingTasks.size() > 0) ? null : stopLatch;
+            latch = (!pendingTasks.isEmpty()) ? null : stopLatch;
         }
 
         if (latch != null) { latch.countDown(); }

--- a/common/test/java/com/couchbase/lite/LogTest.kt
+++ b/common/test/java/com/couchbase/lite/LogTest.kt
@@ -578,7 +578,7 @@ class LogTest : BaseDbTest() {
     fun testInternalLogging() {
         val c4Domain = "foo"
         val testC4Logger = TestC4Logger(c4Domain)
-        val oldLogger = C4Log.LOGGER.getAndSet(testC4Logger)
+        val oldLogger = C4Log.swap(testC4Logger)
         try {
             testC4Logger.reset()
             QueryBuilder.select(SelectResult.expression(Meta.id))
@@ -603,7 +603,7 @@ class LogTest : BaseDbTest() {
             assertEquals(actualMinLevel, testC4Logger.minLevel)
         } finally {
             testC4Logger.setLevels(C4TestUtils.getLogLevel(c4Domain), c4Domain)
-            C4Log.LOGGER.set(oldLogger)
+            C4Log.swap(oldLogger)
         }
     }
 

--- a/common/test/java/com/couchbase/lite/LogTest.kt
+++ b/common/test/java/com/couchbase/lite/LogTest.kt
@@ -574,8 +574,6 @@ class LogTest : BaseDbTest() {
         assertTrue(customLogger.content.contains("[{\"hebrew\":\"$hebrew\"}]"))
     }
 
-    // Verify that we can set the level for log domains that the platform doesn't recognize.
-    // !!! I don't think this test is actually testing anything.
     @Test
     fun testInternalLogging() {
         val c4Domain = "foo"

--- a/common/test/java/com/couchbase/lite/internal/core/C4QueryObserverTest.kt
+++ b/common/test/java/com/couchbase/lite/internal/core/C4QueryObserverTest.kt
@@ -71,9 +71,11 @@ class C4QueryObserverTest : C4BaseTest() {
                 result?.close()
             })
 
-        obs.queryChanged(5L, 0, 0, null)
-        obs.queryChanged(5L, 0, 0, null)
-        obs.queryChanged(5L, 0, 0, null)
+
+        val token = obs.token
+        C4QueryObserver.onQueryChanged(token, 5L, 0, 0, null)
+        C4QueryObserver.onQueryChanged(token, 5L, 0, 0, null)
+        C4QueryObserver.onQueryChanged(token, 5L, 0, 0, null)
 
         assertEquals(3, i)
     }


### PR DESCRIPTION
This is bigger than it should be.  Sorry about that.  The native crash is the biggest fix.  The ClientTask fix is more contained but, perhaps, more important.  The rest is just preening.

CBL-5729: Prevent native crash on unknown log domain
CBL-5714: API Doc: Can't start a replicator inside a batch block
CBL-5658: Tune the ClientTask executor
CBL-5651: Tests for LiteCore callbacks
