### PR TITLE
Autoclosable FLSliceResult

### DIFF
--- a/common/jni_android.ld
+++ b/common/jni_android.ld
@@ -179,6 +179,7 @@ CBL {
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_endDict;
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish;
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish2;
+        Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish3;
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finishJSON;
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_free;
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_newFleeceEncoder;
@@ -195,6 +196,7 @@ CBL {
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_writeStringChars;
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_writeValue;
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLSliceResult_getBuf;
+        Java_com_couchbase_lite_internal_fleece_impl_NativeFLSliceResult_release;
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asArray;
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asBool;
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asData;

--- a/common/main/cpp/com_couchbase_lite_internal_core_impl_NativeC4Blob.h
+++ b/common/main/cpp/com_couchbase_lite_internal_core_impl_NativeC4Blob.h
@@ -59,9 +59,9 @@ JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4Blob_getSize
 /*
  * Class:     com_couchbase_lite_internal_core_impl_NativeC4Blob
  * Method:    getContents
- * Signature: (JJ)Lcom/couchbase/lite/internal/fleece/FLSliceResult;
+ * Signature: (JJ)[B
  */
-JNIEXPORT jobject
+JNIEXPORT jbyteArray
 JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4Blob_getContents
         (JNIEnv *, jclass, jlong, jlong);
 

--- a/common/main/cpp/com_couchbase_lite_internal_fleece_impl_NativeFLEncoder.h
+++ b/common/main/cpp/com_couchbase_lite_internal_fleece_impl_NativeFLEncoder.h
@@ -179,6 +179,15 @@ JNIEXPORT jobject
 JNICALL Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish2
         (JNIEnv * , jclass, jlong);
 
+/*
+ * Class:     com_couchbase_lite_internal_fleece_impl_NativeFLEncoder
+ * Method:    finish3
+ * Signature: (J)Lcom/couchbase/lite/internal/fleece/FLSliceResult
+ */
+JNIEXPORT jobject
+JNICALL Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish3
+        (JNIEnv * , jclass, jlong);
+
 // ----------------------------------------------------------------------------
 // JsonEncoder
 // ----------------------------------------------------------------------------

--- a/common/main/cpp/com_couchbase_lite_internal_fleece_impl_NativeFleece.h
+++ b/common/main/cpp/com_couchbase_lite_internal_fleece_impl_NativeFleece.h
@@ -326,6 +326,7 @@ JNICALL Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_json5toJson
 // ----------------------------------------------------------------------------
 // NativeFLSliceResult
 // ----------------------------------------------------------------------------
+
 /*
  * Class:     com_couchbase_lite_internal_fleece_impl_NativeFLSliceResult
  * Method:    getBuf
@@ -334,6 +335,15 @@ JNICALL Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_json5toJson
 JNIEXPORT jbyteArray
 JNICALL Java_com_couchbase_lite_internal_fleece_impl_NativeFLSliceResult_getBuf
         (JNIEnv * , jclass, jlong, jlong);
+
+/*
+ * Class:     com_couchbase_lite_internal_fleece_impl_NativeFLSliceResult
+ * Method:    release
+ * Signature: (JJ)V
+ */
+JNIEXPORT void
+JNICALL Java_com_couchbase_lite_internal_fleece_impl_NativeFLSliceResult_release(
+        JNIEnv *, jclass, jlong, jlong);
 
 #ifdef __cplusplus
 }

--- a/common/main/cpp/native_c4blobstore.cc
+++ b/common/main/cpp/native_c4blobstore.cc
@@ -100,9 +100,9 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Blob_getSize(
 /*
  * Class:     com_couchbase_lite_internal_core_impl_NativeC4Blob
  * Method:    getContents
- * Signature: (JJ)Lcom/couchbase/lite/internal/fleece/FLSliceResult;
+ * Signature: (JJ)[B
  */
-JNIEXPORT jobject JNICALL
+JNIEXPORT jbyteArray JNICALL
 Java_com_couchbase_lite_internal_core_impl_NativeC4Blob_getContents(
         JNIEnv *env,
         jclass ignore,
@@ -116,7 +116,12 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Blob_getContents(
         throwError(env, error);
         return nullptr;
     }
-    return toJavaFLSliceResult(env, res);
+
+    jbyteArray content = toJByteArray(env, res);
+
+    FLSliceResult_Release(res);
+
+    return content;
 }
 
 /*

--- a/common/main/cpp/native_c4replicator.cc
+++ b/common/main/cpp/native_c4replicator.cc
@@ -727,7 +727,6 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Replicator_getPendingDocIds(
     C4CollectionSpec collSpec = {collection, scope};
 
     C4Error error{};
-
     C4SliceResult res = c4repl_getPendingDocIDs((C4Replicator *) repl, collSpec, &error);
     if (error.domain != 0 && error.code != 0) {
         throwError(env, error);

--- a/common/main/cpp/native_c4testutils.cc
+++ b/common/main/cpp/native_c4testutils.cc
@@ -171,7 +171,7 @@ Java_com_couchbase_lite_internal_core_C4TestUtils_encodeJSON(
 
     C4Error error{};
     C4SliceResult res = c4db_encodeJSON((C4Database *) db, (C4Slice) body, &error);
-    if (!res && error.code != 0) {
+    if (error.domain != 0 && error.code != 0) {
         throwError(env, error);
         return nullptr;
     }

--- a/common/main/cpp/native_fleece.cc
+++ b/common/main/cpp/native_fleece.cc
@@ -432,6 +432,7 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_toJSON5(JNIEnv *env, 
 // ----------------------------------------------------------------------------
 // FLSliceResult
 // ----------------------------------------------------------------------------
+
 /*
  * Class:     com_couchbase_lite_internal_fleece_impl_NativeFLSliceResult
  * Method:    getBuf
@@ -445,5 +446,20 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLSliceResult_getBuf(
         jlong size) {
     C4Slice s = {(const void *) base, (size_t) size};
     return toJByteArray(env, s);
+}
+
+/*
+ * Class:     com_couchbase_lite_internal_fleece_impl_NativeFLSliceResult
+ * Method:    release
+ * Signature: (JJ)V
+ */
+JNIEXPORT void JNICALL
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLSliceResult_release(
+        JNIEnv *env,
+        jclass ignore,
+        jlong base,
+        jlong size) {
+    FLSliceResult result = {(const void *) base, (size_t) size};
+    FLSliceResult_Release(result);
 }
 }

--- a/common/main/cpp/native_flencoder.cc
+++ b/common/main/cpp/native_flencoder.cc
@@ -267,7 +267,25 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish2(JNIEnv *env
         throwError(env, {FleeceDomain, error});
         return 0;
     }
+
     return toJavaFLSliceResult(env, res);
+}
+
+/*
+ * Class:     com_couchbase_lite_internal_fleece_impl_NativeFLEncoder
+ * Method:    finish3
+ * Signature: (J)Lcom/couchbase/lite/internal/fleece/FLSliceResult
+ */
+JNIEXPORT jobject JNICALL
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish3(JNIEnv *env, jclass ignore, jlong jenc) {
+    FLError error = kFLNoError;
+    FLSliceResult res = FLEncoder_Finish((FLEncoder) jenc, &error);
+    if (error != kFLNoError) {
+        throwError(env, {FleeceDomain, error});
+        return 0;
+    }
+
+    return toJavaUnmanagedFLSliceResult(env, res);
 }
 
 /*

--- a/common/main/cpp/native_glue.cc
+++ b/common/main/cpp/native_glue.cc
@@ -121,20 +121,21 @@ std::string litecore::jni::JcharsToUTF8(JNIEnv *env, const jchar *chars, jsize l
 
 
 // Java ArrayList class
-static jclass cls_ArrayList;                     // global class reference
-static jmethodID m_ArrayList_init;               // constructor
-static jmethodID m_ArrayList_add;                // add
+static jclass cls_ArrayList;                      // global class reference
+static jmethodID m_ArrayList_init;                // constructor
+static jmethodID m_ArrayList_add;                 // add
 
 // Java HashSet class
-static jclass cls_HashSet;                       // global class reference
-static jmethodID m_HashSet_init;                 // constructor
-static jmethodID m_HashSet_add;                  // add
+static jclass cls_HashSet;                        // global class reference
+static jmethodID m_HashSet_init;                  // constructor
+static jmethodID m_HashSet_add;                   // add
 
 // Java FLSliceResult class
-static jclass cls_FLSliceResult;                 // global class reference
-static jmethodID m_FLSliceResult_init;           // constructor
-static jfieldID f_FLSliceResult_base;            // field: base
-static jfieldID f_FLSliceResult_size;            // field: size
+static jclass cls_FLSliceResult;                  // global class reference
+static jmethodID m_FLSliceResult_createManaged;   // static constructor
+static jmethodID m_FLSliceResult_createUnmanaged; // static constructor
+static jfieldID f_FLSliceResult_base;             // field: base
+static jfieldID f_FLSliceResult_size;             // field: size
 
 
 static bool initC4Glue(JNIEnv *env) {
@@ -181,8 +182,18 @@ static bool initC4Glue(JNIEnv *env) {
         if (!cls_FLSliceResult)
             return false;
 
-        m_FLSliceResult_init = env->GetMethodID(cls_FLSliceResult, "<init>", "(JJ)V");
-        if (!m_FLSliceResult_init)
+        m_FLSliceResult_createManaged = env->GetStaticMethodID(
+                cls_FLSliceResult,
+                "createManagedSlice",
+                "(JJ)Lcom/couchbase/lite/internal/fleece/FLSliceResult;");
+        if (!m_FLSliceResult_createManaged)
+            return false;
+
+        m_FLSliceResult_createUnmanaged = env->GetStaticMethodID(
+                cls_FLSliceResult,
+                "createUnmanagedSlice",
+                "(JJ)Lcom/couchbase/lite/internal/fleece/FLSliceResult;");
+        if (!m_FLSliceResult_createUnmanaged)
             return false;
 
         f_FLSliceResult_base = env->GetFieldID(cls_FLSliceResult, "base", "J");
@@ -420,7 +431,19 @@ namespace litecore {
         }
 
         jobject toJavaFLSliceResult(JNIEnv *const env, const FLSliceResult &sr) {
-            return env->NewObject(cls_FLSliceResult, m_FLSliceResult_init, (jlong) sr.buf, (jlong) sr.size);
+            return env->CallStaticObjectMethod(
+                    cls_FLSliceResult,
+                    m_FLSliceResult_createManaged,
+                    (jlong) sr.buf,
+                    (jlong) sr.size);
+        }
+
+        jobject toJavaUnmanagedFLSliceResult(JNIEnv *const env, const FLSliceResult &sr) {
+            return env->CallStaticObjectMethod(
+                    cls_FLSliceResult,
+                    m_FLSliceResult_createUnmanaged,
+                    (jlong) sr.buf,
+                    (jlong) sr.size);
         }
 
         FLSliceResult fromJavaFLSliceResult(JNIEnv *const env, jobject jsr) {

--- a/common/main/cpp/native_glue.hh
+++ b/common/main/cpp/native_glue.hh
@@ -140,8 +140,11 @@ namespace litecore {
         // Copy a FLMutableArray of strings to a Java HashSet<String>
         jobject toStringSet(JNIEnv *env, FLMutableArray array);
 
-        // Copy a native FLSliceResult to a Java FLSliceResult
+        // Copy a native FLSliceResult to a Managed Java FLSliceResult
         jobject toJavaFLSliceResult(JNIEnv *const env, const FLSliceResult &sr);
+
+        // Copy a native FLSliceResult to an Unmanaged Java FLSliceResult
+        jobject toJavaUnmanagedFLSliceResult(JNIEnv *const env, const FLSliceResult &sr);
 
         // Copy a Java FLSliceResult to a native FLSliceResult
         FLSliceResult fromJavaFLSliceResult(JNIEnv *const env, jobject jsr);

--- a/common/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/common/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -1493,8 +1493,7 @@ abstract class AbstractDatabase extends BaseDatabase
                 mergedFlags |= C4Constants.RevisionFlags.DELETED;
                 try (FLEncoder enc = getSharedFleeceEncoder()) {
                     enc.writeValue(Collections.emptyMap());
-                    final FLSliceResult mergedBody = enc.finish2();
-                    mergedBodyBytes = mergedBody.getContent();
+                    mergedBodyBytes = enc.finish();
                 }
             }
             else {

--- a/common/main/java/com/couchbase/lite/Blob.java
+++ b/common/main/java/com/couchbase/lite/Blob.java
@@ -622,7 +622,7 @@ public final class Blob implements FLEncodable {
 
         final byte[] newContent;
         try (C4BlobStore blobStore = database.getBlobStore(); C4BlobKey key = C4BlobKey.create(blobDigest)) {
-            newContent = blobStore.getContents(key).getContent();
+            newContent = blobStore.getContents(key);
         }
         catch (LiteCoreException e) {
             final String msg = "Failed to read content from database for digest: " + blobDigest;

--- a/common/main/java/com/couchbase/lite/internal/core/C4BlobStore.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4BlobStore.java
@@ -21,7 +21,6 @@ import androidx.annotation.VisibleForTesting;
 
 import com.couchbase.lite.LiteCoreException;
 import com.couchbase.lite.internal.core.impl.NativeC4Blob;
-import com.couchbase.lite.internal.fleece.FLSliceResult;
 
 
 /**
@@ -31,8 +30,8 @@ public abstract class C4BlobStore extends C4NativePeer {
     public interface NativeImpl {
         long nGetBlobStore(long db) throws LiteCoreException;
         long nGetSize(long peer, long key);
-        @NonNull
-        FLSliceResult nGetContents(long peer, long key) throws LiteCoreException;
+        @Nullable
+        byte[] nGetContents(long peer, long key) throws LiteCoreException;
         @Nullable
         String nGetFilePath(long peer, long key) throws LiteCoreException;
         long nCreate(long peer, byte[] data) throws LiteCoreException;
@@ -108,10 +107,9 @@ public abstract class C4BlobStore extends C4NativePeer {
      * Reads the entire contents of a blob into memory.
      * NOTE: the FLSliceResult returned by this method must be released by the caller
      */
