### PR TITLE
CBL-6230: Move C4Query to the Cleaner

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/core/C4QueryObserver.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4QueryObserver.java
@@ -61,7 +61,7 @@ public final class C4QueryObserver extends C4NativePeer {
         @NonNull QueryChangeCallback callback) {
         final long token = QUERY_OBSERVER_CONTEXT.reserveKey();
 
-        final long peer = impl.nCreate(token, query.getPeer());
+        final long peer = query.withPeerOrThrow(queryPeer -> impl.nCreate(token, queryPeer));
 
         final C4QueryObserver observer = new C4QueryObserver(impl, peer, queryEnumeratorFactory, token, callback);
         QUERY_OBSERVER_CONTEXT.bind(token, observer);

--- a/common/main/java/com/couchbase/lite/internal/core/peers/TaggedWeakPeerBinding.java
+++ b/common/main/java/com/couchbase/lite/internal/core/peers/TaggedWeakPeerBinding.java
@@ -43,6 +43,9 @@ public class TaggedWeakPeerBinding<T> extends WeakPeerBinding<T> {
      * Sometimes the object to be put into the map needs to know
      * its own token.  Pre-reserving it makes it possible to make it final.
      *
+     * Don't leak keys.  If code throws an exception between this call
+     * and when you actually bind the key, it will be lost.
+     *
      * @return a unique value 3 <= key < Integer.MAX_VALUE - 1.
      */
     public synchronized long reserveKey() {


### PR DESCRIPTION
Also: Catch leaking PeerBinding tokens