### PR TITLE
CBL-5678: set state to CLOSING in coreRequestClose

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
+++ b/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
@@ -419,7 +419,7 @@ public abstract class AbstractCBLWebSocket implements SocketFromCore, SocketFrom
     public final void coreRequestsClose(@NonNull CloseStatus status) {
         Log.d(LOG_DOMAIN, "%s.coreRequestsClose: %s", this, status);
 
-        if (!assertState(SocketState.OPENING, SocketState.OPEN, SocketState.CLOSING)) { return; }
+        if (!changeState(SocketState.CLOSING)) { return; }
 
         // We've told Core to leave the connection to us, so it might pass us the HTTP status
         // If it does, we need to convert it to a WS status for the other side.

--- a/common/test/java/com/couchbase/lite/BaseReplicatorTest.kt
+++ b/common/test/java/com/couchbase/lite/BaseReplicatorTest.kt
@@ -127,7 +127,11 @@ abstract class BaseReplicatorTest : BaseDbTest() {
     @After
     fun tearDownBaseReplicatorTest() {
         targetCollection.close()
-        replicators.forEach { it.close() }
+
+        val repls = replicators.toList()
+        replicators.clear()
+        repls.forEach { it.close() }
+
         eraseDb(targetDatabase)
     }
 

--- a/common/test/java/com/couchbase/lite/LoadTest.kt
+++ b/common/test/java/com/couchbase/lite/LoadTest.kt
@@ -32,8 +32,8 @@ class LoadTest : BaseDbTest() {
     companion object {
         private val DEVICE_SPEED_MULTIPLIER = mapOf(
             // java devices
-            "lin" to 33,
-            "mac" to 40,
+            "lin" to 50,
+            "mac" to 70,
             "win" to 120,
 
             // android on jenkins

--- a/common/test/java/com/couchbase/lite/internal/core/C4QueryBaseTest.java
+++ b/common/test/java/com/couchbase/lite/internal/core/C4QueryBaseTest.java
@@ -35,7 +35,9 @@ public class C4QueryBaseTest extends C4BaseTest {
 
     @After
     public final void tearDownC4QueryBaseTest() {
-        if (query != null) { query.close(); }
+        final C4Query q = query;
+        query = null;
+        if (q != null) { q.close(); }
     }
 
     protected final void compileSelect(String json) throws LiteCoreException {
@@ -64,7 +66,7 @@ public class C4QueryBaseTest extends C4BaseTest {
         json.append(c4Collection.getName()).append("'}],");
         json.append("\"WHERE\": ");
         json.append(whereExpr);
-        if (sortExpr != null && sortExpr.length() > 0) {
+        if ((sortExpr != null) && !sortExpr.isEmpty()) {
             json.append(", \"ORDER_BY\": ");
             json.append(sortExpr);
         }

--- a/common/test/java/com/couchbase/lite/internal/core/C4SocketTest.kt
+++ b/common/test/java/com/couchbase/lite/internal/core/C4SocketTest.kt
@@ -26,6 +26,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -85,11 +86,11 @@ open class MockImpl : C4Socket.NativeImpl {
 }
 
 class C4SocketTest : BaseTest() {
-    @After
-    fun tearDownC4SocketTest() {
-        C4Socket.BOUND_SOCKETS.clear()
-    }
+    @Before
+    fun setupC4SocketTest() = C4Socket.BOUND_SOCKETS.clear()
 
+    @After
+    fun tearDownC4SocketTest() = C4Socket.BOUND_SOCKETS.clear()
 
     ////////////////  S T A T I C   U T I L I T I E S   ////////////////
 


### PR DESCRIPTION
Although the only ticketable change in this PR, it is not the biggest change.  In addition:

- [Workaround for CBL-5780: Listeners cani't be stopped.](https://github.com/couchbase/couchbase-lite-java-common/commit/28c871aae3e9ba0e4aa4f33aa8b5e13678f8fbae)
- Fix a regression caused by test time-out timer that doubled the time that it took to run a test.