### PR TITLE
CBL-5845: Port LocalRef handling from 3.1

### DIFF
--- a/common/main/cpp/native_c4.cc
+++ b/common/main/cpp/native_c4.cc
@@ -120,23 +120,26 @@ static void logCallback(C4LogDomain domain, C4LogLevel level, const char *fmt, v
 
     jstring message = UTF8ToJstring(env, fmt, strlen(fmt));
     if (!message) {
-        logError("logCallback(): Failed encoding error message");
+        logError("Failed encoding log message");
         return;
     }
 
     const char *domainNameRaw = c4log_getDomainName(domain);
     jstring domainName = UTF8ToJstring(env, domainNameRaw, strlen(domainNameRaw));
+    if (!domainName)
+        domainName = env->NewStringUTF("???");
+
     env->CallStaticVoidMethod(cls_C4Log, m_C4Log_logCallback, domainName, (jint) level, message);
 
-    env->DeleteLocalRef(message);
-    if (domainName)
-        env->DeleteLocalRef(domainName);
-
     if (getEnvStat == JNI_EDETACHED) {
-        if (gJVM->DetachCurrentThread() != 0) {
-            C4Warn("logCallback(): doRequestClose(): Failed to detach the current thread from a Java VM");
+        if (gJVM->DetachCurrentThread() == 0) {
+            return;
         }
+        C4Warn("logCallback(): doRequestClose(): Failed to detach the current thread from a Java VM");
     }
+
+    env->DeleteLocalRef(message);
+    env->DeleteLocalRef(domainName);
 }
 
 /*

--- a/common/main/cpp/native_c4.cc
+++ b/common/main/cpp/native_c4.cc
@@ -41,11 +41,11 @@ static void logCallback(C4LogDomain domain, C4LogLevel level, const char *fmt, v
 
 bool litecore::jni::initC4Logging(JNIEnv *env) {
     jclass localClass = env->FindClass("com/couchbase/lite/internal/core/C4Log");
-    if (!localClass)
+    if (localClass == nullptr)
         return false;
 
     cls_C4Log = reinterpret_cast<jclass>(env->NewGlobalRef(localClass));
-    if (!cls_C4Log)
+    if (cls_C4Log == nullptr)
         return false;
 
     m_C4Log_logCallback = env->GetStaticMethodID(
@@ -53,14 +53,18 @@ bool litecore::jni::initC4Logging(JNIEnv *env) {
             "logCallback",
             "(Ljava/lang/String;ILjava/lang/String;)V");
 
-    if (!m_C4Log_logCallback)
+    if (m_C4Log_logCallback == nullptr)
         return false;
 
     c4log_writeToCallback((C4LogLevel) kC4LogDebug, logCallback, true);
 
-    logError("logging initialized");
+    jniLog("logging initialized");
     return true;
 }
+
+//-------------------------------------------------------------------------
+// Logging
+//-------------------------------------------------------------------------
 
 // The default logging callback writes to stderr, or on Android to __android_log_write.
 // ??? Need to do something better for web service and Windows logging
@@ -87,16 +91,24 @@ void vLogError(const char *fmt, va_list args) {
 #endif
 }
 
-void litecore::jni::logError(const char *fmt, ...) {
+void litecore::jni::jniLog(const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     vLogError(fmt, args);
     va_end(args);
 }
 
+static bool detach(jint getEnvStat) {
+    if (getEnvStat == JNI_EDETACHED) {
+        if (gJVM->DetachCurrentThread() == 0) return true;
+        C4Warn("logCallback(): doRequestClose(): Failed to detach the current thread from a Java VM");
+    }
+    return false;
+}
+
 static void logCallback(C4LogDomain domain, C4LogLevel level, const char *fmt, va_list ignore) {
-    if (!cls_C4Log || !m_C4Log_logCallback) {
-        logError("logCallback(): Logging not initialized");
+    if ((cls_C4Log == nullptr) || (m_C4Log_logCallback == nullptr)) {
+        jniLog("Logger: not initialized");
         return;
     }
 
@@ -105,41 +117,37 @@ static void logCallback(C4LogDomain domain, C4LogLevel level, const char *fmt, v
 
     if (getEnvStat == JNI_EDETACHED) {
         if (attachCurrentThread(&env) != 0) {
-            logError("logCallback(): Failed to attach the current thread to a Java VM)");
+            jniLog("Logger: Failed to attach the current thread for logging");
             return;
         }
     } else if (getEnvStat != JNI_OK) {
-        logError("logCallback(): Failed to get the environment: getEnvStat -> %d", getEnvStat);
+        jniLog("Logger: Could not get the environment: %d", getEnvStat);
         return;
     }
 
     if (env->ExceptionCheck() == JNI_TRUE) {
-        logError("logCallback(): Cannot log while an exception is outstanding");
+        jniLog("Logger: exception outstanding");
+        detach(getEnvStat);
         return;
     }
 
     jstring message = UTF8ToJstring(env, fmt, strlen(fmt));
-    if (!message) {
-        logError("Failed encoding log message");
+    if (message == nullptr) {
+        jniLog("Logger: Failed encoding message");
+        detach(getEnvStat);
         return;
     }
 
     const char *domainNameRaw = c4log_getDomainName(domain);
     jstring domainName = UTF8ToJstring(env, domainNameRaw, strlen(domainNameRaw));
-    if (!domainName)
-        domainName = env->NewStringUTF("???");
+    if (domainName == nullptr) domainName = env->NewStringUTF("???");
 
     env->CallStaticVoidMethod(cls_C4Log, m_C4Log_logCallback, domainName, (jint) level, message);
 
-    if (getEnvStat == JNI_EDETACHED) {
-        if (gJVM->DetachCurrentThread() == 0) {
-            return;
-        }
-        C4Warn("logCallback(): doRequestClose(): Failed to detach the current thread from a Java VM");
+    if (!detach(getEnvStat)) {
+        env->DeleteLocalRef(message);
+        env->DeleteLocalRef(domainName);
     }
-
-    env->DeleteLocalRef(message);
-    env->DeleteLocalRef(domainName);
 }
 
 /*
@@ -255,7 +263,7 @@ JNIEXPORT void JNICALL
 Java_com_couchbase_lite_internal_core_impl_NativeC4_setTempDir(JNIEnv *env, jclass ignore, jstring jtempDir) {
     jstringSlice tempDir(env, jtempDir);
     C4Error error{};
-    auto ok = c4_setTempDir(tempDir, &error);
+    bool ok = c4_setTempDir(tempDir, &error);
     if (!ok && error.code != 0)
         throwError(env, error);
 }
@@ -347,7 +355,7 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Log_writeToBinaryFile(
     };
 
     C4Error error{};
-    auto ok = c4log_writeToBinaryFile(options, &error);
+    bool ok = c4log_writeToBinaryFile(options, &error);
     if (!ok && error.code != 0)
         throwError(env, error);
 }
@@ -379,8 +387,8 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Key_pbkdf2(JNIEnv *env, jclas
     jstringSlice pwd(env, password);
 
     C4EncryptionKey key;
-    if (!c4key_setPasswordSHA1(&key, pwd, kC4EncryptionAES256))
-        return nullptr;
+    bool ok = c4key_setPasswordSHA1(&key, pwd, kC4EncryptionAES256);
+    if (!ok) return nullptr;
 
     int keyLen = sizeof(key.bytes);
     jbyteArray result = env->NewByteArray(keyLen);

--- a/common/main/cpp/native_c4blobstore.cc
+++ b/common/main/cpp/native_c4blobstore.cc
@@ -33,7 +33,7 @@ JNIEXPORT jlong JNICALL
 Java_com_couchbase_lite_internal_core_impl_NativeC4Blob_getBlobStore(JNIEnv *env, jclass ignore, jlong jdb) {
     C4Error error{};
     C4BlobStore *store = c4db_getBlobStore((C4Database *) jdb, &error);
-    if (!store) {
+    if (store == nullptr) {
         throwError(env, error);
         return 0;
     }
@@ -49,7 +49,8 @@ JNIEXPORT jlong JNICALL
 Java_com_couchbase_lite_internal_core_impl_NativeC4Blob_fromString(JNIEnv *env, jclass ignore, jstring jstr) {
     jstringSlice str(env, jstr);
     auto pBlobKey = (C4BlobKey *) ::malloc(sizeof(C4BlobKey));
-    if (!c4blob_keyFromString(str, pBlobKey)) {
+    bool ok = c4blob_keyFromString(str, pBlobKey);
+    if (!ok) {
         ::free(pBlobKey);
         throwError(env, {LiteCoreDomain, 0});
         return 0L;
@@ -164,7 +165,8 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Blob_create(
 
     C4BlobKey blobKey;
     C4Error error{};
-    if (!c4blob_create((C4BlobStore *) jblobstore, ccontents, nullptr, &blobKey, &error)) {
+    bool ok = c4blob_create((C4BlobStore *) jblobstore, ccontents, nullptr, &blobKey, &error);
+    if (!ok) {
         throwError(env, error);
         return 0;
     }
@@ -187,7 +189,8 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Blob_delete(
         jlong jblobkey) {
     auto pBlobKey = (C4BlobKey *) jblobkey;
     C4Error error{};
-    if (!c4blob_delete((C4BlobStore *) jblobstore, *pBlobKey, &error))
+    bool ok = c4blob_delete((C4BlobStore *) jblobstore, *pBlobKey, &error);
+    if (!ok)
         throwError(env, error);
 }
 
@@ -287,7 +290,8 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Blob_seek(
         jlong jstream,
         jlong jposition) {
     C4Error error{};
-    if (!c4stream_seek((C4ReadStream *) jstream, (uint64_t) jposition, &error))
+    bool ok = c4stream_seek((C4ReadStream *) jstream, (uint64_t) jposition, &error);
+    if (!ok)
         throwError(env, error);
 }
 
@@ -320,7 +324,8 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Blob_write(
     jbyteArraySlice bytes(env, false, jbytes, (size_t) jsize, true);
     auto slice = (C4Slice) bytes;
     C4Error error{};
-    if (!c4stream_write((C4WriteStream *) jstream, slice.buf, slice.size, &error))
+    bool ok = c4stream_write((C4WriteStream *) jstream, slice.buf, slice.size, &error);
+    if (!ok)
         throwError(env, error);
 }
 
@@ -344,7 +349,8 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Blob_computeBlobKey(JNIEnv *e
 JNIEXPORT void JNICALL
 Java_com_couchbase_lite_internal_core_impl_NativeC4Blob_install(JNIEnv *env, jclass ignore, jlong jstream) {
     C4Error error{};
-    if (!c4stream_install((C4WriteStream *) jstream, nullptr, &error))
+    bool ok = c4stream_install((C4WriteStream *) jstream, nullptr, &error);
+    if (!ok)
         throwError(env, error);
 }
 

--- a/common/main/cpp/native_c4blobstore.cc
+++ b/common/main/cpp/native_c4blobstore.cc
@@ -317,7 +317,7 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Blob_write(
         jlong jstream,
         jbyteArray jbytes,
         jint jsize) {
-    jbyteArraySlice bytes(env, jbytes, (size_t) jsize);
+    jbyteArraySlice bytes(env, false, jbytes, (size_t) jsize, true);
     auto slice = (C4Slice) bytes;
     C4Error error{};
     if (!c4stream_write((C4WriteStream *) jstream, slice.buf, slice.size, &error))

--- a/common/main/cpp/native_c4collection.cc
+++ b/common/main/cpp/native_c4collection.cc
@@ -34,7 +34,7 @@ static void createIndex(
     jstringSlice queryExpressions(env, jqueryExpressions);
 
     C4Error error{};
-    bool res = c4coll_createIndex(
+    bool ok = c4coll_createIndex(
             (C4Collection *) coll,
             name,
             queryExpressions,
@@ -43,7 +43,7 @@ static void createIndex(
             &options,
             &error);
 
-    if (!res && error.code != 0)
+    if (!ok && error.code != 0)
         throwError(env, error);
 }
 
@@ -65,7 +65,7 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Collection_createCollection(
 
     C4Error error{};
     C4Collection *coll = c4db_createCollection((C4Database *) db, collSpec, &error);
-    if (!coll && error.code != 0) {
+    if ((coll == nullptr) && (error.code != 0)) {
         throwError(env, error);
         return 0;
     }
@@ -120,7 +120,7 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Collection_getDefaultCollecti
         jlong db) {
     C4Error error{};
     C4Collection *coll = c4db_getDefaultCollection((C4Database *) db, &error);
-    if (!coll && error.code != 0) {
+    if ((coll == nullptr) && (error.code != 0)) {
         throwError(env, error);
         return 0;
     }
@@ -161,7 +161,10 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Collection_free(
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL
-Java_com_couchbase_lite_internal_core_impl_NativeC4Collection_getDocumentCount(JNIEnv *env, jclass ignore, jlong coll) {
+Java_com_couchbase_lite_internal_core_impl_NativeC4Collection_getDocumentCount(
+        JNIEnv *env,
+        jclass ignore,
+        jlong coll) {
     return (jlong) c4coll_getDocumentCount((C4Collection *) coll);
 }
 
@@ -223,8 +226,8 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Collection_purgeDoc(
     jstringSlice docId(env, jDocId);
 
     C4Error error{};
-    bool purged = c4coll_purgeDoc((C4Collection *) coll, docId, &error);
-    if (!purged && error.code != 0)
+    bool ok = c4coll_purgeDoc((C4Collection *) coll, docId, &error);
+    if (!ok && error.code != 0)
         throwError(env, error);
 }
 
@@ -357,8 +360,8 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Collection_deleteIndex(
     jstringSlice name(env, jName);
 
     C4Error error{};
-    bool res = c4coll_deleteIndex((C4Collection *) coll, name, &error);
-    if (!res && error.code != 0)
+    bool ok = c4coll_deleteIndex((C4Collection *) coll, name, &error);
+    if (!ok && error.code != 0)
         throwError(env, error);
 }
 }

--- a/common/main/cpp/native_c4document.cc
+++ b/common/main/cpp/native_c4document.cc
@@ -83,7 +83,7 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Document_createFromSlice(
     C4Slice body{(const void *) jbodyPtr, (size_t) jbodySize};
     C4Error error{};
     C4Document *doc = c4coll_createDoc((C4Collection *) jcollection, docID, body, (unsigned) flags, &error);
-    if (!doc) {
+    if (doc == nullptr) {
         throwError(env, error);
         return 0;
     }
@@ -99,7 +99,10 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Document_createFromSlice(
  * Signature: (J)I
  */
 JNIEXPORT jint JNICALL
-Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getFlags(JNIEnv *ignore1, jclass ignore2, jlong jdoc) {
+Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getFlags(
+        JNIEnv *ignore1,
+        jclass ignore2,
+        jlong jdoc) {
     auto doc = (C4Document *) jdoc;
     return doc->flags;
 }
@@ -110,7 +113,10 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getFlags(JNIEnv *ign
  * Signature: (J)Ljava/lang/String;
  */
 JNIEXPORT jstring JNICALL
-Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getRevID(JNIEnv *env, jclass ignore, jlong jdoc) {
+Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getRevID(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jdoc) {
     auto doc = (C4Document *) jdoc;
     return toJString(env, doc->revID);
 }
@@ -121,7 +127,10 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getRevID(JNIEnv *env
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL
-Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getSequence(JNIEnv *ignore1, jclass ignore2, jlong jdoc) {
+Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getSequence(
+        JNIEnv *ignore1,
+        jclass ignore2,
+        jlong jdoc) {
     auto doc = (C4Document *) jdoc;
     return doc->sequence;
 }
@@ -135,7 +144,10 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getSequence(JNIEnv *
  * Signature: (J)I
  */
 JNIEXPORT jint JNICALL
-Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getSelectedFlags(JNIEnv *ignore1, jclass ignore2, jlong jdoc) {
+Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getSelectedFlags(
+        JNIEnv *ignore1,
+        jclass ignore2,
+        jlong jdoc) {
     auto doc = (C4Document *) jdoc;
     return doc->selectedRev.flags;
 }
@@ -146,7 +158,10 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getSelectedFlags(JNI
  * Signature: (J)Ljava/lang/String;
  */
 JNIEXPORT jstring JNICALL
-Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getSelectedRevID(JNIEnv *env, jclass ignore, jlong jdoc) {
+Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getSelectedRevID(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jdoc) {
     auto doc = (C4Document *) jdoc;
     return toJString(env, doc->selectedRev.revID);
 }
@@ -157,10 +172,13 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getSelectedRevID(JNI
  * Signature: (J)J;
  */
 JNIEXPORT jlong JNICALL
-Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getTimestamp(JNIEnv *ignore1, jclass ignore2, jlong jdoc) {
+Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getTimestamp(
+        JNIEnv *ignore1,
+        jclass ignore2,
+        jlong jdoc) {
     auto doc = (C4Document *) jdoc;
-    auto revId = doc->selectedRev.revID;
-    return  c4rev_getTimestamp(revId);
+    FLHeapSlice revId = doc->selectedRev.revID;
+    return c4rev_getTimestamp(revId);
 }
 
 /*
@@ -169,7 +187,10 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getTimestamp(JNIEnv 
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL
-Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getSelectedSequence(JNIEnv *ignore1, jclass ignore2, jlong jdoc) {
+Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getSelectedSequence(
+        JNIEnv *ignore1,
+        jclass ignore2,
+        jlong jdoc) {
     auto doc = (C4Document *) jdoc;
     return doc->selectedRev.sequence;
 }
@@ -180,7 +201,10 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getSelectedSequence(
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL
-Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getSelectedBody2(JNIEnv *ignore1, jclass ignore2, jlong jdoc) {
+Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getSelectedBody2(
+        JNIEnv *ignore1,
+        jclass ignore2,
+        jlong jdoc) {
     auto doc = (C4Document *) jdoc;
     FLDict root = nullptr;
     C4Slice body = c4doc_getRevisionBody(doc);
@@ -204,7 +228,8 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Document_selectNextLeafRevisi
         jboolean jincludeDeleted,
         jboolean jwithBody) {
     C4Error error{};
-    if (!c4doc_selectNextLeafRevision((C4Document *) jdoc, jincludeDeleted, jwithBody, &error))
+    bool ok = c4doc_selectNextLeafRevision((C4Document *) jdoc, jincludeDeleted, jwithBody, &error);
+    if (!ok)
         throwError(env, error);
 }
 
@@ -227,7 +252,8 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Document_resolveConflict(
     jbyteArraySlice mergedBody(env, jMergedBody);
     auto revisionFlag = (C4RevisionFlags) jMergedFlags;
     C4Error error{};
-    if (!c4doc_resolveConflict((C4Document *) jdoc, winningRevID, losingRevID, mergedBody, revisionFlag, &error))
+    bool ok = c4doc_resolveConflict((C4Document *) jdoc, winningRevID, losingRevID, mergedBody, revisionFlag, &error);
+    if (!ok)
         throwError(env, error);
 }
 
@@ -254,7 +280,7 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Document_update2(
 
     C4Error error{};
     C4Document *newDoc = c4doc_update((C4Document *) jdoc, body, (unsigned) flags, &error);
-    if (!newDoc) {
+    if (newDoc == nullptr) {
         throwError(env, error);
         return 0;
     }
@@ -274,7 +300,8 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Document_save(
         jlong jdoc,
         jint maxRevTreeDepth) {
     C4Error error{};
-    if (!c4doc_save((C4Document *) jdoc, (uint16_t) maxRevTreeDepth, &error))
+    bool ok = c4doc_save((C4Document *) jdoc, (uint16_t) maxRevTreeDepth, &error);
+    if (!ok)
         throwError(env, error);
 }
 
@@ -293,7 +320,7 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Document_bodyAsJSON(
         jboolean canonical) {
     C4Error error{};
     C4StringResult result = c4doc_bodyAsJSON((C4Document *) jdoc, canonical, &error);
-    if (error.code != 0) {
+    if (!result && error.code != 0) {
         throwError(env, error);
         return nullptr;
     }
@@ -311,7 +338,10 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Document_bodyAsJSON(
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL
-Java_com_couchbase_lite_internal_core_impl_NativeC4Document_free(JNIEnv *ignore1, jclass ignore2, jlong jdoc) {
+Java_com_couchbase_lite_internal_core_impl_NativeC4Document_free(
+        JNIEnv *ignore1,
+        jclass ignore2,
+        jlong jdoc) {
     c4doc_release((C4Document *) jdoc);
 }
 

--- a/common/main/cpp/native_c4fulltextmatch.cc
+++ b/common/main/cpp/native_c4fulltextmatch.cc
@@ -32,8 +32,8 @@ extern "C" {
  * Method:    dataSource
  * Signature: (J)J
  */
-JNIEXPORT jlong
-JNICALL Java_com_couchbase_lite_internal_core_C4FullTextMatch_dataSource(
+JNIEXPORT jlong JNICALL
+Java_com_couchbase_lite_internal_core_C4FullTextMatch_dataSource(
         JNIEnv *env,
         jclass ignore,
         jlong handle) {
@@ -46,8 +46,8 @@ JNICALL Java_com_couchbase_lite_internal_core_C4FullTextMatch_dataSource(
  * Method:    property
  * Signature: (J)J
  */
-JNIEXPORT jlong
-JNICALL Java_com_couchbase_lite_internal_core_C4FullTextMatch_property(
+JNIEXPORT jlong JNICALL
+Java_com_couchbase_lite_internal_core_C4FullTextMatch_property(
         JNIEnv *env,
         jclass ignore,
         jlong handle) {
@@ -60,8 +60,8 @@ JNICALL Java_com_couchbase_lite_internal_core_C4FullTextMatch_property(
  * Method:    term
  * Signature: (J)J
  */
-JNIEXPORT jlong
-JNICALL Java_com_couchbase_lite_internal_core_C4FullTextMatch_term(
+JNIEXPORT jlong JNICALL
+Java_com_couchbase_lite_internal_core_C4FullTextMatch_term(
         JNIEnv *env,
         jclass ignore,
         jlong handle) {
@@ -74,8 +74,8 @@ JNICALL Java_com_couchbase_lite_internal_core_C4FullTextMatch_term(
  * Method:    start
  * Signature: (J)J
  */
-JNIEXPORT jlong
-JNICALL Java_com_couchbase_lite_internal_core_C4FullTextMatch_start(
+JNIEXPORT jlong JNICALL
+Java_com_couchbase_lite_internal_core_C4FullTextMatch_start(
         JNIEnv *env,
         jclass ignore,
         jlong handle) {
@@ -88,8 +88,8 @@ JNICALL Java_com_couchbase_lite_internal_core_C4FullTextMatch_start(
  * Method:    length
  * Signature: (J)J
  */
-JNIEXPORT jlong
-JNICALL Java_com_couchbase_lite_internal_core_C4FullTextMatch_length(
+JNIEXPORT jlong JNICALL
+Java_com_couchbase_lite_internal_core_C4FullTextMatch_length(
         JNIEnv *env,
         jclass ignore,
         jlong handle) {

--- a/common/main/cpp/native_c4listener.cc
+++ b/common/main/cpp/native_c4listener.cc
@@ -66,14 +66,14 @@ static bool httpAuthCallback(C4Listener *ignore, C4Slice authHeader, void *conte
     JNIEnv *env = nullptr;
     jint getEnvStat = gJVM->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6);
 
-    jboolean res = false;
+    jboolean ok = false;
     if (getEnvStat == JNI_OK) {
         jstring _header = toJString(env, authHeader);
-        res = env->CallStaticBooleanMethod(cls_C4Listener, m_C4Listener_httpAuthCallback, (jlong) context, _header);
-        if (_header) env->DeleteLocalRef(_header);
+        ok = env->CallStaticBooleanMethod(cls_C4Listener, m_C4Listener_httpAuthCallback, (jlong) context, _header);
+        if (_header != nullptr) env->DeleteLocalRef(_header);
     } else if (getEnvStat == JNI_EDETACHED) {
         if (attachCurrentThread(&env) == 0) {
-            res = env->CallStaticBooleanMethod(
+            ok = env->CallStaticBooleanMethod(
                     cls_C4Listener,
                     m_C4Listener_httpAuthCallback,
                     (jlong) context,
@@ -83,26 +83,26 @@ static bool httpAuthCallback(C4Listener *ignore, C4Slice authHeader, void *conte
         } else {
             C4Warn("httpAuthCallback(): Failed to attaches the current thread to a Java VM");
         }
-        return res;
+        return ok;
     } else {
         C4Warn("httpAuthCallback(): Failed to get the environment: getEnvStat -> %d", getEnvStat);
     }
 
-    return res;
+    return ok;
 }
 
 static bool certAuthCallback(C4Listener *ignore, C4Slice clientCertData, void *context) {
     JNIEnv *env = nullptr;
     jint getEnvStat = gJVM->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6);
 
-    bool res = false;
+    bool ok = false;
     if (getEnvStat == JNI_OK) {
         jbyteArray _data = toJByteArray(env, clientCertData);
-        res = env->CallStaticBooleanMethod(cls_C4Listener, m_C4Listener_certAuthCallback, (jlong) context, _data);
-        if (_data) env->DeleteLocalRef(_data);
+        ok = env->CallStaticBooleanMethod(cls_C4Listener, m_C4Listener_certAuthCallback, (jlong) context, _data);
+        if (_data != nullptr) env->DeleteLocalRef(_data);
     } else if (getEnvStat == JNI_EDETACHED) {
         if (attachCurrentThread(&env) == 0) {
-            res = env->CallStaticBooleanMethod(
+            ok = env->CallStaticBooleanMethod(
                     cls_C4Listener,
                     m_C4Listener_certAuthCallback,
                     (jlong) context,
@@ -116,14 +116,14 @@ static bool certAuthCallback(C4Listener *ignore, C4Slice clientCertData, void *c
         C4Warn("certAuthCallback(): Failed to get the environment: getEnvStat -> %d", getEnvStat);
     }
 
-    return res;
+    return ok;
 }
 
 // The Java method returns a byte array of key data.
 // This method copies the data to its destination.
 static bool doKeyDataCallback(JNIEnv *env, void *extKey, size_t outMaxLen, void *output, size_t *outLen) {
     auto key = (jbyteArray) (env->CallStaticObjectMethod(cls_C4KeyPair, m_C4KeyPair_keyDataCallback, (jlong) extKey));
-    if (!key)
+    if (key == nullptr)
         return false;
 
     jsize keyDataSize = env->GetArrayLength(key);
@@ -147,12 +147,12 @@ static bool publicKeyDataCallback(void *externalKey, void *output, size_t output
     JNIEnv *env = nullptr;
     jint getEnvStat = gJVM->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6);
 
-    bool res = false;
+    bool ok = false;
     if (getEnvStat == JNI_OK) {
-        res = doKeyDataCallback(env, externalKey, outputMaxLen, output, outputLen);
+        ok = doKeyDataCallback(env, externalKey, outputMaxLen, output, outputLen);
     } else if (getEnvStat == JNI_EDETACHED) {
         if (attachCurrentThread(&env) == 0) {
-            res = doKeyDataCallback(env, externalKey, outputMaxLen, output, outputLen);
+            ok = doKeyDataCallback(env, externalKey, outputMaxLen, output, outputLen);
             if (gJVM->DetachCurrentThread() != 0)
                 C4Warn("publicKeyDataCallback(): Failed to detach the current thread from a Java VM");
         } else {
@@ -162,7 +162,7 @@ static bool publicKeyDataCallback(void *externalKey, void *output, size_t output
         C4Warn("publicKeyDataCallback(): Failed to get the environment: getEnvStat -> %d", getEnvStat);
     }
 
-    return res;
+    return ok;
 }
 
 // The Java method takes a byte array of encrypted data and returns a byte array
@@ -179,12 +179,13 @@ static bool doDecryptCallback(
     int n = (int) input.size;
 
     jbyteArray encData = env->NewByteArray(n);
+    if (encData == nullptr) return false;
     env->SetByteArrayRegion(encData, 0, n, (jbyte *) input.buf);
 
     auto decData = (jbyteArray)
             (env->CallStaticObjectMethod(cls_C4KeyPair, m_C4KeyPair_decryptCallback, (jlong) extKey, encData));
     env->DeleteLocalRef(encData);
-    if (!decData)
+    if (decData == nullptr)
         return false;
 
     jsize dataSize = env->GetArrayLength(decData);
@@ -208,12 +209,12 @@ static bool decryptKeyCallback(void *externalKey, C4Slice input, void *output, s
     JNIEnv *env = nullptr;
     jint getEnvStat = gJVM->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6);
 
-    bool res = false;
+    bool ok = false;
     if (getEnvStat == JNI_OK) {
-        res = doDecryptCallback(env, externalKey, input, outputMaxLen, output, outputLen);
+        ok = doDecryptCallback(env, externalKey, input, outputMaxLen, output, outputLen);
     } else if (getEnvStat == JNI_EDETACHED) {
         if (attachCurrentThread(&env) == 0) {
-            res = doDecryptCallback(env, externalKey, input, outputMaxLen, output, outputLen);
+            ok = doDecryptCallback(env, externalKey, input, outputMaxLen, output, outputLen);
             if (gJVM->DetachCurrentThread() != 0)
                 C4Warn("decryptKeyCallback(): Failed to detach the current thread from a Java VM");
         } else {
@@ -223,7 +224,7 @@ static bool decryptKeyCallback(void *externalKey, C4Slice input, void *output, s
         C4Warn("decryptKeyCallback(): Failed to get the environment: getEnvStat -> %d", getEnvStat);
     }
 
-    return res;
+    return ok;
 }
 
 // The Java method takes a byte array of data and returns a byte array
@@ -234,12 +235,13 @@ static bool doSignCallback(JNIEnv *env, void *extKey, C4SignatureDigestAlgorithm
     int n = (int) inData.size;
 
     jbyteArray data = env->NewByteArray(n);
+    if (data == nullptr) return false;
     env->SetByteArrayRegion(data, 0, n, (jbyte *) inData.buf);
 
     auto sig = (jbyteArray)
             (env->CallStaticObjectMethod(cls_C4KeyPair, m_C4KeyPair_signCallback, (jlong) extKey, (jint) alg, data));
     env->DeleteLocalRef(data);
-    if (!sig)
+    if (sig == nullptr)
         return false;
 
     jsize sigSize = env->GetArrayLength(sig);
@@ -263,12 +265,12 @@ static bool signKeyCallback(
     JNIEnv *env = nullptr;
     jint getEnvStat = gJVM->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6);
 
-    bool res = false;
+    bool ok = false;
     if (getEnvStat == JNI_OK) {
-        res = doSignCallback(env, externalKey, digestAlgorithm, inputData, outSignature);
+        ok = doSignCallback(env, externalKey, digestAlgorithm, inputData, outSignature);
     } else if (getEnvStat == JNI_EDETACHED) {
         if (attachCurrentThread(&env) == 0) {
-            res = doSignCallback(env, externalKey, digestAlgorithm, inputData, outSignature);
+            ok = doSignCallback(env, externalKey, digestAlgorithm, inputData, outSignature);
             if (gJVM->DetachCurrentThread() != 0)
                 C4Warn("signKeyCallback(): Failed to detach the current thread from a Java VM");
         } else {
@@ -278,7 +280,7 @@ static bool signKeyCallback(
         C4Warn("signKeyCallback(): Failed to get the environment: getEnvStat -> %d", getEnvStat);
     }
 
-    return res;
+    return ok;
 }
 
 // See C4ExternalKeyCallbacks in C4Certificate.h
@@ -308,25 +310,25 @@ static void freeKeyCallback(void *externalKey) {
 static bool initListenerCallbacks(JNIEnv *env) {
     {
         jclass localClass = env->FindClass("com/couchbase/lite/ConnectionStatus");
-        if (!localClass)
+        if (localClass == nullptr)
             return false;
 
         cls_ConnectionStatus = reinterpret_cast<jclass>(env->NewGlobalRef(localClass));
-        if (!cls_ConnectionStatus)
+        if (cls_ConnectionStatus == nullptr)
             return false;
 
         m_ConnectionStatus_init = env->GetMethodID(cls_ConnectionStatus, "<init>", "(II)V");
-        if (!m_ConnectionStatus_init)
+        if (m_ConnectionStatus_init == nullptr)
             return false;
     }
 
     {
         jclass localClass = env->FindClass("com/couchbase/lite/internal/core/C4Listener");
-        if (!localClass)
+        if (localClass == nullptr)
             return false;
 
         cls_C4Listener = reinterpret_cast<jclass>(env->NewGlobalRef(localClass));
-        if (!cls_C4Listener)
+        if (cls_C4Listener == nullptr)
             return false;
 
         m_C4Listener_certAuthCallback = env->GetStaticMethodID(
@@ -334,7 +336,7 @@ static bool initListenerCallbacks(JNIEnv *env) {
                 "certAuthCallback",
                 "(J[B)Z");
 
-        if (!m_C4Listener_certAuthCallback)
+        if (m_C4Listener_certAuthCallback == nullptr)
             return false;
 
         m_C4Listener_httpAuthCallback = env->GetStaticMethodID(
@@ -342,37 +344,37 @@ static bool initListenerCallbacks(JNIEnv *env) {
                 "httpAuthCallback",
                 "(JLjava/lang/String;)Z");
 
-        if (!m_C4Listener_httpAuthCallback)
+        if (m_C4Listener_httpAuthCallback == nullptr)
             return false;
     }
 
-    logError("listener initialized");
+    jniLog("listener initialized");
     return true;
 }
 
 static bool initKeyPairCallbacks(JNIEnv *env) {
     jclass localClass = env->FindClass("com/couchbase/lite/internal/core/C4KeyPair");
-    if (!localClass)
+    if (localClass == nullptr)
         return false;
 
     cls_C4KeyPair = reinterpret_cast<jclass>(env->NewGlobalRef(localClass));
-    if (!cls_C4KeyPair)
+    if (cls_C4KeyPair == nullptr)
         return false;
 
     m_C4KeyPair_keyDataCallback = env->GetStaticMethodID(cls_C4KeyPair, "getKeyDataCallback", "(J)[B");
-    if (!m_C4KeyPair_keyDataCallback)
+    if (m_C4KeyPair_keyDataCallback == nullptr)
         return false;
 
     m_C4KeyPair_signCallback = env->GetStaticMethodID(cls_C4KeyPair, "signCallback", "(JI[B)[B");
-    if (!m_C4KeyPair_signCallback)
+    if (m_C4KeyPair_signCallback == nullptr)
         return false;
 
     m_C4KeyPair_decryptCallback = env->GetStaticMethodID(cls_C4KeyPair, "decryptCallback", "(J[B)[B");
-    if (!m_C4KeyPair_decryptCallback)
+    if (m_C4KeyPair_decryptCallback == nullptr)
         return false;
 
     m_C4KeyPair_freeCallback = env->GetStaticMethodID(cls_C4KeyPair, "freeCallback", "(J)V");
-    if (!m_C4KeyPair_freeCallback)
+    if (m_C4KeyPair_freeCallback == nullptr)
         return false;
 
     keyCallbacks.publicKeyData = &publicKeyDataCallback;
@@ -380,7 +382,7 @@ static bool initKeyPairCallbacks(JNIEnv *env) {
     keyCallbacks.sign = &signKeyCallback;
     keyCallbacks.free = &freeKeyCallback;
 
-    logError("keypair initialized");
+    jniLog("keypair initialized");
     return true;
 }
 
@@ -421,8 +423,8 @@ static C4Listener *startListener(
     }
 
     C4Error error{};
-    auto listener = c4listener_start(&config, &error);
-    if (!listener && error.code != 0) {
+    C4Listener *listener = c4listener_start(&config, &error);
+    if ((listener == nullptr) && (error.code != 0)) {
         throwError(env, error);
         return nullptr;
     }
@@ -441,7 +443,7 @@ static jobject toConnectionStatus(JNIEnv *env, unsigned connectionCount, unsigne
 static C4Cert *getCert(JNIEnv *env, jbyteArray cert, bool &didThrow) {
     didThrow = false;
 
-    if (!cert)
+    if (cert == nullptr)
         return nullptr;
 
     jsize certSize = env->GetArrayLength(cert);
@@ -452,11 +454,11 @@ static C4Cert *getCert(JNIEnv *env, jbyteArray cert, bool &didThrow) {
     FLSlice certSlice = {certData, (size_t) certSize};
 
     C4Error error{};
-    auto c4cert = c4cert_fromData(certSlice, &error);
+    C4Cert *c4cert = c4cert_fromData(certSlice, &error);
 
     env->ReleaseByteArrayElements(cert, certData, 0);
 
-    if (!c4cert) {
+    if (c4cert == nullptr) {
         throwError(env, error);
         didThrow = true;
         return nullptr;
@@ -466,25 +468,26 @@ static C4Cert *getCert(JNIEnv *env, jbyteArray cert, bool &didThrow) {
 }
 
 static jbyteArray getCertData(JNIEnv *env, C4Cert *cert) {
-    if (!cert)
+    if (cert == nullptr)
         return nullptr;
 
-    auto certData = c4cert_copyData(cert, false);
+    FLSliceResult certData = c4cert_copyData(cert, false);
     jbyteArray jData = toJByteArray(env, certData);
-    c4slice_free(certData);
+    FLSliceResult_Release(certData);
 
     return jData;
 }
 
 static C4KeyPair *createKeyPair(JNIEnv *env, jbyte algorithm, jint keySizeInBits, jlong context) {
     C4Error error{};
-    auto keyPair = c4keypair_fromExternal((C4KeyPairAlgorithm) algorithm,
-                                          (size_t) keySizeInBits,
-                                          (void *) context,
-                                          keyCallbacks,
-                                          &error);
-    if (!keyPair) {
-        litecore::jni::throwError(env, error);
+    C4KeyPair *keyPair = c4keypair_fromExternal(
+            (C4KeyPairAlgorithm) algorithm,
+            (size_t) keySizeInBits,
+            (void *) context,
+            keyCallbacks,
+            &error);
+    if (keyPair == nullptr) {
+        throwError(env, error);
         return nullptr;
     }
 
@@ -570,7 +573,7 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Listener_startTls(
 
     // Client Cert Authentication:
     tlsConfig.requireClientCerts = requireClientCerts;
-    if (requireClientCerts == true) {
+    if (requireClientCerts == JNI_TRUE) {
         if (rootClientCerts == nullptr) {
             tlsConfig.certAuthCallback = &certAuthCallback;
             tlsConfig.tlsCallbackContext = reinterpret_cast<void *>(context);
@@ -583,7 +586,7 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Listener_startTls(
         }
     }
 
-    auto listener = reinterpret_cast<jlong>(startListener(
+    C4Listener *listener = startListener(
             env,
             port,
             networkInterface,
@@ -596,12 +599,12 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Listener_startTls(
             allowPull,
             enableDeltaSync,
             requirePasswordAuth,
-            &tlsConfig));
+            &tlsConfig);
 
     c4cert_release(tlsConfig.certificate);
     c4cert_release(tlsConfig.rootClientCerts);
 
-    return listener;
+    return (jlong) listener;
 }
 
 /*
@@ -634,12 +637,12 @@ JNIEXPORT void JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4Listen
     jstringSlice name(env, dbName);
 
     C4Error error1{};
-    auto ok1 = c4listener_shareDB(
+    bool ok = c4listener_shareDB(
             reinterpret_cast<C4Listener *>(c4Listener),
             name,
             reinterpret_cast<C4Database *>(c4db),
             &error1);
-    if (!ok1 && error1.code != 0) {
+    if (!ok && error1.code != 0) {
         throwError(env, error1);
         return;
     }
@@ -648,12 +651,12 @@ JNIEXPORT void JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4Listen
     jlong *colls = env->GetLongArrayElements(c4Collections, nullptr);
     for (int i = 0; i < n; i++) {
         C4Error error2{};
-        auto ok2 = c4listener_shareCollection(
+        ok = c4listener_shareCollection(
                 reinterpret_cast<C4Listener *>(c4Listener),
                 name,
                 reinterpret_cast<C4Collection *>(colls[i]),
                 &error2);
-        if (!ok2 && error2.code != 0) {
+        if (!ok && error2.code != 0) {
             throwError(env, error2);
             break;
         }
@@ -673,13 +676,13 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Listener_getUrls(
         jlong c4Listener,
         jlong c4Database) {
     C4Error error{};
-    auto urls = c4listener_getURLs(
+    FLMutableArray urls = c4listener_getURLs(
             reinterpret_cast<C4Listener *>(c4Listener),
             reinterpret_cast<C4Database *>(c4Database),
             kC4SyncAPI, // forced
             &error);
 
-    if (!urls) {
+    if (urls == nullptr) {
         throwError(env, error);
         return nullptr;
     }
@@ -718,9 +721,9 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Listener_getUriFromPath(
         jclass ignore,
         jstring path) {
     jstringSlice pathSlice(env, path);
-    auto uri = c4db_URINameFromPath(pathSlice);
+    FLSliceResult uri = c4db_URINameFromPath(pathSlice);
     jstring jstr = toJString(env, uri);
-    c4slice_free(uri);
+    FLSliceResult_Release(uri);
     return jstr;
 }
 
@@ -751,21 +754,21 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4KeyPair_generateSelfSignedCer
     auto keys = (C4KeyPair *) c4KeyPair;
 
     int size = env->GetArrayLength(nameComponents);
-    auto subjectName = new C4CertNameComponent[size];
+    C4CertNameComponent *subjectName = new C4CertNameComponent[size];
 
     // For retaining jstringSlice objects of cert's attributes and values:
     std::vector<jstringSlice *> attrs;
     for (int i = 0; i < size; ++i) {
         auto component = (jobjectArray) env->GetObjectArrayElement(nameComponents, i);
-        if (!component) continue;
+        if (component == nullptr) continue;
 
         auto key = (jstring) env->GetObjectArrayElement(component, 0);
-        auto keySlice = new jstringSlice(env, key);
-        if (key) env->DeleteLocalRef(key);
+        jstringSlice *keySlice = new jstringSlice(env, key);
+        if (key != nullptr) env->DeleteLocalRef(key);
 
         auto value = (jstring) env->GetObjectArrayElement(component, 1);
-        auto valueSlice = new jstringSlice(env, value);
-        if (value) env->DeleteLocalRef(value);
+        jstringSlice *valueSlice = new jstringSlice(env, value);
+        if (value != nullptr) env->DeleteLocalRef(value);
 
         env->DeleteLocalRef(component);
 
@@ -776,7 +779,7 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4KeyPair_generateSelfSignedCer
     }
 
     C4Error error{};
-    auto csr = c4cert_createRequest(subjectName, size, usage, keys, &error);
+    C4Cert *csr = c4cert_createRequest(subjectName, size, usage, keys, &error);
 
     // Release cert's attributes and values:
     delete[] subjectName;
@@ -784,24 +787,23 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4KeyPair_generateSelfSignedCer
         delete attrs.at(i);
     }
 
-    if (!csr) {
+    if (csr == nullptr) {
         throwError(env, error);
         return nullptr;
     }
 
     C4CertIssuerParameters issuerParams = kDefaultCertIssuerParameters;
-    if (validityInSeconds > 0) {
+    if (validityInSeconds > 0)
         issuerParams.validityInSeconds = validityInSeconds;
-    }
 
-    auto cert = c4cert_signRequest(csr, &issuerParams, keys, nullptr, &error);
+    C4Cert *cert = c4cert_signRequest(csr, &issuerParams, keys, nullptr, &error);
     c4cert_release(csr);
-    if (!cert) {
+    if (cert == nullptr) {
         throwError(env, error);
         return nullptr;
     }
 
-    auto certData = getCertData(env, cert);
+    jbyteArray certData = getCertData(env, cert);
     c4cert_release(cert);
 
     return certData;

--- a/common/main/cpp/native_c4observer.cc
+++ b/common/main/cpp/native_c4observer.cc
@@ -157,7 +157,7 @@ c4DocObsCallback(C4DocumentObserver *ign1, C4Collection *ign2, C4Slice docID, C4
     if (getEnvStat == JNI_OK) {
         jstring _docID = toJString(env, docID);
         env->CallStaticVoidMethod(cls_C4DocObs, m_C4DocObs_callback, (jlong) context, (jlong) seq, _docID);
-        if (_docID) env->DeleteLocalRef(_docID);
+        if (_docID != nullptr) env->DeleteLocalRef(_docID);
     } else if (getEnvStat == JNI_EDETACHED) {
         if (attachCurrentThread(&env) == 0) {
             env->CallStaticVoidMethod(

--- a/common/main/cpp/native_c4observer.cc
+++ b/common/main/cpp/native_c4observer.cc
@@ -108,7 +108,7 @@ bool litecore::jni::initC4Observer(JNIEnv *env) {
             return false;
     }
 
-    logError("observers initialized");
+    jniLog("observers initialized");
     return true;
 }
 
@@ -200,8 +200,8 @@ c4DocChangesToJavaArray(JNIEnv *env, C4CollectionChange changes[], uint32_t nCha
                 (jlong) changes[i].sequence,
                 (jboolean) external);
 
-        if (_docId) env->DeleteLocalRef(_docId);
-        if (_revId) env->DeleteLocalRef(_revId);
+        if (_docId != nullptr) env->DeleteLocalRef(_docId);
+        if (_revId != nullptr) env->DeleteLocalRef(_revId);
 
         if (obj != nullptr) {
             env->SetObjectArrayElement(array, (jsize) i, obj);
@@ -237,7 +237,7 @@ doC4QueryObserverCallback(JNIEnv *env, C4QueryObserver *observer, void *ctx) {
             (jint) error.code,
             errMsg);
 
-    if (errMsg) env->DeleteLocalRef(errMsg);
+    if (errMsg != nullptr) env->DeleteLocalRef(errMsg);
 }
 
 /**

--- a/common/main/cpp/native_c4prediction.cc
+++ b/common/main/cpp/native_c4prediction.cc
@@ -32,21 +32,21 @@ static jmethodID m_C4Prediction_prediction;
 
 bool litecore::jni::initC4Prediction(JNIEnv *env) {
     jclass localClass = env->FindClass("com/couchbase/lite/internal/core/C4Prediction");
-    if (!localClass)
+    if (localClass == nullptr)
         return false;
 
     cls_C4Prediction = reinterpret_cast<jclass>(env->NewGlobalRef(localClass));
-    if (!cls_C4Prediction)
+    if (cls_C4Prediction == nullptr)
         return false;
 
     m_C4Prediction_prediction = env->GetStaticMethodID(
             cls_C4Prediction,
             "prediction",
             "(JJJ)Lcom/couchbase/lite/internal/fleece/FLSliceResult;");
-    if (!m_C4Prediction_prediction)
+    if (m_C4Prediction_prediction == nullptr)
         return false;
 
-    logError("prediction initialized");
+    jniLog("prediction initialized");
     return true;
 }
 
@@ -63,7 +63,7 @@ static C4SliceResult prediction(void *token, FLDict input, C4Database *c4db, C4E
                 (jlong) token,
                 (jlong) input,
                 (jlong) c4db);
-        if (sliceResult) {
+        if (sliceResult != nullptr) {
             res = fromJavaFLSliceResult(env, sliceResult);
             env->DeleteLocalRef(sliceResult);
         }
@@ -75,7 +75,7 @@ static C4SliceResult prediction(void *token, FLDict input, C4Database *c4db, C4E
                     (jlong) token,
                     (jlong) input,
                     (jlong) c4db);
-            if (sliceResult)
+            if (sliceResult != nullptr)
                 res = fromJavaFLSliceResult(env, sliceResult);
             if (gJVM->DetachCurrentThread() != 0)
                 C4Warn("doRequestClose(): Failed to detach the current thread from a Java VM");

--- a/common/main/cpp/native_c4query.cc
+++ b/common/main/cpp/native_c4query.cc
@@ -48,8 +48,8 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Query_createQuery(
             &errorLoc,
             &error);
 
-    // !!! Should put the error location into the exception message.
-    if (!query) {
+    // ??? Should put errorLoc into the exception message.
+    if (query == nullptr) {
         throwError(env, error);
         return 0;
     }
@@ -101,7 +101,7 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Query_run(
     C4Error error{};
     C4Slice params {(const void *) jparamPtr, (size_t) jparamSize};
     C4QueryEnumerator *e = c4query_run((C4Query *) jquery, params, &error);
-    if (!e) {
+    if (e == nullptr) {
         throwError(env, error);
         return 0;
     }

--- a/common/main/cpp/native_c4replicator.cc
+++ b/common/main/cpp/native_c4replicator.cc
@@ -58,109 +58,109 @@ static bool pushFilterFunction(C4CollectionSpec, C4String, C4String, C4RevisionF
 bool litecore::jni::initC4Replicator(JNIEnv *env) {
     {
         jclass localClass = env->FindClass("com/couchbase/lite/internal/core/C4Replicator");
-        if (!localClass)
+        if (localClass == nullptr)
             return false;
 
         cls_C4Replicator = reinterpret_cast<jclass>(env->NewGlobalRef(localClass));
-        if (!cls_C4Replicator)
+        if (cls_C4Replicator == nullptr)
             return false;
 
         m_C4Replicator_statusChangedCallback = env->GetStaticMethodID(
                 cls_C4Replicator,
                 "statusChangedCallback",
                 "(JLcom/couchbase/lite/internal/core/C4ReplicatorStatus;)V");
-        if (!m_C4Replicator_statusChangedCallback)
+        if (m_C4Replicator_statusChangedCallback == nullptr)
             return false;
 
         m_C4Replicator_documentEndedCallback = env->GetStaticMethodID(
                 cls_C4Replicator,
                 "documentEndedCallback",
                 "(JZ[Lcom/couchbase/lite/internal/core/C4DocumentEnded;)V");
-        if (!m_C4Replicator_documentEndedCallback)
+        if (m_C4Replicator_documentEndedCallback == nullptr)
             return false;
     }
 
     // C4ReplicatorStatus, constructor, and fields
     {
         jclass localClass = env->FindClass("com/couchbase/lite/internal/core/C4ReplicatorStatus");
-        if (!localClass)
+        if (localClass == nullptr)
             return false;
 
         cls_C4ReplStatus = reinterpret_cast<jclass>(env->NewGlobalRef(localClass));
-        if (!cls_C4ReplStatus)
+        if (cls_C4ReplStatus == nullptr)
             return false;
 
         m_C4ReplStatus_init = env->GetMethodID(cls_C4ReplStatus, "<init>", "(IJJJIII)V");
-        if (!m_C4ReplStatus_init)
+        if (m_C4ReplStatus_init == nullptr)
             return false;
     }
 
     // C4DocumentEnded, constructor, and fields
     {
         jclass localClass = env->FindClass("com/couchbase/lite/internal/core/C4DocumentEnded");
-        if (!localClass)
+        if (localClass == nullptr)
             return false;
 
         cls_C4DocEnded = reinterpret_cast<jclass>(env->NewGlobalRef(localClass));
-        if (!cls_C4DocEnded)
+        if (cls_C4DocEnded == nullptr)
             return false;
 
         m_C4DocEnded_init = env->GetMethodID(
                 cls_C4DocEnded,
                 "<init>",
                 "(JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IJIIIZ)V");
-        if (!m_C4DocEnded_init)
+        if (m_C4DocEnded_init == nullptr)
             return false;
     }
 
     {
         jclass localClass = env->FindClass("com/couchbase/lite/internal/ReplicationCollection");
-        if (!localClass)
+        if (localClass == nullptr)
             return false;
 
         cls_ReplColl = reinterpret_cast<jclass>(env->NewGlobalRef(localClass));
-        if (!cls_ReplColl)
+        if (cls_ReplColl == nullptr)
             return false;
 
         f_ReplColl_token = env->GetFieldID(cls_ReplColl, "token", "J");
-        if (!f_ReplColl_token)
+        if (f_ReplColl_token == nullptr)
             return false;
 
         f_ReplColl_scope = env->GetFieldID(cls_ReplColl, "scope", "Ljava/lang/String;");
-        if (!f_ReplColl_scope)
+        if (f_ReplColl_scope == nullptr)
             return false;
 
         f_ReplColl_name = env->GetFieldID(cls_ReplColl, "name", "Ljava/lang/String;");
-        if (!f_ReplColl_name)
+        if (f_ReplColl_name == nullptr)
             return false;
 
         f_ReplColl_options = env->GetFieldID(cls_ReplColl, "options", "[B");
-        if (!f_ReplColl_options)
+        if (f_ReplColl_options == nullptr)
             return false;
 
         f_ReplColl_pushFilter = env->GetFieldID(
                 cls_ReplColl,
                 "c4PushFilter",
                 "Lcom/couchbase/lite/internal/ReplicationCollection$C4Filter;");
-        if (!f_ReplColl_pushFilter)
+        if (f_ReplColl_pushFilter == nullptr)
             return false;
 
         f_ReplColl_pullFilter = env->GetFieldID(
                 cls_ReplColl,
                 "c4PullFilter",
                 "Lcom/couchbase/lite/internal/ReplicationCollection$C4Filter;");
-        if (!f_ReplColl_pullFilter)
+        if (f_ReplColl_pullFilter == nullptr)
             return false;
 
         m_ReplColl_filterCallback = env->GetStaticMethodID(
                 cls_ReplColl,
                 "filterCallback",
                 "(JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IJZ)Z");
-        if (!m_ReplColl_filterCallback)
+        if (m_ReplColl_filterCallback == nullptr)
             return false;
     }
 
-    logError("replicator initialized");
+    jniLog("replicator initialized");
     return true;
 }
 
@@ -198,10 +198,10 @@ static jobject toJavaDocumentEnded(JNIEnv *env, const C4DocumentEnded *document)
             (jint) document->error.internal_info,
             (jboolean) document->errorIsTransient);
 
-    if (_scope) env->DeleteLocalRef(_scope);
-    if (_name) env->DeleteLocalRef(_name);
-    if (_docID) env->DeleteLocalRef(_docID);
-    if (_revID) env->DeleteLocalRef(_revID);
+    if (_scope != nullptr) env->DeleteLocalRef(_scope);
+    if (_name != nullptr) env->DeleteLocalRef(_name);
+    if (_docID != nullptr) env->DeleteLocalRef(_docID);
+    if (_revID != nullptr) env->DeleteLocalRef(_revID);
 
     return _docEnd;
 }
@@ -211,7 +211,7 @@ static jobjectArray toJavaDocumentEndedArray(JNIEnv *env, int arraySize, const C
     for (int i = 0; i < arraySize; i++) {
         jobject d = toJavaDocumentEnded(env, array[i]);
         env->SetObjectArrayElement(ds, i, d);
-        env->DeleteLocalRef(d);
+        if (d != nullptr) env->DeleteLocalRef(d);
     }
     return ds;
 }
@@ -221,7 +221,6 @@ static jobjectArray toJavaDocumentEndedArray(JNIEnv *env, int arraySize, const C
 // are just around to keep the slices they contain from going out of scope.
 // All they do is hold on to them, so that the C4ReplicationCollections
 // in colls can point to them, until the end of the *caller's* scope.
-// Since this is a loop, we delete all the LocalRefs explicitly
 static int fromJavaReplColls(
         JNIEnv *env,
         jobjectArray jColls,
@@ -235,17 +234,17 @@ static int fromJavaReplColls(
 
     for (jsize i = 0; i < nColls; i++) {
         jobject replColl = env->GetObjectArrayElement(jColls, i);
-        if (!replColl) continue;
+        if (replColl == nullptr) continue;
 
         jobject jscope = env->GetObjectField(replColl, f_ReplColl_scope);
         auto pScope = std::make_shared<jstringSlice>(env, (jstring) jscope);
-        if (jscope) env->DeleteLocalRef(jscope);
+        if (jscope != nullptr) env->DeleteLocalRef(jscope);
         collNames.push_back(pScope);
         colls[i].collection.scope = *pScope;
 
         jobject jname = env->GetObjectField(replColl, f_ReplColl_name);
         auto pName = std::make_shared<jstringSlice>(env, (jstring) jname);
-        if (jname) env->DeleteLocalRef(jname);
+        if (jname != nullptr) env->DeleteLocalRef(jname);
         collNames.push_back(pName);
         colls[i].collection.name = *pName;
 
@@ -257,12 +256,12 @@ static int fromJavaReplColls(
         collOptions.push_back(pOptions);
         colls[i].optionsDictFleece = *pOptions;
 
-        auto pushf = env->GetObjectField(replColl, f_ReplColl_pushFilter);
+        jobject pushf = env->GetObjectField(replColl, f_ReplColl_pushFilter);
         if (pushf != nullptr) {
             colls[i].pushFilter = &pushFilterFunction;
             env->DeleteLocalRef(pushf);
         }
-        auto pullf = env->GetObjectField(replColl, f_ReplColl_pullFilter);
+        jobject pullf = env->GetObjectField(replColl, f_ReplColl_pullFilter);
         if (pullf != nullptr) {
             colls[i].pullFilter = &pullFilterFunction;
             env->DeleteLocalRef(pullf);
@@ -290,7 +289,7 @@ static void statusChangedCallback(C4Replicator *ignored, C4ReplicatorStatus stat
     if (getEnvStat == JNI_OK) {
         jobject _status = toJavaReplStatus(env, status);
         env->CallStaticVoidMethod(cls_C4Replicator, m_C4Replicator_statusChangedCallback, (jlong) token, _status);
-        env->DeleteLocalRef(_status);
+        if (_status != nullptr) env->DeleteLocalRef(_status);
     } else if (getEnvStat == JNI_EDETACHED) {
         if (attachCurrentThread(&env) == 0) {
             env->CallStaticVoidMethod(
@@ -331,7 +330,7 @@ static void documentEndedCallback(
     if (getEnvStat == JNI_OK) {
         jobjectArray docs = toJavaDocumentEndedArray(env, nDocs, documentEnded);
         env->CallStaticVoidMethod(cls_C4Replicator, m_C4Replicator_documentEndedCallback, (jlong) token, pushing, docs);
-        env->DeleteLocalRef(docs);
+        if (docs != nullptr) env->DeleteLocalRef(docs);
     } else if (getEnvStat == JNI_EDETACHED) {
         if (attachCurrentThread(&env) == 0) {
             env->CallStaticVoidMethod(
@@ -381,10 +380,10 @@ static jboolean replicationFilter(
                 (jlong) dict,
                 isPush);
 
-        if (_scope) env->DeleteLocalRef(_scope);
-        if (_name) env->DeleteLocalRef(_name);
-        if (_docID) env->DeleteLocalRef(_docID);
-        if (_revID) env->DeleteLocalRef(_revID);
+        if (_scope != nullptr) env->DeleteLocalRef(_scope);
+        if (_name != nullptr) env->DeleteLocalRef(_name);
+        if (_docID != nullptr) env->DeleteLocalRef(_docID);
+        if (_revID != nullptr) env->DeleteLocalRef(_revID);
     } else if (getEnvStat == JNI_EDETACHED) {
         if (attachCurrentThread(&env) == 0) {
             res = (jboolean) env->CallStaticBooleanMethod(
@@ -528,7 +527,7 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Replicator_create(
 
     C4Error error{};
     C4Replicator *repl = c4repl_new((C4Database *) jdb, c4Address, remoteDBName, params, id, &error);
-    if (!repl && error.code != 0) {
+    if ((repl == nullptr) && (error.code != 0)) {
         throwError(env, error);
         return 0;
     }
@@ -591,7 +590,7 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Replicator_createLocal(
 
     C4Error error{};
     C4Replicator *repl = c4repl_newLocal((C4Database *) jdb, (C4Database *) targetDb, params, id, &error);
-    if (!repl && error.code != 0) {
+    if ((repl == nullptr) && (error.code != 0)) {
         throwError(env, error);
         return 0;
     }
@@ -646,7 +645,7 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Replicator_createWithSocket(
 
     C4Error error{};
     C4Replicator *repl = c4repl_newWithSocket(db, openSocket, params, id, &error);
-    if (!repl && error.code != 0) {
+    if ((repl == nullptr) && (error.code != 0)) {
         throwError(env, error);
         return 0;
     }
@@ -764,7 +763,7 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Replicator_isDocumentPending(
 
     C4Error c4Error{};
     bool pending = c4repl_isDocumentPending((C4Replicator *) repl, docId, collSpec, &c4Error);
-    if (c4Error.domain != 0 && c4Error.code != 0) {
+    if (!pending && c4Error.code != 0) {
         throwError(env, c4Error);
         return false;
     }
@@ -784,7 +783,7 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Replicator_setProgressLevel(
         jlong repl,
         jint level) {
     C4Error error{};
-    auto ok = c4repl_setProgressLevel((C4Replicator *) repl, (C4ReplicatorProgressLevel) level, &error);
+    bool ok = c4repl_setProgressLevel((C4Replicator *) repl, (C4ReplicatorProgressLevel) level, &error);
     if (!ok && error.code != 0) {
         throwError(env, error);
     }

--- a/common/main/cpp/native_fleece.cc
+++ b/common/main/cpp/native_fleece.cc
@@ -90,7 +90,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLArray_getValueAt(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLArray_next(JNIEnv *env, jclass ignore, jlong jitr) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLArray_next(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jitr) {
     return (jboolean) FLArrayIterator_Next((FLArrayIterator *) jitr);
 }
 
@@ -100,7 +103,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLArray_next(JNIEnv *env, jcl
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLArray_getValue(JNIEnv *env, jclass ignore, jlong jitr) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLArray_getValue(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jitr) {
     return (jlong) FLArrayIterator_GetValue((FLArrayIterator *) jitr);
 }
 
@@ -110,7 +116,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLArray_getValue(JNIEnv *env,
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLArray_free(JNIEnv *env, jclass ignore, jlong jitr) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLArray_free(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jitr) {
     ::free((FLArrayIterator *) jitr);
 }
 
@@ -124,7 +133,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLArray_free(JNIEnv *env, jcl
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLDict_count(JNIEnv *env, jclass ignore, jlong jdict) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLDict_count(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jdict) {
     return (jlong) FLDict_Count((FLDict) jdict);
 }
 
@@ -188,7 +200,8 @@ JNIEXPORT jstring JNICALL
 Java_com_couchbase_lite_internal_fleece_impl_NativeFLDict_getKey(JNIEnv *env, jclass ignore, jlong jitr) {
     // This is necessary because, when the iterator is exhausted, calling GetKey
     // will fail with a pointer exception.  GetValue returns null instead.
-    if (!FLDictIterator_GetValue((FLDictIterator *) jitr))
+    bool ok = FLDictIterator_GetValue((FLDictIterator *) jitr);
+    if (!ok)
         return nullptr;
 
     FLString s = FLDictIterator_GetKeyString((FLDictIterator *) jitr);
@@ -225,7 +238,11 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLDict_free(JNIEnv *env, jcla
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_fromData(JNIEnv *env, jclass ignore, jlong ptr, jlong size) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_fromData(
+        JNIEnv *env,
+        jclass ignore,
+        jlong ptr,
+        jlong size) {
     FLSlice slice{(const void *) ptr, (size_t) size};
     return (jlong) FLValue_FromData(slice, kFLUntrusted);
 }
@@ -236,7 +253,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_fromData(JNIEnv *env,
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_fromTrustedData(JNIEnv *env, jclass ignore, jbyteArray jdata) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_fromTrustedData(
+        JNIEnv *env,
+        jclass ignore,
+        jbyteArray jdata) {
     jbyteArraySlice data(env, jdata, true);
     return (jlong) FLValue_FromData(data, kFLTrusted);
 }
@@ -247,7 +267,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_fromTrustedData(JNIEn
  * Signature: (J)I
  */
 JNIEXPORT jint JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_getType(JNIEnv *env, jclass ignore, jlong jvalue) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_getType(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jvalue) {
     return FLValue_GetType((FLValue) jvalue);
 }
 
@@ -257,7 +280,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_getType(JNIEnv *env, 
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asBool(JNIEnv *env, jclass ignore, jlong jvalue) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asBool(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jvalue) {
     return (jboolean) FLValue_AsBool((FLValue) jvalue);
 }
 
@@ -267,7 +293,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asBool(JNIEnv *env, j
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asUnsigned(JNIEnv *env, jclass ignore, jlong jvalue) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asUnsigned(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jvalue) {
     return (jlong) FLValue_AsUnsigned((FLValue) jvalue);
 }
 
@@ -287,7 +316,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asInt(JNIEnv *env, jc
  * Signature: (J)F
  */
 JNIEXPORT jfloat JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asFloat(JNIEnv *env, jclass ignore, jlong jvalue) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asFloat(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jvalue) {
     return (jfloat) FLValue_AsFloat((FLValue) jvalue);
 }
 
@@ -297,7 +329,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asFloat(JNIEnv *env, 
  * Signature: (J)D
  */
 JNIEXPORT jdouble JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asDouble(JNIEnv *env, jclass ignore, jlong jvalue) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asDouble(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jvalue) {
     return (jdouble) FLValue_AsDouble((FLValue) jvalue);
 }
 
@@ -307,7 +342,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asDouble(JNIEnv *env,
  * Signature: (J)Ljava/lang/String;
  */
 JNIEXPORT jstring JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asString(JNIEnv *env, jclass ignore, jlong jvalue) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asString(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jvalue) {
     FLString str = FLValue_AsString((FLValue) jvalue);
     return toJString(env, str);
 }
@@ -318,7 +356,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asString(JNIEnv *env,
  * Signature: (J)[B
  */
 JNIEXPORT jbyteArray JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asData(JNIEnv *env, jclass ignore, jlong jvalue) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asData(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jvalue) {
     FLSlice bytes = FLValue_AsData((FLValue) jvalue);
     return toJByteArray(env, bytes);
 }
@@ -329,7 +370,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asData(JNIEnv *env, j
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asArray(JNIEnv *env, jclass ignore, jlong jvalue) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asArray(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jvalue) {
     return (jlong) FLValue_AsArray((FLValue) jvalue);
 }
 
@@ -339,7 +383,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asArray(JNIEnv *env, 
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asDict(JNIEnv *env, jclass ignore, jlong jvalue) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asDict(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jvalue) {
     return (jlong) FLValue_AsDict((FLValue) jvalue);
 }
 
@@ -349,7 +396,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_asDict(JNIEnv *env, j
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_isInteger(JNIEnv *env, jclass ignore, jlong jvalue) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_isInteger(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jvalue) {
     return (jboolean) FLValue_IsInteger((FLValue) jvalue);
 }
 
@@ -359,7 +409,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_isInteger(JNIEnv *env
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_isDouble(JNIEnv *env, jclass ignore, jlong jvalue) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_isDouble(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jvalue) {
     return (jboolean) FLValue_IsDouble((FLValue) jvalue);
 }
 /*
@@ -368,7 +421,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_isDouble(JNIEnv *env,
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_isUnsigned(JNIEnv *env, jclass ignore, jlong jvalue) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_isUnsigned(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jvalue) {
     return (jboolean) FLValue_IsUnsigned((FLValue) jvalue);
 }
 
@@ -378,7 +434,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_isUnsigned(JNIEnv *en
  * Signature: (Ljava/lang/String;)Ljava/lang/String;
  */
 JNIEXPORT jstring JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_json5toJson(JNIEnv *env, jclass ignore, jstring jjson5) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_json5toJson(
+        JNIEnv *env,
+        jclass ignore,
+        jstring jjson5) {
     jstringSlice json5(env, jjson5);
     FLError error = kFLNoError;
     FLStringResult json = FLJSON5_ToJSON(json5, nullptr, nullptr, &error);
@@ -396,7 +455,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_json5toJson(JNIEnv *e
  * Signature: (J)Ljava/lang/String;
  */
 JNIEXPORT jstring JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_toString(JNIEnv *env, jclass ignore, jlong jvalue) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_toString(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jvalue) {
     FLStringResult str = FLValue_ToString((FLValue) jvalue);
     jstring res = toJString(env, str);
     FLSliceResult_Release(str);
@@ -409,7 +471,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_toString(JNIEnv *env,
  * Signature: (J)Ljava/lang/String;
  */
 JNIEXPORT jstring JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_toJSON(JNIEnv *env, jclass ignore, jlong jvalue) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_toJSON(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jvalue) {
     FLStringResult str = FLValue_ToJSON((FLValue) jvalue);
     jstring res = toJString(env, str);
     FLSliceResult_Release(str);
@@ -422,7 +487,10 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_toJSON(JNIEnv *env, j
  * Signature: (J)Ljava/lang/String;
  */
 JNIEXPORT jstring JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_toJSON5(JNIEnv *env, jclass ignore, jlong jvalue) {
+Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_toJSON5(
+        JNIEnv *env,
+        jclass ignore,
+        jlong jvalue) {
     FLStringResult str = FLValue_ToJSON5((FLValue) jvalue);
     jstring res = toJString(env, str);
     FLSliceResult_Release(str);

--- a/common/main/cpp/native_flencoder.cc
+++ b/common/main/cpp/native_flencoder.cc
@@ -265,7 +265,7 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish2(JNIEnv *env
     FLSliceResult res = FLEncoder_Finish((FLEncoder) jenc, &error);
     if (error != kFLNoError) {
         throwError(env, {FleeceDomain, error});
-        return 0;
+        return nullptr;
     }
 
     return toJavaFLSliceResult(env, res);
@@ -281,8 +281,8 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish3(JNIEnv *env
     FLError error = kFLNoError;
     FLSliceResult res = FLEncoder_Finish((FLEncoder) jenc, &error);
     if (error != kFLNoError) {
-        throwError(env, {FleeceDomain, error});
-        return 0;
+        throwError(env, {FleeceDomain, error}, FLEncoder_GetErrorMessage((FLEncoder) jenc));
+        return nullptr;
     }
 
     return toJavaUnmanagedFLSliceResult(env, res);

--- a/common/main/cpp/native_flencoder.cc
+++ b/common/main/cpp/native_flencoder.cc
@@ -245,7 +245,7 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish(JNIEnv *env,
     FLError error = kFLNoError;
     FLSliceResult result = FLEncoder_Finish((FLEncoder) jenc, &error);
     if (error != kFLNoError) {
-        throwError(env, {FleeceDomain, error});
+        throwError(env, {FleeceDomain, error}, FLEncoder_GetErrorMessage((FLEncoder) jenc));
         return nullptr;
     }
 
@@ -264,7 +264,7 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish2(JNIEnv *env
     FLError error = kFLNoError;
     FLSliceResult res = FLEncoder_Finish((FLEncoder) jenc, &error);
     if (error != kFLNoError) {
-        throwError(env, {FleeceDomain, error});
+        throwError(env, {FleeceDomain, error}, FLEncoder_GetErrorMessage((FLEncoder) jenc));
         return nullptr;
     }
 
@@ -330,7 +330,7 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finishJSON(
     FLError error = kFLNoError;
     FLSliceResult result = FLEncoder_Finish((FLEncoder) jenc, &error);
     if (error != kFLNoError) {
-        throwError(env, {FleeceDomain, error});
+        throwError(env, {FleeceDomain, error}, FLEncoder_GetErrorMessage((FLEncoder) jenc));
         return nullptr;
     }
 

--- a/common/main/cpp/native_glue.cc
+++ b/common/main/cpp/native_glue.cc
@@ -69,31 +69,7 @@ jstring litecore::jni::UTF8ToJstring(JNIEnv *env, const char *s, size_t size) {
     return jstr;
 }
 
-// ??? Callers can't handle exceptions so we just ignore errors and return an empty string.
-std::string litecore::jni::JstringToUTF8(JNIEnv *env, jstring jstr) {
-    jsize len = env->GetStringLength(jstr);
-    if (len <= 0)
-        return std::string();
-
-    const jchar *chars = env->GetStringChars(jstr, nullptr);
-    auto ret = litecore::jni::JcharsToUTF8(env, chars, len);
-    env->ReleaseStringChars(jstr, chars);
-    return ret;
-}
-
-// ??? Callers can't handle exceptions so we just ignore errors and return an empty string.
-std::string litecore::jni::JcharArrayToUTF8(JNIEnv *env, jcharArray jcharArray) {
-    jsize len = env->GetArrayLength(jcharArray);
-    if (len <= 0)
-        return std::string();
-
-    jchar *chars = env->GetCharArrayElements(jcharArray, nullptr);
-    auto ret = litecore::jni::JcharsToUTF8(env, chars, len);
-    env->ReleaseCharArrayElements(jcharArray, chars, JNI_ABORT);
-    return ret;
-}
-
-std::string litecore::jni::JcharsToUTF8(JNIEnv *env, const jchar *chars, jsize len) {
+std::string JcharsToUTF8(const jchar *chars, jsize len) {
     std::string str;
 
     if (chars == nullptr) {
@@ -119,6 +95,30 @@ std::string litecore::jni::JcharsToUTF8(JNIEnv *env, const jchar *chars, jsize l
     return str;
 }
 
+// ??? Callers can't handle exceptions so we just ignore errors and return an empty string.
+std::string litecore::jni::JstringToUTF8(JNIEnv *env, jstring jstr) {
+    jsize len = env->GetStringLength(jstr);
+    if (len <= 0)
+        return std::string();
+
+    const jchar *chars = env->GetStringChars(jstr, nullptr);
+    auto ret = JcharsToUTF8(chars, len);
+    env->ReleaseStringChars(jstr, chars);
+    return ret;
+}
+
+// ??? Callers can't handle exceptions so we just ignore errors and return an empty string.
+std::string litecore::jni::JcharArrayToUTF8(JNIEnv *env, jcharArray jcharArray) {
+    jsize len = env->GetArrayLength(jcharArray);
+    if (len <= 0)
+        return std::string();
+
+    jchar *chars = env->GetCharArrayElements(jcharArray, nullptr);
+    auto ret = JcharsToUTF8(chars, len);
+    env->ReleaseCharArrayElements(jcharArray, chars, JNI_ABORT);
+    return ret;
+}
+
 
 // Java ArrayList class
 static jclass cls_ArrayList;                      // global class reference
@@ -136,6 +136,10 @@ static jmethodID m_FLSliceResult_createManaged;   // static constructor
 static jmethodID m_FLSliceResult_createUnmanaged; // static constructor
 static jfieldID f_FLSliceResult_base;             // field: base
 static jfieldID f_FLSliceResult_size;             // field: size
+
+// Java LiteCoreException class
+static jclass cls_LiteCoreException;             // global reference
+static jmethodID m_LiteCoreException_throw;      // static throw
 
 
 static bool initC4Glue(JNIEnv *env) {
@@ -204,6 +208,19 @@ static bool initC4Glue(JNIEnv *env) {
         if (!f_FLSliceResult_size)
             return false;
 
+    }
+    {
+        jclass localClass = env->FindClass("com/couchbase/lite/LiteCoreException");
+        if (!localClass)
+            return false;
+
+        cls_LiteCoreException = reinterpret_cast<jclass>(env->NewGlobalRef(localClass));
+        if (!cls_LiteCoreException)
+            return false;
+
+        m_LiteCoreException_throw = env->GetStaticMethodID(cls_LiteCoreException, "throwException", "(IILjava/lang/String;)V");
+        if (!m_LiteCoreException_throw)
+            return false;
     }
 
     logError("glue initialized");
@@ -276,18 +293,22 @@ namespace litecore {
 
         const char *jstringSlice::c_str() {
             return (const char *) _slice.buf;
-        };
+        }
 
-        // ATTN: In critical, should not call any other JNI methods.
+        // ATTN: In critical, cannot call any other JNI methods.
         // http://docs.oracle.com/javase/6/docs/technotes/guides/jni/spec/functions.html
         // Just don't set it true.
         jbyteArraySlice::jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, bool critical)
-                : jbyteArraySlice(env, jbytes, (size_t) (!jbytes ? 0 : env->GetArrayLength(jbytes)), critical) {}
+                : jbyteArraySlice(env, false, jbytes, critical) {}
 
-        jbyteArraySlice::jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, size_t length, bool critical)
+        jbyteArraySlice::jbyteArraySlice(JNIEnv *env, bool delRef, jbyteArray jbytes, bool critical)
+                : jbyteArraySlice(env, delRef, jbytes, (size_t) (!jbytes ? 0 : env->GetArrayLength(jbytes)), critical) {}
+
+        jbyteArraySlice::jbyteArraySlice(JNIEnv *env, bool delRef, jbyteArray jbytes, size_t length, bool critical)
                 : _env(env),
                   _jbytes(jbytes),
-                  _critical(critical) {
+                  _critical(critical),
+                  _delRef(delRef) {
             if (!jbytes || length <= 0) {
                 _slice = kFLSliceNull;
                 return;
@@ -311,6 +332,7 @@ namespace litecore {
                     _env->ReleaseByteArrayElements(_jbytes, (jbyte *) _slice.buf, JNI_ABORT);
                 }
             }
+            if (_jbytes && _delRef) _env->DeleteLocalRef(_jbytes);
         }
 
         FLSliceResult jbyteArraySlice::copy(JNIEnv *env, jbyteArray jbytes) {
@@ -321,16 +343,19 @@ namespace litecore {
         void throwError(JNIEnv *env, C4Error error) {
             if (env->ExceptionOccurred())
                 return;
-            jclass xclass = env->FindClass("com/couchbase/lite/LiteCoreException");
-            assert(xclass); // if we can't even throw an exception, we're really fuxored
-            jmethodID m = env->GetStaticMethodID(xclass, "throwException", "(IILjava/lang/String;)V");
-            assert(m);
 
             C4SliceResult msgSlice = c4error_getMessage(error);
             jstring msg = toJString(env, msgSlice);
             c4slice_free(msgSlice);
 
-            env->CallStaticVoidMethod(xclass, m, (jint) error.domain, (jint) error.code, msg);
+            env->CallStaticVoidMethod(
+                    cls_LiteCoreException,
+                    m_LiteCoreException_throw,
+                    (jint) error.domain,
+                    (jint) error.code,
+                    msg);
+
+            if (msg) env->DeleteLocalRef(msg);
         }
 
         jstring toJString(JNIEnv *env, C4Slice s) {
@@ -347,8 +372,6 @@ namespace litecore {
         jbyteArray toJByteArray(JNIEnv *env, C4Slice s) {
             if (s.buf == nullptr)
                 return nullptr;
-            // NOTE: Local reference is taken care by JVM.
-            // http://docs.oracle.com/javase/6/docs/technotes/guides/jni/spec/functions.html#global_local
             jbyteArray array = env->NewByteArray((jsize) s.size);
             if (array)
                 env->SetByteArrayRegion(array, 0, (jsize) s.size, (const jbyte *) s.buf);

--- a/common/main/cpp/native_glue.cc
+++ b/common/main/cpp/native_glue.cc
@@ -27,98 +27,6 @@ using namespace litecore;
 using namespace litecore::jni;
 using namespace std;
 
-// Java uses Modified-UTF-8, not UTF-8: Attempting to decode a real UTF-8 string will cause a failure that looks like:
-//   art/runtime/check_jni.cc:65] JNI DETECTED ERROR IN APPLICATION: input is not valid Modified UTF-8: illegal start byte ...
-//   art/runtime/check_jni.cc:65]     string: ...
-//   art/runtime/check_jni.cc:65]     in call to NewStringUTF
-// See:
-//   https://stackoverflow.com/questions/35519823/jni-detected-error-in-application-input-is-not-valid-modified-utf-8-illegal-st
-// The strategy here is to use standard C functions to convert the UTF-8 directly to UTF-16, which Java handles nicely.
-// The following two functions are derived from this code:
-//   https://github.com/incanus/android-jni/blob/master/app/src/main/jni/JNI.cpp#L57-L86
-// ??? Creating the wstring_convert is expensive.  It would be nice to create one
-//     and to re-use it.  It is *NOT*, however, threadsafe.
-// ??? On failure, just return a nullptr.
-jstring litecore::jni::UTF8ToJstring(JNIEnv *env, const char *s, size_t size) {
-    std::u16string ustr;
-    try {
-#ifdef _MSC_VER
-        auto tmpstr = std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t>().from_bytes(s, s + size);
-        ustr = reinterpret_cast<const char16_t *>(tmpstr.data());
-#else
-        ustr = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>().from_bytes(s, s + size);
-#endif
-    }
-    catch (const std::bad_alloc &x) {
-        logError("Failed allocating space to convert string: %s", x.what());
-        return nullptr;
-    }
-    catch (const std::exception &x) {
-        // sadly, we better not try to log the actual string...
-        logError("Failed to convert string from UTF-8 to UTF-16: %s", x.what());
-        return nullptr;
-    }
-
-    auto jstr = env->NewString(reinterpret_cast<const jchar *>(ustr.c_str()), ustr.size());
-    if (jstr == nullptr) {
-        C4Error error = {LiteCoreDomain, kC4ErrorMemoryError, 0};
-        throwError(env, error);
-        return nullptr;
-    }
-
-    return jstr;
-}
-
-std::string JcharsToUTF8(const jchar *chars, jsize len) {
-    std::string str;
-
-    if (chars == nullptr) {
-        str = std::string();
-    } else {
-        try {
-#ifdef _MSC_VER
-            str = std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t>()
-                                .to_bytes(reinterpret_cast<const int16_t *>(chars),
-                                          reinterpret_cast<const int16_t *>(chars + len));
-#else
-            str = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>()
-                    .to_bytes(reinterpret_cast<const char16_t *>(chars),
-                              reinterpret_cast<const char16_t *>(chars + len));
-#endif
-
-        }
-        catch (const std::exception &x) {
-            str = std::string();
-        }
-    }
-
-    return str;
-}
-
-// ??? Callers can't handle exceptions so we just ignore errors and return an empty string.
-std::string litecore::jni::JstringToUTF8(JNIEnv *env, jstring jstr) {
-    jsize len = env->GetStringLength(jstr);
-    if (len <= 0)
-        return std::string();
-
-    const jchar *chars = env->GetStringChars(jstr, nullptr);
-    auto ret = JcharsToUTF8(chars, len);
-    env->ReleaseStringChars(jstr, chars);
-    return ret;
-}
-
-// ??? Callers can't handle exceptions so we just ignore errors and return an empty string.
-std::string litecore::jni::JcharArrayToUTF8(JNIEnv *env, jcharArray jcharArray) {
-    jsize len = env->GetArrayLength(jcharArray);
-    if (len <= 0)
-        return std::string();
-
-    jchar *chars = env->GetCharArrayElements(jcharArray, nullptr);
-    auto ret = JcharsToUTF8(chars, len);
-    env->ReleaseCharArrayElements(jcharArray, chars, JNI_ABORT);
-    return ret;
-}
-
 
 // Java ArrayList class
 static jclass cls_ArrayList;                      // global class reference
@@ -145,88 +53,90 @@ static jmethodID m_LiteCoreException_throw;      // static throw
 static bool initC4Glue(JNIEnv *env) {
     {
         jclass localClass = env->FindClass("java/util/ArrayList");
-        if (!localClass)
+        if (localClass == nullptr)
             return false;
 
         cls_ArrayList = reinterpret_cast<jclass>(env->NewGlobalRef(localClass));
-        if (!cls_ArrayList)
+        if (cls_ArrayList == nullptr)
             return false;
 
         m_ArrayList_init = env->GetMethodID(cls_ArrayList, "<init>", "(I)V");
-        if (!m_ArrayList_init)
+        if (m_ArrayList_init == nullptr)
             return false;
 
         m_ArrayList_add = env->GetMethodID(cls_ArrayList, "add", "(Ljava/lang/Object;)Z");
-        if (!m_ArrayList_add)
+        if (m_ArrayList_add == nullptr)
             return false;
     }
     {
         jclass localClass = env->FindClass("java/util/HashSet");
-        if (!localClass)
+        if (localClass == nullptr)
             return false;
 
         cls_HashSet = reinterpret_cast<jclass>(env->NewGlobalRef(localClass));
-        if (!cls_HashSet)
+        if (cls_HashSet == nullptr)
             return false;
 
         m_HashSet_init = env->GetMethodID(cls_HashSet, "<init>", "(I)V");
-        if (!m_HashSet_init)
+        if (m_HashSet_init == nullptr)
             return false;
 
         m_HashSet_add = env->GetMethodID(cls_HashSet, "add", "(Ljava/lang/Object;)Z");
-        if (!m_HashSet_add)
+        if (m_HashSet_add == nullptr)
             return false;
     }
     {
         jclass localClass = env->FindClass("com/couchbase/lite/internal/fleece/FLSliceResult");
-        if (!localClass)
+        if (localClass == nullptr)
             return false;
 
         cls_FLSliceResult = reinterpret_cast<jclass>(env->NewGlobalRef(localClass));
-        if (!cls_FLSliceResult)
+        if (cls_FLSliceResult == nullptr)
             return false;
 
         m_FLSliceResult_createManaged = env->GetStaticMethodID(
                 cls_FLSliceResult,
                 "createManagedSlice",
                 "(JJ)Lcom/couchbase/lite/internal/fleece/FLSliceResult;");
-        if (!m_FLSliceResult_createManaged)
+        if (m_FLSliceResult_createManaged == nullptr)
             return false;
 
         m_FLSliceResult_createUnmanaged = env->GetStaticMethodID(
                 cls_FLSliceResult,
                 "createUnmanagedSlice",
                 "(JJ)Lcom/couchbase/lite/internal/fleece/FLSliceResult;");
-        if (!m_FLSliceResult_createUnmanaged)
+        if (m_FLSliceResult_createUnmanaged == nullptr)
             return false;
 
         f_FLSliceResult_base = env->GetFieldID(cls_FLSliceResult, "base", "J");
-        if (!f_FLSliceResult_base)
+        if (f_FLSliceResult_base == nullptr)
             return false;
 
         f_FLSliceResult_size = env->GetFieldID(cls_FLSliceResult, "size", "J");
-        if (!f_FLSliceResult_size)
+        if (f_FLSliceResult_size == nullptr)
             return false;
 
     }
     {
         jclass localClass = env->FindClass("com/couchbase/lite/LiteCoreException");
-        if (!localClass)
+        if (localClass == nullptr)
             return false;
 
         cls_LiteCoreException = reinterpret_cast<jclass>(env->NewGlobalRef(localClass));
-        if (!cls_LiteCoreException)
+        if (cls_LiteCoreException == nullptr)
             return false;
 
-        m_LiteCoreException_throw = env->GetStaticMethodID(cls_LiteCoreException, "throwException", "(IILjava/lang/String;)V");
-        if (!m_LiteCoreException_throw)
+        m_LiteCoreException_throw = env->GetStaticMethodID(
+                cls_LiteCoreException,
+                "throwException",
+                "(IILjava/lang/String;)V");
+        if (m_LiteCoreException_throw == nullptr)
             return false;
     }
 
-    logError("glue initialized");
+    jniLog("glue initialized");
     return true;
 }
-
 
 /*
  * Will be called by JNI when the library is loaded
@@ -249,18 +159,21 @@ JNI_OnLoad(JavaVM *jvm, void *ignore) {
         && initC4Prediction(env)
         #endif
         && initC4Socket(env)) {
-
         assert(gJVM == nullptr);
         gJVM = jvm;
+
         return JNI_VERSION_1_6;
-    } else {
-        return JNI_ERR;
     }
+
+    return JNI_ERR;
 }
 
 namespace litecore {
     namespace jni {
 
+        // ----------------------------------------------------------------------------
+        // JVM
+        // ----------------------------------------------------------------------------
         JavaVM *gJVM;
 
         int attachCurrentThread(JNIEnv **env) {
@@ -271,29 +184,173 @@ namespace litecore {
 #endif
         }
 
+        // ----------------------------------------------------------------------------
+        // Exception Handling
+        // ----------------------------------------------------------------------------
+
+        void throwError(JNIEnv *env, C4Error error, jstring msg) {
+            if (env->ExceptionOccurred())
+                return;
+
+            env->CallStaticVoidMethod(
+                    cls_LiteCoreException,
+                    m_LiteCoreException_throw,
+                    (jint)
+                            error.domain,
+                    (jint) error.code,
+                    msg);
+
+            if (msg != nullptr)env->DeleteLocalRef(msg);
+        }
+
+        void throwError(JNIEnv *env, C4Error error) {
+            C4SliceResult msgSlice = c4error_getMessage(error);
+            jstring msg = toJString(env, msgSlice);
+            c4slice_free(msgSlice);
+            throwError(env, error, msg);
+        }
+
+        void throwError(JNIEnv *env, C4Error error, char const *message) {
+            if (message != nullptr) {
+                jstring msg = UTF8ToJstring(env, message, sizeof(message));
+                if (msg != nullptr) {
+                    throwError(env, error, msg);
+                    return;
+                }
+            }
+            throwError(env, error);
+        }
+
+        // ----------------------------------------------------------------------------
+        // String Conversions
+        // ----------------------------------------------------------------------------
+
+        /**
+         * Java uses Modified-UTF-8, not UTF-8: Attempting to decode a real UTF-8 string will cause a failure that
+         * looks like:
+         *   art/runtime/check_jni.cc:65] JNI DETECTED ERROR IN APPLICATION: input is not valid Modified UTF-8: illegal start byte ...
+         *   art/runtime/check_jni.cc:65]     string: ...
+         *   art/runtime/check_jni.cc:65]     in call to NewStringUTF
+         *  See:
+         *    https://stackoverflow.com/questions/35519823/jni-detected-error-in-application-input-is-not-valid-modified-utf-8-illegal-st
+         *  The strategy here is to use standard C functions to convert the UTF-8 directly to UTF-16,
+         *  which Java handles nicely. These functions are derived from this code
+         *      (https://github.com/incanus/android-jni/blob/master/app/src/main/jni/JNI.cpp#L57-L86):
+         *  ??? Creating the wstring_convert is expensive.  It would be nice to create one
+         *      and to re-use it.  It is *NOT*, however, threadsafe.
+         *  ??? On failure, just return a nullptr.
+         */
+        jstring UTF8ToJstring(JNIEnv *env, const char *s, size_t size) {
+            std::u16string ustr;
+            try {
+#ifdef _MSC_VER
+                auto tmpstr = std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t>().from_bytes(s, s + size);
+        ustr = reinterpret_cast<const char16_t *>(tmpstr.data());
+#else
+                ustr = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>().from_bytes(s, s + size);
+#endif
+            }
+            catch (const std::bad_alloc &x) {
+                jniLog("Failed allocating space to convert string: %s", x.what());
+                return nullptr;
+            }
+            catch (const std::exception &x) {
+                // sadly, we better not try to log the actual string...
+                jniLog("Failed to convert string from UTF-8 to UTF-16: %s", x.what());
+                return nullptr;
+            }
+
+            jstring jstr = env->NewString(reinterpret_cast<const jchar *>(ustr.c_str()), ustr.size());
+            if (jstr == nullptr) {
+                C4Error error = {LiteCoreDomain, kC4ErrorMemoryError, 0};
+                throwError(env, error);
+                return nullptr;
+            }
+
+            return jstr;
+        }
+
+        std::string JcharsToUTF8(const jchar *chars, jsize len) {
+            std::string str;
+
+            if (chars == nullptr) {
+                str = std::string();
+            } else {
+                try {
+#ifdef _MSC_VER
+                    str = std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t>()
+                                .to_bytes(reinterpret_cast<const int16_t *>(chars),
+                                          reinterpret_cast<const int16_t *>(chars + len));
+#else
+                    str = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>()
+                            .to_bytes(reinterpret_cast<const char16_t *>(chars),
+                                      reinterpret_cast<const char16_t *>(chars + len));
+#endif
+
+                }
+                catch (const std::exception &x) {
+                    str = std::string();
+                }
+            }
+
+            return str;
+        }
+
+        // ??? Callers can't handle exceptions so we just ignore errors and return an empty string.
+        std::string JstringToUTF8(JNIEnv *env, jstring jstr) {
+            jsize len = env->GetStringLength(jstr);
+            if (len <= 0)
+                return std::string();
+
+            const jchar *chars = env->GetStringChars(jstr, nullptr);
+            std::string ret = JcharsToUTF8(chars, len);
+            env->ReleaseStringChars(jstr, chars);
+            return ret;
+        }
+
+        // ??? Callers can't handle exceptions so we just ignore errors and return an empty string.
+        std::string JcharArrayToUTF8(JNIEnv *env, jcharArray jcharArray) {
+            jsize len = env->GetArrayLength(jcharArray);
+            if (len <= 0)
+                return std::string();
+
+            jchar *chars = env->GetCharArrayElements(jcharArray, nullptr);
+            std::string ret = JcharsToUTF8(chars, len);
+            env->ReleaseCharArrayElements(jcharArray, chars, JNI_ABORT);
+            return ret;
+        }
+
+        // ----------------------------------------------------------------------------
+        // jstringSlice
+        // ----------------------------------------------------------------------------
+
         jstringSlice::jstringSlice(JNIEnv *env, jstring js) {
             assert(env != nullptr);
-            if (js != nullptr) {
+            if (js == nullptr) {
+                _slice = kFLSliceNull;
+            } else {
                 _str = JstringToUTF8(env, js);
                 _slice = FLStr(_str.c_str());
-            } else {
-                _slice = kFLSliceNull;
             }
         }
 
         jstringSlice::jstringSlice(JNIEnv *env, jcharArray jchars) {
             assert(env != nullptr);
-            if (jchars != nullptr) {
+            if (jchars == nullptr) {
+                _slice = kFLSliceNull;
+            } else {
                 _str = JcharArrayToUTF8(env, jchars);
                 _slice = FLStr(_str.c_str());
-            } else {
-                _slice = kFLSliceNull;
             }
         }
 
         const char *jstringSlice::c_str() {
             return (const char *) _slice.buf;
         }
+
+        // ----------------------------------------------------------------------------
+        // jbyteArraySlice
+        // ----------------------------------------------------------------------------
 
         // ATTN: In critical, cannot call any other JNI methods.
         // http://docs.oracle.com/javase/6/docs/technotes/guides/jni/spec/functions.html
@@ -302,14 +359,19 @@ namespace litecore {
                 : jbyteArraySlice(env, false, jbytes, critical) {}
 
         jbyteArraySlice::jbyteArraySlice(JNIEnv *env, bool delRef, jbyteArray jbytes, bool critical)
-                : jbyteArraySlice(env, delRef, jbytes, (size_t) (!jbytes ? 0 : env->GetArrayLength(jbytes)), critical) {}
+                : jbyteArraySlice(
+                env,
+                delRef,
+                jbytes,
+                (size_t) (!jbytes ? 0 : env->GetArrayLength(jbytes)),
+                critical) {}
 
         jbyteArraySlice::jbyteArraySlice(JNIEnv *env, bool delRef, jbyteArray jbytes, size_t length, bool critical)
                 : _env(env),
                   _jbytes(jbytes),
                   _critical(critical),
                   _delRef(delRef) {
-            if (!jbytes || length <= 0) {
+            if ((jbytes == nullptr) || (length <= 0)) {
                 _slice = kFLSliceNull;
                 return;
             }
@@ -325,7 +387,7 @@ namespace litecore {
         }
 
         jbyteArraySlice::~jbyteArraySlice() {
-            if (_slice.buf) {
+            if (_slice.buf != nullptr) {
                 if (_critical) {
                     _env->ReleasePrimitiveArrayCritical(_jbytes, (void *) _slice.buf, JNI_ABORT);
                 } else {
@@ -340,23 +402,9 @@ namespace litecore {
             return FLSlice_Copy(bytes);
         }
 
-        void throwError(JNIEnv *env, C4Error error) {
-            if (env->ExceptionOccurred())
-                return;
-
-            C4SliceResult msgSlice = c4error_getMessage(error);
-            jstring msg = toJString(env, msgSlice);
-            c4slice_free(msgSlice);
-
-            env->CallStaticVoidMethod(
-                    cls_LiteCoreException,
-                    m_LiteCoreException_throw,
-                    (jint) error.domain,
-                    (jint) error.code,
-                    msg);
-
-            if (msg) env->DeleteLocalRef(msg);
-        }
+        // ----------------------------------------------------------------------------
+        // Other Glue
+        // ----------------------------------------------------------------------------
 
         jstring toJString(JNIEnv *env, C4Slice s) {
             if (s.buf == nullptr)
@@ -373,84 +421,13 @@ namespace litecore {
             if (s.buf == nullptr)
                 return nullptr;
             jbyteArray array = env->NewByteArray((jsize) s.size);
-            if (array)
+            if (array != nullptr)
                 env->SetByteArrayRegion(array, 0, (jsize) s.size, (const jbyte *) s.buf);
             return array;
         }
 
         jbyteArray toJByteArray(JNIEnv *env, C4SliceResult s) {
             return toJByteArray(env, (C4Slice) s);
-        }
-
-        bool getEncryptionKey(JNIEnv *env, jint keyAlg, jbyteArray jKeyBytes, C4EncryptionKey *outKey) {
-            outKey->algorithm = (C4EncryptionAlgorithm) keyAlg;
-            if (keyAlg != kC4EncryptionNone) {
-                jbyteArraySlice keyBytes(env, jKeyBytes);
-                FLSlice keySlice = keyBytes;
-                if (!keySlice.buf || keySlice.size > sizeof(outKey->bytes)) {
-                    throwError(env, C4Error{LiteCoreDomain, kC4ErrorCrypto});
-                    return false;
-                }
-                memset(outKey->bytes, 0, sizeof(outKey->bytes));
-                memcpy(outKey->bytes, keySlice.buf, keySlice.size);
-            }
-            return true;
-        }
-
-        jobject toStringList(JNIEnv *env, const FLMutableArray array) {
-            uint32_t n = FLArray_Count(array);
-            jobject result = env->NewObject(cls_ArrayList, m_ArrayList_init, (jint) n);
-
-            if (!array)
-                return result;
-
-            for (int i = 0; i < n; i++) {
-                auto arrayElem = FLArray_Get(array, (uint32_t) i);
-                if (!arrayElem)
-                    continue;
-
-                auto str = FLValue_AsString((FLValue) arrayElem);
-                if (!str)
-                    continue;
-
-                jstring jstr = toJString(env, str);
-                if (!jstr)
-                    continue;
-
-                env->CallBooleanMethod(result, m_ArrayList_add, jstr);
-
-                env->DeleteLocalRef(jstr);
-            }
-
-            return result;
-        }
-
-        jobject toStringSet(JNIEnv *env, const FLMutableArray array) {
-            uint32_t n = FLArray_Count(array);
-            jobject result = env->NewObject(cls_HashSet, m_HashSet_init, (jint) n);
-
-            if (!array)
-                return result;
-
-            for (int i = 0; i < n; i++) {
-                auto arrayElem = FLArray_Get(array, (uint32_t) i);
-                if (!arrayElem)
-                    continue;
-
-                auto str = FLValue_AsString((FLValue) arrayElem);
-                if (!str)
-                    continue;
-
-                jstring jstr = toJString(env, str);
-                if (!jstr)
-                    continue;
-
-                env->CallBooleanMethod(result, m_HashSet_add, jstr);
-
-                env->DeleteLocalRef(jstr);
-            }
-
-            return result;
         }
 
         jobject toJavaFLSliceResult(JNIEnv *const env, const FLSliceResult &sr) {
@@ -474,6 +451,74 @@ namespace litecore {
             auto size = (size_t) env->GetLongField(jsr, f_FLSliceResult_size);
             C4SliceResult sliceResult{base, size};
             return sliceResult;
+        }
+
+        jobject toStringList(JNIEnv *env, const FLMutableArray array) {
+            uint32_t n = FLArray_Count(array);
+            jobject result = env->NewObject(cls_ArrayList, m_ArrayList_init, (jint) n);
+
+            if (array == nullptr)
+                return result;
+
+            for (int i = 0; i < n; i++) {
+                FLValue arrayElem = FLArray_Get(array, (uint32_t) i);
+                if (arrayElem == nullptr) continue;
+
+                FLSlice str = FLValue_AsString(arrayElem);
+                if (!str) continue;
+
+                jstring jstr = toJString(env, str);
+                if (!jstr) continue;
+
+                env->CallBooleanMethod(result, m_ArrayList_add, jstr);
+
+                env->DeleteLocalRef(jstr);
+            }
+
+            return result;
+        }
+
+        jobject toStringSet(JNIEnv *env, const FLMutableArray array) {
+            uint32_t n = FLArray_Count(array);
+            jobject result = env->NewObject(cls_HashSet, m_HashSet_init, (jint) n);
+
+            if (!array)
+                return result;
+
+            for (int i = 0; i < n; i++) {
+                FLValue arrayElem = FLArray_Get(array, (uint32_t) i);
+                if (arrayElem == nullptr) continue;
+
+                FLSlice str = FLValue_AsString(arrayElem);
+                if (!str) continue;
+
+                jstring jstr = toJString(env, str);
+                if (!jstr) continue;
+
+                env->CallBooleanMethod(result, m_HashSet_add, jstr);
+
+                env->DeleteLocalRef(jstr);
+            }
+
+            return result;
+        }
+
+        bool getEncryptionKey(JNIEnv *env, jint keyAlg, jbyteArray jKeyBytes, C4EncryptionKey *outKey) {
+            outKey->algorithm = (C4EncryptionAlgorithm) keyAlg;
+            if (keyAlg == kC4EncryptionNone)
+                return true;
+
+            jbyteArraySlice keyBytes(env, jKeyBytes);
+            FLSlice keySlice = keyBytes;
+            if ((!keySlice) || (keySlice.size > sizeof(outKey->bytes))) {
+                throwError(env, C4Error{LiteCoreDomain, kC4ErrorCrypto});
+                return false;
+            }
+
+            memset(outKey->bytes, 0, sizeof(outKey->bytes));
+            memcpy(outKey->bytes, keySlice.buf, keySlice.size);
+
+            return true;
         }
     }
 }

--- a/common/main/cpp/native_glue.hh
+++ b/common/main/cpp/native_glue.hh
@@ -59,8 +59,6 @@ namespace litecore {
 
         std::string JcharArrayToUTF8(JNIEnv *env, const jcharArray jcharArray);
 
-        std::string JcharsToUTF8(JNIEnv *env, const jchar *jchars, jsize len);
-
         jstring UTF8ToJstring(JNIEnv *env, const char *s, size_t size);
 
         // Creates a temporary slice value from a Java String object
@@ -84,13 +82,15 @@ namespace litecore {
 
         // Creates a temporary slice value from a Java byte[], attempting to avoid copying
         class jbyteArraySlice {
-        public:
             // Warning: If `critical` is true, you cannot make any further JNI calls (except other
             // critical accesses) until this object goes out of scope or is deleted.
             // That includes any attempt to log anything.
+        public:
             jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, bool critical = false);
 
-            jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, size_t length, bool critical = false);
+            jbyteArraySlice(JNIEnv *env, bool delRef, jbyteArray jbytes, bool critical = false);
+
+            jbyteArraySlice(JNIEnv *env, bool delRef, jbyteArray jbytes, size_t length, bool critical = false);
 
             ~jbyteArraySlice();
 
@@ -108,6 +108,7 @@ namespace litecore {
             JNIEnv *_env;
             jbyteArray _jbytes;
             bool _critical;
+            bool _delRef;
         };
 
         // Creates a Java String from the contents of a C4Slice.
@@ -123,10 +124,11 @@ namespace litecore {
         jbyteArray toJByteArray(JNIEnv *, C4SliceResult);
 
         // Copies an encryption key to a C4EncryptionKey. Returns false on exception.
-        bool getEncryptionKey(JNIEnv *env,
-                              jint keyAlg,
-                              jbyteArray jKeyBytes,
-                              C4EncryptionKey *outKey);
+        bool getEncryptionKey(
+                JNIEnv *env,
+                jint keyAlg,
+                jbyteArray jKeyBytes,
+                C4EncryptionKey *outKey);
 
         // lightweight logging
         void logError(const char *fmt, ...);

--- a/common/main/cpp/native_glue.hh
+++ b/common/main/cpp/native_glue.hh
@@ -42,24 +42,32 @@ namespace litecore {
 
         extern JavaVM *gJVM;
 
-        int attachCurrentThread(JNIEnv **p_env);
-
         bool initC4Logging(JNIEnv *env); // Implemented in native_c4.cc
         bool initC4Observer(JNIEnv *);   // Implemented in native_c4observer.cc
         bool initC4Replicator(JNIEnv *); // Implemented in native_c4replicator.cc
         bool initC4Socket(JNIEnv *);     // Implemented in native_c4socket.cc
 
 #ifdef COUCHBASE_ENTERPRISE
-
         bool initC4Prediction(JNIEnv *); // Implemented in native_c4prediction.cc
         bool initC4Listener(JNIEnv *);   // Implemented in native_c4listener.cc
 #endif
+
+        int attachCurrentThread(JNIEnv **p_env);
+
+        // Sets a Java exception based on the LiteCore error.
+        void throwError(JNIEnv *, C4Error);
+
+        // Sets a Java exception based on the LiteCore error.
+        void throwError(JNIEnv *, C4Error, const char *msg);
+
+        jstring UTF8ToJstring(JNIEnv *env, const char *s, size_t size);
 
         std::string JstringToUTF8(JNIEnv *env, jstring jstr);
 
         std::string JcharArrayToUTF8(JNIEnv *env, const jcharArray jcharArray);
 
-        jstring UTF8ToJstring(JNIEnv *env, const char *s, size_t size);
+        // lightweight logging: defined in native_c4.cc
+        void jniLog(const char *fmt, ...);
 
         // Creates a temporary slice value from a Java String object
         class jstringSlice {
@@ -95,7 +103,7 @@ namespace litecore {
             ~jbyteArraySlice();
 
             jbyteArraySlice(jbyteArraySlice &&s) // move constructor
-                    : _slice(s._slice), _env(s._env), _jbytes(s._jbytes),
+                    : _slice(s._slice), _env(s._env), _delRef(s._delRef), _jbytes(s._jbytes),
                       _critical(s._critical) { s._slice = kFLSliceNull; }
 
             operator FLSlice() { return _slice; }
@@ -123,19 +131,6 @@ namespace litecore {
 
         jbyteArray toJByteArray(JNIEnv *, C4SliceResult);
 
-        // Copies an encryption key to a C4EncryptionKey. Returns false on exception.
-        bool getEncryptionKey(
-                JNIEnv *env,
-                jint keyAlg,
-                jbyteArray jKeyBytes,
-                C4EncryptionKey *outKey);
-
-        // lightweight logging
-        void logError(const char *fmt, ...);
-
-        // Sets a Java exception based on the LiteCore error.
-        void throwError(JNIEnv *, C4Error);
-
         // Copy a FLMutableArray of strings to a Java ArrayList<String>
         jobject toStringList(JNIEnv *env, FLMutableArray array);
 
@@ -150,6 +145,13 @@ namespace litecore {
 
         // Copy a Java FLSliceResult to a native FLSliceResult
         FLSliceResult fromJavaFLSliceResult(JNIEnv *const env, jobject jsr);
+
+        // Copies an encryption key to a C4EncryptionKey. Returns false on exception.
+        bool getEncryptionKey(
+                JNIEnv *env,
+                jint keyAlg,
+                jbyteArray jKeyBytes,
+                C4EncryptionKey *outKey);
     }
 }
 

--- a/common/main/java/com/couchbase/lite/BasicAuthenticator.java
+++ b/common/main/java/com/couchbase/lite/BasicAuthenticator.java
@@ -88,7 +88,10 @@ public final class BasicAuthenticator extends BaseAuthenticator {
     @SuppressWarnings("NoFinalizer")
     @Override
     protected void finalize() throws Throwable {
-        try { Arrays.fill(password, (char) 0); }
+        try {
+            final char[] pwd = password;
+            if (pwd != null) { Arrays.fill(pwd, (char) 0); }
+        }
         finally { super.finalize(); }
     }
 

--- a/common/test/java/com/couchbase/lite/internal/core/C4BaseTest.java
+++ b/common/test/java/com/couchbase/lite/internal/core/C4BaseTest.java
@@ -243,9 +243,9 @@ public class C4BaseTest extends BaseTest {
 
     private void createRev(C4Collection coll, String docID, String revID, byte[] body, int flags)
         throws LiteCoreException {
-        boolean commit = false;
-
         C4Database db = coll.getDb();
+
+        boolean commit = false;
         db.beginTransaction();
         try {
             C4Document curDoc = getOrCreateDocument(coll, docID);
@@ -257,10 +257,6 @@ public class C4BaseTest extends BaseTest {
             String[] history = revIDs.toArray(new String[0]);
             C4Document doc = C4TestUtils.create(coll, body, docID, flags, true, false, history, true, 0, 0);
             assertNotNull(doc);
-
-            doc.close();
-            // don't try to close the C4Document
-
             commit = true;
         }
         finally {

--- a/common/test/java/com/couchbase/lite/internal/core/C4QueryTest.java
+++ b/common/test/java/com/couchbase/lite/internal/core/C4QueryTest.java
@@ -264,8 +264,6 @@ public class C4QueryTest extends C4QueryBaseTest {
                     0,
                     0);
                 assertNotNull(updatedDoc);
-                doc.close();
-                updatedDoc.close();
                 commit = true;
             }
             finally {


### PR DESCRIPTION
This is a pretty big commit.  There are two functional changes:
- Use FLEncoder_GetErrorMessage to give better error messages when the encoder fails
- LocalRefs are explicitly freed as soon as possible (DeleteLocalRef, or DetachCurrentThread)

The rest of the changes (that is, most of them)  are just an attempt to normalize the code:
- logError renamed as jniLog, because it is used to log things other than errors
- pointers are explicitly compared to nullptr for verification
- SliceResults are verified using their bool op
- "auto" used only if the right side of the assignment makes the type absolutely clear.
- FSSliceResults are freed with FLSliceResult_Release; C4Slices are freed with its alias c4slice_free
- boolean returns are now named "ok", pretty much universally.
- some line wrapping to make the code fit on the page


