### PR TITLE
CBL-5794: FLSliceResult leaks memory

### DIFF
--- a/common/jni_android.ld
+++ b/common/jni_android.ld
@@ -110,7 +110,6 @@ CBL {
         Java_com_couchbase_lite_internal_core_impl_NativeC4Listener_shareDbCollections;
         Java_com_couchbase_lite_internal_core_impl_NativeC4Listener_startHttp;
         Java_com_couchbase_lite_internal_core_impl_NativeC4Listener_startTls;
-        Java_com_couchbase_lite_internal_core_impl_NativeC4Log_getBinaryFileLevel;
         Java_com_couchbase_lite_internal_core_impl_NativeC4Log_log;
         Java_com_couchbase_lite_internal_core_impl_NativeC4Log_setBinaryFileLevel;
         Java_com_couchbase_lite_internal_core_impl_NativeC4Log_setCallbackLevel;

--- a/common/jni_android.ld
+++ b/common/jni_android.ld
@@ -179,6 +179,7 @@ CBL {
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_endDict;
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish;
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish2;
+        Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish3;
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finishJSON;
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_free;
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_newFleeceEncoder;
@@ -195,6 +196,7 @@ CBL {
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_writeStringChars;
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_writeValue;
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLSliceResult_getBuf;
+        Java_com_couchbase_lite_internal_fleece_impl_NativeFLSliceResult_release;
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asArray;
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asBool;
         Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asData;

--- a/common/main/cpp/com_couchbase_lite_internal_core_impl_NativeC4Log.h
+++ b/common/main/cpp/com_couchbase_lite_internal_core_impl_NativeC4Log.h
@@ -19,15 +19,6 @@ JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4Log_log
 
 /*
  * Class:     com_couchbase_lite_internal_core_impl_NativeC4Log
- * Method:    getBinaryFileLevel
- * Signature: ()I
- */
-JNIEXPORT jint
-JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4Log_getBinaryFileLevel
-        (JNIEnv *, jclass);
-
-/*
- * Class:     com_couchbase_lite_internal_core_impl_NativeC4Log
  * Method:    setBinaryFileLevel
  * Signature: (I)V
  */

--- a/common/main/cpp/com_couchbase_lite_internal_fleece_impl_NativeFLEncoder.h
+++ b/common/main/cpp/com_couchbase_lite_internal_fleece_impl_NativeFLEncoder.h
@@ -179,6 +179,15 @@ JNIEXPORT jobject
 JNICALL Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish2
         (JNIEnv * , jclass, jlong);
 
+/*
+ * Class:     com_couchbase_lite_internal_fleece_impl_NativeFLEncoder
+ * Method:    finish3
+ * Signature: (J)Lcom/couchbase/lite/internal/fleece/FLSliceResult
+ */
+JNIEXPORT jobject
+JNICALL Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish3
+        (JNIEnv * , jclass, jlong);
+
 // ----------------------------------------------------------------------------
 // JsonEncoder
 // ----------------------------------------------------------------------------

--- a/common/main/cpp/com_couchbase_lite_internal_fleece_impl_NativeFleece.h
+++ b/common/main/cpp/com_couchbase_lite_internal_fleece_impl_NativeFleece.h
@@ -326,6 +326,7 @@ JNICALL Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_json5toJson
 // ----------------------------------------------------------------------------
 // NativeFLSliceResult
 // ----------------------------------------------------------------------------
+
 /*
  * Class:     com_couchbase_lite_internal_fleece_impl_NativeFLSliceResult
  * Method:    getBuf
@@ -334,6 +335,15 @@ JNICALL Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_json5toJson
 JNIEXPORT jbyteArray
 JNICALL Java_com_couchbase_lite_internal_fleece_impl_NativeFLSliceResult_getBuf
         (JNIEnv * , jclass, jlong, jlong);
+
+/*
+ * Class:     com_couchbase_lite_internal_fleece_impl_NativeFLSliceResult
+ * Method:    release
+ * Signature: (JJ)V
+ */
+JNIEXPORT void
+JNICALL Java_com_couchbase_lite_internal_fleece_impl_NativeFLSliceResult_release(
+        JNIEnv *, jclass, jlong, jlong);
 
 #ifdef __cplusplus
 }

--- a/common/main/cpp/native_c4.cc
+++ b/common/main/cpp/native_c4.cc
@@ -294,16 +294,6 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Log_log(
 
 /*
  * Class:     com_couchbase_lite_internal_core_impl_NativeC4Log
- * Method:    getBinaryFileLevel
- * Signature: (V)I
- */
-JNIEXPORT jint JNICALL
-Java_com_couchbase_lite_internal_core_impl_NativeC4Log_getBinaryFileLevel(JNIEnv *env, jclass ignore) {
-    return c4log_binaryFileLevel();
-}
-
-/*
- * Class:     com_couchbase_lite_internal_core_impl_NativeC4Log
  * Method:    setBinaryFileLevel
  * Signature: (I)V
  */

--- a/common/main/cpp/native_c4testutils.cc
+++ b/common/main/cpp/native_c4testutils.cc
@@ -171,7 +171,7 @@ Java_com_couchbase_lite_internal_core_C4TestUtils_encodeJSON(
 
     C4Error error{};
     C4SliceResult res = c4db_encodeJSON((C4Database *) db, (C4Slice) body, &error);
-    if (!res && error.code != 0) {
+    if (error.domain != 0 && error.code != 0) {
         throwError(env, error);
         return nullptr;
     }

--- a/common/main/cpp/native_fleece.cc
+++ b/common/main/cpp/native_fleece.cc
@@ -432,6 +432,7 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_toJSON5(JNIEnv *env, 
 // ----------------------------------------------------------------------------
 // FLSliceResult
 // ----------------------------------------------------------------------------
+
 /*
  * Class:     com_couchbase_lite_internal_fleece_impl_NativeFLSliceResult
  * Method:    getBuf
@@ -445,5 +446,20 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLSliceResult_getBuf(
         jlong size) {
     C4Slice s = {(const void *) base, (size_t) size};
     return toJByteArray(env, s);
+}
+
+/*
+ * Class:     com_couchbase_lite_internal_fleece_impl_NativeFLSliceResult
+ * Method:    release
+ * Signature: (JJ)V
+ */
+JNIEXPORT void JNICALL
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLSliceResult_release(
+        JNIEnv *env,
+        jclass ignore,
+        jlong base,
+        jlong size) {
+    FLSliceResult result = {(const void *) base, (size_t) size};
+    FLSliceResult_Release(result);
 }
 }

--- a/common/main/cpp/native_flencoder.cc
+++ b/common/main/cpp/native_flencoder.cc
@@ -267,7 +267,25 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish2(JNIEnv *env
         throwError(env, {FleeceDomain, error});
         return 0;
     }
+
     return toJavaFLSliceResult(env, res);
+}
+
+/*
+ * Class:     com_couchbase_lite_internal_fleece_impl_NativeFLEncoder
+ * Method:    finish3
+ * Signature: (J)Lcom/couchbase/lite/internal/fleece/FLSliceResult
+ */
+JNIEXPORT jobject JNICALL
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish3(JNIEnv *env, jclass ignore, jlong jenc) {
+    FLError error = kFLNoError;
+    FLSliceResult res = FLEncoder_Finish((FLEncoder) jenc, &error);
+    if (error != kFLNoError) {
+        throwError(env, {FleeceDomain, error});
+        return 0;
+    }
+
+    return toJavaUnmanagedFLSliceResult(env, res);
 }
 
 /*

--- a/common/main/cpp/native_glue.hh
+++ b/common/main/cpp/native_glue.hh
@@ -140,8 +140,11 @@ namespace litecore {
         // Copy a FLMutableArray of strings to a Java HashSet<String>
         jobject toStringSet(JNIEnv *env, FLMutableArray array);
 
-        // Copy a native FLSliceResult to a Java FLSliceResult
+        // Copy a native FLSliceResult to a Managed Java FLSliceResult
         jobject toJavaFLSliceResult(JNIEnv *const env, const FLSliceResult &sr);
+
+        // Copy a native FLSliceResult to an Unmanaged Java FLSliceResult
+        jobject toJavaUnmanagedFLSliceResult(JNIEnv *const env, const FLSliceResult &sr);
 
         // Copy a Java FLSliceResult to a native FLSliceResult
         FLSliceResult fromJavaFLSliceResult(JNIEnv *const env, jobject jsr);

--- a/common/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/common/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -1493,8 +1493,7 @@ abstract class AbstractDatabase extends BaseDatabase
                 mergedFlags |= C4Constants.RevisionFlags.DELETED;
                 try (FLEncoder enc = getSharedFleeceEncoder()) {
                     enc.writeValue(Collections.emptyMap());
-                    final FLSliceResult mergedBody = enc.finish2();
-                    mergedBodyBytes = mergedBody.getContent();
+                    mergedBodyBytes = enc.finish();
                 }
             }
             else {

--- a/common/main/java/com/couchbase/lite/internal/core/C4Log.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Log.java
@@ -40,7 +40,6 @@ public class C4Log {
         void nLog(String domain, int level, String message);
         void nSetLevel(String domain, int level);
         void nSetCallbackLevel(int level);
-        int nGetBinaryFileLevel();
         void nSetBinaryFileLevel(int level);
         void nWriteToBinaryFile(
             String path,
@@ -144,8 +143,6 @@ public class C4Log {
         String header) {
         impl.nWriteToBinaryFile(path, getC4LevelForLogLevel(level), maxRotate, maxSize, plainText, header);
     }
-
-    public final int getFileLogLevel() { return impl.nGetBinaryFileLevel(); }
 
     public final void setFileLogLevel(LogLevel level) { impl.nSetBinaryFileLevel(getC4LevelForLogLevel(level)); }
 

--- a/common/main/java/com/couchbase/lite/internal/core/impl/NativeC4Log.java
+++ b/common/main/java/com/couchbase/lite/internal/core/impl/NativeC4Log.java
@@ -15,9 +15,6 @@ public final class NativeC4Log implements C4Log.NativeImpl {
     public void nSetCallbackLevel(int level) { setCallbackLevel(level); }
 
     @Override
-    public int nGetBinaryFileLevel() { return getBinaryFileLevel(); }
-
-    @Override
     public void nSetBinaryFileLevel(int level) { setBinaryFileLevel(level); }
 
     @Override
@@ -34,8 +31,6 @@ public final class NativeC4Log implements C4Log.NativeImpl {
     private static native void setLevel(String domain, int level);
 
     private static native void setCallbackLevel(int level);
-
-    private static native int getBinaryFileLevel();
 
     private static native void setBinaryFileLevel(int level);
 

--- a/common/main/java/com/couchbase/lite/internal/fleece/FLEncoder.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/FLEncoder.java
@@ -62,6 +62,8 @@ public abstract class FLEncoder extends C4NativePeer {
         @NonNull
         FLSliceResult nFinish2(long peer) throws LiteCoreException;
         @NonNull
+        FLSliceResult nFinish3(long peer) throws LiteCoreException;
+        @NonNull
         String nFinishJSON(long peer) throws LiteCoreException;
         void nFree(long peer);
     }
@@ -335,6 +337,12 @@ public abstract class FLEncoder extends C4NativePeer {
     @NonNull
     public byte[] finish() throws LiteCoreException { return impl.nFinish(getPeer()); }
 
+    // NOTE: the FLSliceResult returned by this method must be released by the caller
     @NonNull
     public FLSliceResult finish2() throws LiteCoreException { return impl.nFinish2(getPeer()); }
+
+    // NOTE: We expect the FLSliceResult returned by this method to be handed, immediately,
+    // to someone else (LiteCore) who will release it.  Java does release the memory.
+    @NonNull
+    public FLSliceResult finish3() throws LiteCoreException { return impl.nFinish3(getPeer()); }
 }

--- a/common/main/java/com/couchbase/lite/internal/fleece/FLSliceResult.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/FLSliceResult.java
@@ -15,46 +15,85 @@
 //
 package com.couchbase.lite.internal.fleece;
 
+import androidx.annotation.GuardedBy;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import com.couchbase.lite.internal.fleece.impl.NativeFLSliceResult;
+import com.couchbase.lite.internal.utils.ClassUtils;
+import com.couchbase.lite.internal.utils.Preconditions;
 
 
 /**
- * This is an interesting object. It frames a piece of memory that LiteCore owns:
- * it just passes us this view: `base` points at the start of the block, base + size is its end.
- * Its C companion is a struct so there is no memory for Java to manage.
- * The JNI just creates one of these whenever LiteCore returns a native FLSliceResult.
+ * This object a frames a piece of native memory for which the recipient (caller) is responsible.
+ * `base` points at the start of the block, base + size is its end. The JNI just creates one of these
+ * whenever LiteCore returns a native FLSliceResult (or its alias, C4SliceResult).
  */
-public class FLSliceResult {
+public abstract class FLSliceResult implements AutoCloseable {
     public interface NativeImpl {
         @Nullable
         byte[] nGetBuf(long base, long size);
+        void nRelease(long base, long size);
+    }
+
+    // We manage the FLSliceResult in almost all cases.
+    // We own the block of memory it frames and must release it.
+    private static final class ManagedFLSliceResult extends FLSliceResult {
+        ManagedFLSliceResult(@NonNull NativeImpl impl, long base, long size) { super(impl, base, size); }
+
+        @Override
+        protected void release(@NonNull NativeImpl impl) { impl.nRelease(base, size); }
+
+        @SuppressWarnings("NoFinalizer")
+        @Override
+        protected void finalize() throws Throwable {
+            try { close(); }
+            finally { super.finalize(); }
+        }
+    }
+
+    // If we are going to return this FLSliceResult to someone else (LiteCore),
+    // though, it will belong to *them* and we must not release it.
+    private static final class UnmanagedFLSliceResult extends FLSliceResult {
+        UnmanagedFLSliceResult(@NonNull NativeImpl impl, long base, long size) { super(impl, base, size); }
+
+        @Override
+        protected void release(@NonNull NativeImpl impl) { }
     }
 
     private static final FLSliceResult.NativeImpl NATIVE_IMPL = new NativeFLSliceResult();
 
+    // This method is used by reflection.  Don't change its signature.
+    @NonNull
+    public static FLSliceResult createManagedSlice(long base, long size) {
+        return new ManagedFLSliceResult(NATIVE_IMPL, base, size);
+    }
 
     @NonNull
-    private final NativeImpl impl;
+    public static FLSliceResult createUnmanagedSlice(long base, long size) {
+        return new UnmanagedFLSliceResult(NATIVE_IMPL, base, size);
+    }
 
-    // These fields are accessed by reflection.  Don't change them.
+    @VisibleForTesting
+    @NonNull
+    public static FLSliceResult createTestSlice() { return createManagedSlice(0, 0); }
+
+
+    // These fields are used by reflection.  Don't change them.
     final long base;
     final long size;
 
-    //-------------------------------------------------------------------------
-    // Constructors
-    //-------------------------------------------------------------------------
-    // This method is called by reflection.  Don't change its signature.
-    public FLSliceResult(long base, long size) { this(NATIVE_IMPL, base, size); }
+    // Not using an AtomicBoolean here because the Android VM
+    // will GC an object's data members before finalizing the object
+    @GuardedBy("this")
+    private NativeImpl impl;
 
-    @VisibleForTesting
-    public FLSliceResult(@NonNull NativeImpl impl, long base, long size) {
+
+    private FLSliceResult(@NonNull NativeImpl impl, long base, long size) {
         this.impl = impl;
         this.base = base;
-        this.size = size;
+        this.size = Preconditions.assertNotNegative(size, "size");
     }
 
     //-------------------------------------------------------------------------
@@ -63,13 +102,34 @@ public class FLSliceResult {
 
     @NonNull
     @Override
-    public String toString() { return "SliceResult{" + size + "@0x0" + Long.toHexString(base); }
+    public String toString() {
+        return "SliceResult{" + ClassUtils.objId(this) + " @0x0" + Long.toHexString(base) + ", " + size + "}";
+    }
 
-    // ???  Exposes a native pointer
+    // ??? Exposes a native pointer
     public long getBase() { return base; }
 
     public long getSize() { return size; }
 
+    // this returns a *copy* of the data
     @Nullable
-    public byte[] getContent() { return impl.nGetBuf(base, size); }
+    public byte[] getContent() {
+        synchronized (this) {
+            if (impl == null) { throw new IllegalStateException("Attempt to use a closed slice"); }
+            return impl.nGetBuf(base, size);
+        }
+    }
+
+    @Override
+    public void close() {
+        final NativeImpl ni;
+        synchronized (this) {
+            ni = impl;
+            impl = null;
+        }
+
+        if (ni != null) { release(ni); }
+    }
+
+    protected abstract void release(@NonNull NativeImpl ni);
 }

--- a/common/main/java/com/couchbase/lite/internal/fleece/impl/NativeFLEncoder.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/impl/NativeFLEncoder.java
@@ -85,6 +85,10 @@ public final class NativeFLEncoder implements FLEncoder.NativeImpl {
 
     @NonNull
     @Override
+    public FLSliceResult nFinish3(long peer) throws LiteCoreException { return finish3(peer); }
+
+    @NonNull
+    @Override
     public String nFinishJSON(long peer) throws LiteCoreException { return finishJSON(peer); }
 
     @Override
@@ -140,4 +144,7 @@ public final class NativeFLEncoder implements FLEncoder.NativeImpl {
 
     @NonNull
     private static native FLSliceResult finish2(long peer) throws LiteCoreException;
+
+    @NonNull
+    private static native FLSliceResult finish3(long peer) throws LiteCoreException;
 }

--- a/common/main/java/com/couchbase/lite/internal/fleece/impl/NativeFLSliceResult.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/impl/NativeFLSliceResult.java
@@ -26,10 +26,15 @@ public final class NativeFLSliceResult implements FLSliceResult.NativeImpl {
     @Nullable
     public byte[]  nGetBuf(long base, long size) { return getBuf(base, size); }
 
+    @Override
+    public void nRelease(long base, long size) { release(base, size); }
+
     //-------------------------------------------------------------------------
     // Native methods
     //-------------------------------------------------------------------------
 
     @Nullable
     private static native byte[] getBuf(long base, long size);
+
+    private static native void release(long base, long size);
 }

--- a/common/test/java/com/couchbase/lite/internal/core/C4QueryBaseTest.java
+++ b/common/test/java/com/couchbase/lite/internal/core/C4QueryBaseTest.java
@@ -98,7 +98,7 @@ public class C4QueryBaseTest extends C4BaseTest {
 
     protected final C4QueryEnumerator runQuery(@NonNull C4Query query)
         throws LiteCoreException {
-        return query.run(new FLSliceResult(0, 0));
+        return query.run(FLSliceResult.createTestSlice());
     }
 
     protected final List<List<C4FullTextMatch>> runFTS() throws LiteCoreException {

--- a/common/test/java/com/couchbase/lite/mock/ReplicatorMocks.kt
+++ b/common/test/java/com/couchbase/lite/mock/ReplicatorMocks.kt
@@ -85,7 +85,7 @@ open class MockNativeReplicator : C4Replicator.NativeImpl {
     override fun nStart(peer: Long, restart: Boolean) = Unit
     override fun nStop(peer: Long) = Unit
     override fun nSetOptions(peer: Long, options: ByteArray?) = Unit
-    override fun nGetPendingDocIds(peer: Long, scope: String, collection: String) = FLSliceResult(0, 0)
+    override fun nGetPendingDocIds(peer: Long, scope: String, collection: String) = FLSliceResult.createTestSlice()
     override fun nIsDocumentPending(peer: Long, id: String, scope: String, collection: String) = true
     override fun nSetProgressLevel(peer: Long, progressLevel: Int) = Unit
     override fun nSetHostReachable(peer: Long, reachable: Boolean) = Unit


### PR DESCRIPTION
FLSliceResult is not freeing the block of memory it frames.  This is an enormous memory leak.

This is a minimal backport of https://github.com/couchbase/couchbase-lite-java-common/pull/296: the SliceResult if freed by the finalizer; not explicitly.

Also removed an unused file logger function