-    @NonNull
-    public FLSliceResult getContents(@NonNull C4BlobKey blobKey) throws LiteCoreException {
-        return this.<FLSliceResult, LiteCoreException>withPeerOrThrow(peer ->
-            impl.nGetContents(peer, blobKey.getHandle()));
+    @Nullable
+    public byte[] getContents(@NonNull C4BlobKey blobKey) throws LiteCoreException {
+        return this.<byte[], LiteCoreException>withPeerOrNull(peer -> impl.nGetContents(peer, blobKey.getHandle()));
     }
 
     /**

--- a/common/main/java/com/couchbase/lite/internal/core/impl/NativeC4Blob.java
+++ b/common/main/java/com/couchbase/lite/internal/core/impl/NativeC4Blob.java
@@ -15,13 +15,12 @@
 //
 package com.couchbase.lite.internal.core.impl;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.couchbase.lite.LiteCoreException;
 import com.couchbase.lite.internal.core.C4BlobKey;
 import com.couchbase.lite.internal.core.C4BlobStore;
-import com.couchbase.lite.internal.fleece.FLSliceResult;
+
 
 @SuppressWarnings("PMD.TooManyMethods")
 public final class NativeC4Blob implements C4BlobKey.NativeImpl, C4BlobStore.NativeImpl {
@@ -41,8 +40,8 @@ public final class NativeC4Blob implements C4BlobKey.NativeImpl, C4BlobStore.Nat
 
     public long nGetSize(long peer, long key) { return getSize(peer, key); }
 
-    @NonNull
-    public FLSliceResult nGetContents(long peer, long key) throws LiteCoreException { return getContents(peer, key); }
+    @Nullable
+    public byte[] nGetContents(long peer, long key) throws LiteCoreException { return getContents(peer, key); }
 
     @Nullable
     public String nGetFilePath(long peer, long key) throws LiteCoreException { return getFilePath(peer, key); }
@@ -96,8 +95,8 @@ public final class NativeC4Blob implements C4BlobKey.NativeImpl, C4BlobStore.Nat
 
     private static native long getSize(long peer, long blobKey);
 
-    @NonNull
-    private static native FLSliceResult getContents(long peer, long blobKey) throws LiteCoreException;
+    @Nullable
+    private static native byte[] getContents(long peer, long blobKey) throws LiteCoreException;
 
     @Nullable
     private static native String getFilePath(long peer, long blobKey) throws LiteCoreException;

--- a/common/main/java/com/couchbase/lite/internal/fleece/FLEncoder.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/FLEncoder.java
@@ -62,6 +62,8 @@ public abstract class FLEncoder extends C4NativePeer {
         @NonNull
         FLSliceResult nFinish2(long peer) throws LiteCoreException;
         @NonNull
+        FLSliceResult nFinish3(long peer) throws LiteCoreException;
+        @NonNull
         String nFinishJSON(long peer) throws LiteCoreException;
         void nFree(long peer);
     }
@@ -338,4 +340,9 @@ public abstract class FLEncoder extends C4NativePeer {
     // NOTE: the FLSliceResult returned by this method must be released by the caller
     @NonNull
     public FLSliceResult finish2() throws LiteCoreException { return impl.nFinish2(getPeer()); }
+
+    // NOTE: We expect the FLSliceResult returned by this method to be handed, immediately,
+    // to someone else (LiteCore) who will release it.  Java does release the memory.
+    @NonNull
+    public FLSliceResult finish3() throws LiteCoreException { return impl.nFinish3(getPeer()); }
 }

--- a/common/main/java/com/couchbase/lite/internal/fleece/impl/NativeFLEncoder.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/impl/NativeFLEncoder.java
@@ -85,6 +85,10 @@ public final class NativeFLEncoder implements FLEncoder.NativeImpl {
 
     @NonNull
     @Override
+    public FLSliceResult nFinish3(long peer) throws LiteCoreException { return finish3(peer); }
+
+    @NonNull
+    @Override
     public String nFinishJSON(long peer) throws LiteCoreException { return finishJSON(peer); }
 
     @Override
@@ -140,4 +144,7 @@ public final class NativeFLEncoder implements FLEncoder.NativeImpl {
 
     @NonNull
     private static native FLSliceResult finish2(long peer) throws LiteCoreException;
+
+    @NonNull
+    private static native FLSliceResult finish3(long peer) throws LiteCoreException;
 }

--- a/common/main/java/com/couchbase/lite/internal/fleece/impl/NativeFLSliceResult.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/impl/NativeFLSliceResult.java
@@ -26,10 +26,15 @@ public final class NativeFLSliceResult implements FLSliceResult.NativeImpl {
     @Nullable
     public byte[]  nGetBuf(long base, long size) { return getBuf(base, size); }
 
+    @Override
+    public void nRelease(long base, long size) { release(base, size); }
+
     //-------------------------------------------------------------------------
     // Native methods
     //-------------------------------------------------------------------------
 
     @Nullable
     private static native byte[] getBuf(long base, long size);
+
+    private static native void release(long base, long size);
 }

--- a/common/test/java/com/couchbase/lite/internal/core/C4QueryBaseTest.java
+++ b/common/test/java/com/couchbase/lite/internal/core/C4QueryBaseTest.java
@@ -100,7 +100,7 @@ public class C4QueryBaseTest extends C4BaseTest {
 
     protected final C4QueryEnumerator runQuery(@NonNull C4Query query)
         throws LiteCoreException {
-        return query.run(new FLSliceResult(0, 0));
+        return query.run(FLSliceResult.createTestSlice());
     }
 
     protected final List<List<C4FullTextMatch>> runFTS() throws LiteCoreException {

--- a/common/test/java/com/couchbase/lite/mock/ReplicatorMocks.kt
+++ b/common/test/java/com/couchbase/lite/mock/ReplicatorMocks.kt
@@ -85,7 +85,7 @@ open class MockNativeReplicator : C4Replicator.NativeImpl {
     override fun nStart(peer: Long, restart: Boolean) = Unit
     override fun nStop(peer: Long) = Unit
     override fun nSetOptions(peer: Long, options: ByteArray?) = Unit
-    override fun nGetPendingDocIds(peer: Long, scope: String, collection: String) = FLSliceResult(0, 0)
+    override fun nGetPendingDocIds(peer: Long, scope: String, collection: String) = FLSliceResult.createTestSlice()
     override fun nIsDocumentPending(peer: Long, id: String, scope: String, collection: String) = true
     override fun nSetProgressLevel(peer: Long, progressLevel: Int) = Unit
     override fun nSetHostReachable(peer: Long, reachable: Boolean) = Unit


### PR DESCRIPTION
FLSliceResult now frees the memory block that it frames, in its finalizer. 

This is the change that will be backported to the 3.2 release.

FLSliceResult is also autoclosable, though there are no calls, at at this point, to its close method: it is all up to the finalizer.

Also eliminated an unnecessary instance of FLSliceResult, in Blob handling: the JNI now just returns the blob contents as a Java byte[].

My apologies for the size of the commit.  All test pass.