### PR TITLE
Port MMap API to 4_0

### DIFF
--- a/common/main/cpp/com_couchbase_lite_internal_core_C4TestUtils.h
+++ b/common/main/cpp/com_couchbase_lite_internal_core_C4TestUtils.h
@@ -175,9 +175,9 @@ JNICALL Java_com_couchbase_lite_internal_core_C4TestUtils_encodeJSON
 /*
  * Class:     com_couchbase_lite_internal_core_C4TestUtils
  * Method:    getFlags
- * Signature: (J)I
+ * Signature: (J)J
  */
-JNIEXPORT jint JNICALL
+JNIEXPORT jlong JNICALL
 Java_com_couchbase_lite_internal_core_C4TestUtils_getFlags(
         JNIEnv *, jclass, jlong);
 

--- a/common/main/cpp/native_c4testutils.cc
+++ b/common/main/cpp/native_c4testutils.cc
@@ -308,9 +308,9 @@ Java_com_couchbase_lite_internal_core_C4TestUtils_encodeJSON(
 /*
  * Class:     com_couchbase_lite_internal_core_C4TestUtils
  * Method:    getFlags
- * Signature: (J)I
+ * Signature: (J)J
  */
-JNIEXPORT jint JNICALL
+JNIEXPORT jlong JNICALL
 Java_com_couchbase_lite_internal_core_C4TestUtils_getFlags(
         JNIEnv *env,
         jclass ignore,
@@ -318,10 +318,10 @@ Java_com_couchbase_lite_internal_core_C4TestUtils_getFlags(
     const C4DatabaseConfig2 *config = c4db_getConfig2((C4Database *) db);
     if (config == nullptr) {
         throwError(env, {LiteCoreDomain, kC4ErrorNotOpen});
-        return 0;
+        return 0L;
     }
 
-    return (jint) config->flags;
+    return (jlong) config->flags;
 }
 
 // C4Document

--- a/common/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/common/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -602,12 +602,24 @@ abstract class AbstractDatabase extends BaseDatabase
         return (blob.updateSize() < 0) ? null : blob;
     }
 
+    /**
+     * Returns a copy of the database configuration.
+     *
+     * @return the READONLY copied config object
+     */
+    @NonNull
+    public DatabaseConfiguration getConfig() { return new DatabaseConfiguration(config); }
+
     // - Object methods:
 
     @NonNull
     @Override
     public String toString() {
-        return "Database{@" + ClassUtils.objId(this) + ": '" + name  + ((config.isFullSync() ? "!" : "") + "'}");
+        return "Database{@" + ClassUtils.objId(this)
+            + ": '" + name
+            + (config.isFullSync() ? "!" : "")
+            + (config.isMMapEnabled() ? "*" : "")
+            + "'}";
     }
 
     @Override
@@ -638,14 +650,6 @@ abstract class AbstractDatabase extends BaseDatabase
         }
         catch (CouchbaseLiteException e) { throw new CouchbaseLiteError("Failed getting default collection", e); }
     }
-
-    /**
-     * Returns a copy of the database configuration.
-     *
-     * @return the READONLY copied config object
-     */
-    @NonNull
-    public DatabaseConfiguration getConfig() { return new DatabaseConfiguration(config); }
 
     /**
      * Gets an existing Document with the given ID from the default collection.
@@ -1321,6 +1325,7 @@ abstract class AbstractDatabase extends BaseDatabase
                 parentDirPath,
                 name,
                 config.isFullSync(),
+                config.isMMapEnabled(),
                 getEncryptionAlgorithm(),
                 getEncryptionKey());
         }

--- a/common/main/java/com/couchbase/lite/AbstractDatabaseConfiguration.java
+++ b/common/main/java/com/couchbase/lite/AbstractDatabaseConfiguration.java
@@ -30,27 +30,32 @@ abstract class AbstractDatabaseConfiguration {
     //---------------------------------------------
     private String dbDirectory;
     private boolean fullSync;
+    private boolean mmapEnabled;
 
     //---------------------------------------------
     // Constructors
     //---------------------------------------------
-    protected AbstractDatabaseConfiguration() { this(null, Defaults.Database.FULL_SYNC); }
+    protected AbstractDatabaseConfiguration() {
+        this(null, Defaults.Database.FULL_SYNC, Defaults.Database.MMAP_ENABLED);
+    }
 
     protected AbstractDatabaseConfiguration(@Nullable AbstractDatabaseConfiguration config) {
         this(
             (config == null) ? null : config.getDirectory(),
-            (config == null) ? Defaults.Database.FULL_SYNC : config.isFullSync()
+            (config == null) ? Defaults.Database.FULL_SYNC : config.isFullSync(),
+            (config == null) ? Defaults.Database.MMAP_ENABLED : config.isMMapEnabled()
         );
     }
 
     protected AbstractDatabaseConfiguration(@NonNull BaseImmutableDatabaseConfiguration config) {
-        this(config.getDirectory(), config.isFullSync());
+        this(config.getDirectory(), config.isFullSync(), config.isMMapEnabled());
     }
 
-    private AbstractDatabaseConfiguration(@Nullable String dbDir, boolean fullSync) {
+    private AbstractDatabaseConfiguration(@Nullable String dbDir, boolean fullSync, boolean mmapEnabled) {
         CouchbaseLiteInternal.requireInit("Cannot create database configuration");
         this.dbDirectory = (dbDir != null) ? dbDir : CouchbaseLiteInternal.getDefaultDbDirPath();
         this.fullSync = fullSync;
+        this.mmapEnabled = mmapEnabled;
     }
 
     //---------------------------------------------
@@ -61,7 +66,7 @@ abstract class AbstractDatabaseConfiguration {
      * Set the canonical path of the directory in which to store the database.
      * If the directory doesn't already exist it will be created.
      * If it cannot be created an CouchbaseLiteError will be thrown.
-     *
+     * <p>
      * Note: The directory set by this method is the canonical path to the
      * directory whose path is passed.  It is *NOT* necessarily the case that
      * directory.equals(config.setDirectory(directory).getDirectory())
@@ -84,7 +89,7 @@ abstract class AbstractDatabaseConfiguration {
      * Returns the path to the directory that contains the database.
      * If this path has not been set explicitly (see: <code>setDirectory</code> below),
      * then it is the system default.
-     *
+     * <p>
      * Note: The directory returned by this method is the canonical path to the
      * directory whose path was set.  It is *NOT* necessarily the case that
      * directory.equals(config.setDirectory(directory).getDirectory())
@@ -102,13 +107,25 @@ abstract class AbstractDatabaseConfiguration {
      * very safe but it is also <b>dramatically</b> slower.
      */
     @NonNull
-    public DatabaseConfiguration setFullSync(boolean isfullSync) {
-        this.fullSync = isfullSync;
+    public DatabaseConfiguration setFullSync(boolean isFullSync) {
+        this.fullSync = isFullSync;
         return getDatabaseConfiguration();
     }
 
     public boolean isFullSync() { return fullSync; }
 
+    /**
+     * Advises Core to enable or disable memory-mapped Database files, if possible.
+     * Nmory-mapped database files are, currently, enabled by default, except on MacOS
+     * where they <b>cannot</b> be enabled at all.
+     */
+    @NonNull
+    public DatabaseConfiguration setMMapEnabled(boolean mmapEnabled) {
+        this.mmapEnabled = mmapEnabled;
+        return getDatabaseConfiguration();
+    }
+
+    public boolean isMMapEnabled() { return mmapEnabled; }
 
     //---------------------------------------------
     // Protected level access

--- a/common/main/java/com/couchbase/lite/AbstractReplicatorConfiguration.java
+++ b/common/main/java/com/couchbase/lite/AbstractReplicatorConfiguration.java
@@ -433,7 +433,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
      *
      * @param replicatorType The replicator type.
      * @return this.
-     * @deprecated Use setType(AbstractReplicator.ReplicatorType)
+     * @deprecated Use setType(com.couchbase.lite.ReplicatorType)
      */
     @SuppressWarnings({"DeprecatedIsStillUsed", "deprecation"})
     @Deprecated
@@ -463,7 +463,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
      *
      * @param pinnedCert the SSL certificate.
      * @return this.
-     * @deprecated Please use setPinnedServerX509Certificate(Certificate)
+     * @deprecated Use setPinnedServerX509Certificate(Certificate)
      */
     @Deprecated
     @NonNull
@@ -689,7 +689,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
     /**
      * Old getter for Replicator type indicating the direction of the replicator.
      *
-     * @deprecated Use getType()
+     * @deprecated Use com.couchbase.lite.ReplicatorType ReplicatorConfiguration.getType()
      */
     @SuppressWarnings({"DeprecatedIsStillUsed", "deprecation"})
     @Deprecated

--- a/common/main/java/com/couchbase/lite/internal/BaseImmutableDatabaseConfiguration.java
+++ b/common/main/java/com/couchbase/lite/internal/BaseImmutableDatabaseConfiguration.java
@@ -21,11 +21,10 @@ import androidx.annotation.Nullable;
 import com.couchbase.lite.DatabaseConfiguration;
 import com.couchbase.lite.Defaults;
 
-
+@SuppressWarnings({"LineLength", "PMD.CommentSize"})
 /**
- * A bit odd.  Why are these properties not simply properties on the AbstractDatabase object?
- * Because they are mandated by a spec:
- * https://docs.google.com/document/d/16XmIOw7aZ_NcFc6Dy6fc1jV7sc994r6iv5qm9_J7qKo/edit#heading=h.kt1n12mtpzx4
+ * These could just be properties on the AbstractDatabase object.  They are, however, mandated by a
+ * <a href="https://docs.google.com/document/d/16XmIOw7aZ_NcFc6Dy6fc1jV7sc994r6iv5qm9_J7qKo/edit#heading=h.kt1n12mtpzx4">spec</a>
  */
 public class BaseImmutableDatabaseConfiguration {
     //-------------------------------------------------------------------------
@@ -34,6 +33,7 @@ public class BaseImmutableDatabaseConfiguration {
     @NonNull
     private final String dbDir;
     private final boolean fullSync;
+    private final boolean mmapEnabled;
 
     //-------------------------------------------------------------------------
     // Constructors
@@ -42,6 +42,7 @@ public class BaseImmutableDatabaseConfiguration {
         final String dbDirectory = (config == null) ? null : config.getDirectory();
         this.dbDir = (dbDirectory != null) ? dbDirectory : CouchbaseLiteInternal.getDefaultDbDirPath();
         this.fullSync = (config == null) ? Defaults.Database.FULL_SYNC : config.isFullSync();
+        this.mmapEnabled = (config == null) ? Defaults.Database.MMAP_ENABLED : config.isMMapEnabled();
     }
 
     //-------------------------------------------------------------------------
@@ -51,4 +52,6 @@ public class BaseImmutableDatabaseConfiguration {
     public final String getDirectory() { return dbDir; }
 
     public final boolean isFullSync() { return fullSync; }
+
+    public final boolean isMMapEnabled() { return mmapEnabled; }
 }

--- a/common/main/java/com/couchbase/lite/internal/core/C4Constants.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Constants.java
@@ -70,17 +70,15 @@ public final class C4Constants {
     // C4DatabaseFlags
     public static final class DatabaseFlags {
         private DatabaseFlags() { }
-        // why most of these are visible in the LiteCore API is utterly beyond me
-
         // @formatter:off
         static final long CREATE = 0x01;                 // Create the file if it doesn't exist
         @VisibleForTesting
         static final long READ_ONLY = 0x02;              // Open file read-only
         private static final long AUTO_COMPACT = 0x04;   // Enable auto-compaction [UNIMPLEMENTED]
         static final long VERSION_VECTORS = 0x08;        // Upgrade DB to version vectors instead of rev trees [EXPERIMENTAL]
+        public static final long DISABLE_MMAP = 0x10;    // Disable MMAP in SQLite.
         private static final long NO_UPGRADE = 0x20;     // Disable upgrading an older-version database
         private static final long NON_OBSERVABLE = 0x40; // Disable database/collection observers, for slightly faster writes
-        @VisibleForTesting
         public static final long DISC_FULL_SYNC = 0x80;  // Flush to disk after each transaction
         private static final long FAKE_CLOCK = 0x100;    // Use counters instead of timestamps in version vectors (TESTS ONLY)
         // @formatter:on

--- a/common/main/java/com/couchbase/lite/internal/core/C4Database.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Database.java
@@ -198,11 +198,13 @@ public abstract class C4Database extends C4Peer {
         @NonNull String parentDirPath,
         @NonNull String name,
         boolean isFullSync,
+        boolean isMMapEnabled,
         int algorithm,
         @Nullable byte[] encryptionKey)
         throws LiteCoreException {
         long flags = C4Constants.DatabaseFlags.CREATE;
         if (isFullSync) { flags |= C4Constants.DatabaseFlags.DISC_FULL_SYNC; }
+        if (!isMMapEnabled) { flags |= C4Constants.DatabaseFlags.DISABLE_MMAP; }
         return getDatabase(NATIVE_IMPL, parentDirPath, name, flags, algorithm, encryptionKey);
     }
 

--- a/common/main/java/com/couchbase/lite/internal/core/C4Query.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Query.java
@@ -93,7 +93,7 @@ public final class C4Query extends C4Peer {
 
     @Nullable
     public C4QueryEnumerator run(@NonNull FLSliceResult params) throws LiteCoreException {
-        return withPeerOrNull(h -> C4QueryEnumerator.create(impl.nRun(h, params.getBase(), params.getSize())));
+        return withPeerOrNull(peer -> C4QueryEnumerator.create(impl.nRun(peer, params.getBase(), params.getSize())));
     }
 
     public int getColumnCount() { return withPeerOrDefault(0, impl::nColumnCount); }

--- a/common/main/kotlin/com/couchbase/lite/CommonConfigurationFactories.kt
+++ b/common/main/kotlin/com/couchbase/lite/CommonConfigurationFactories.kt
@@ -146,11 +146,11 @@ fun LogFileConfiguration?.newConfig(
  * @param expressions (required) the expressions to be matched.
  *
  * @see com.couchbase.lite.FullTextIndexConfiguration
- * @deprecated Use FullTextIndexConfiguration().newConfig(vararg expressions: String, language: String?, ignoreAccents: Boolean?)
+ * @deprecated Use FullTextIndexConfiguration?.newConfig(vararg expressions: String, language: String?, ignoreAccents: Boolean?)
  */
 @Deprecated(
-    "Use FullTextIndexConfiguration().newConfig(vararg expressions: String, language: String?, ignoreAccents: Boolean?)",
-    replaceWith = ReplaceWith("FullTextIndexConfiguration().newConfig(vararg expressions: String, language: String?, ignoreAccents: Boolean?)")
+    "Use FullTextIndexConfiguration?.newConfig(vararg expressions: String, language: String?, ignoreAccents: Boolean?)",
+    replaceWith = ReplaceWith("FullTextIndexConfiguration?.newConfig(vararg expressions: String, language: String?, ignoreAccents: Boolean?)")
 )
 fun FullTextIndexConfiguration?.create(
     vararg expressions: String = emptyArray(),
@@ -165,11 +165,11 @@ fun FullTextIndexConfiguration?.create(
  * @param expressions (required) the expressions to be matched.
  *
  * @see com.couchbase.lite.ValueIndexConfiguration
- * @deprecated Use ValueIndexConfiguration().newConfig(vararg expressions: String)
+ * @deprecated Use ValueIndexConfiguration?.newConfig(vararg expressions: String)
  */
 @Deprecated(
-    "Use ValueIndexConfiguration().newConfig(vararg expressions: String)",
-    replaceWith = ReplaceWith("ValueIndexConfiguration().newConfig(vararg expressions: String)")
+    "Use ValueIndexConfiguration?.newConfig(vararg expressions: String)",
+    replaceWith = ReplaceWith("ValueIndexConfiguration?.newConfig(vararg expressions: String)")
 )
 fun ValueIndexConfiguration?.create(vararg expressions: String = emptyArray()) = this.newConfig(*expressions)
 
@@ -183,11 +183,11 @@ fun ValueIndexConfiguration?.create(vararg expressions: String = emptyArray()) =
  * @param usePlainText whether or not to log in plaintext.
  *
  * @see com.couchbase.lite.LogFileConfiguration
- * @deprecated Use LogFileConfiguration().newConfig(String?, Long?, Int?, Boolean?)
+ * @deprecated Use LogFileConfiguration?.newConfig(String?, Long?, Int?, Boolean?)
  */
 @Deprecated(
-    "Use LogFileConfiguration().newConfig(String?, Long?, Int?, Boolean?)",
-    replaceWith = ReplaceWith("LogFileConfiguration().newConfig(String?, Long?, Int?, Boolean?)")
+    "Use LogFileConfiguration?.newConfig(String?, Long?, Int?, Boolean?)",
+    replaceWith = ReplaceWith("LogFileConfiguration?.newConfig(String?, Long?, Int?, Boolean?)")
 )
 fun LogFileConfiguration?.create(
     directory: String? = null,

--- a/common/main/kotlin/com/couchbase/lite/CommonFlows.kt
+++ b/common/main/kotlin/com/couchbase/lite/CommonFlows.kt
@@ -120,12 +120,12 @@ fun Query.queryChangeFlow(executor: Executor? = null) = callbackFlow {
  * is provided, the listener will be called on the Flow's CoroutineDispatcher.
  *
  * @see com.couchbase.lite.Database.addChangeListener
- * @deprecated Use getCollection(String, String?).collectionChangeFlow(Executor?)
+ * @deprecated Use Database.getCollection(String, String?).collectionChangeFlow(Executor?)
  */
 @Suppress("DEPRECATION")
 @Deprecated(
-    "Use getCollection(String, String?).collectionChangeFlow(executor)",
-    replaceWith = ReplaceWith("getCollection(String, String?).collectionChangeFlow(executor)")
+    "Use Database.getCollection(String, String?).collectionChangeFlow(executor)",
+    replaceWith = ReplaceWith("Database.getCollection(String, String?).collectionChangeFlow(executor)")
 )
 fun Database.databaseChangeFlow(executor: Executor? = null) = callbackFlow {
     val token = this@databaseChangeFlow.addChangeListener(
@@ -143,12 +143,12 @@ fun Database.databaseChangeFlow(executor: Executor? = null) = callbackFlow {
  * is provided, the listener will be called on the Flow's CoroutineDispatcher.
  *
  * @see com.couchbase.lite.Database.addDocumentChangeListener
- * @deprecated Use getCollection(String, String?).documentChangeFlow(String, Executor?)
+ * @deprecated Use Database.getCollection(String, String?).documentChangeFlow(String, Executor?)
  */
 @Suppress("DEPRECATION")
 @Deprecated(
-    "Use getCollection(String, String?).documentChangeFlow(documentId, executor)",
-    replaceWith = ReplaceWith("getCollection(String, String?).documentChangeFlow(documentId, executor)")
+    "Use Database.getCollection(String, String?).documentChangeFlow(documentId, executor)",
+    replaceWith = ReplaceWith("Database.getCollection(String, String?).documentChangeFlow(documentId, executor)")
 )
 fun Database.documentChangeFlow(documentId: String, executor: Executor? = null) = callbackFlow {
     val token = this@documentChangeFlow.addDocumentChangeListener(

--- a/common/test/java/com/couchbase/lite/DatabaseTest.kt
+++ b/common/test/java/com/couchbase/lite/DatabaseTest.kt
@@ -18,6 +18,7 @@ package com.couchbase.lite
 import com.couchbase.lite.internal.CouchbaseLiteInternal
 import com.couchbase.lite.internal.core.C4Constants
 import com.couchbase.lite.internal.core.C4Database
+import com.couchbase.lite.internal.core.C4TestUtils
 import com.couchbase.lite.internal.utils.FileUtils
 import com.couchbase.lite.internal.utils.SlowTest
 import com.couchbase.lite.internal.utils.StringUtils
@@ -31,7 +32,7 @@ import org.junit.Assert.fail
 import org.junit.Test
 import java.io.File
 import java.nio.charset.StandardCharsets
-import java.util.*
+import java.util.Date
 import java.util.concurrent.FutureTask
 import java.util.concurrent.TimeUnit
 
@@ -179,7 +180,9 @@ class DatabaseTest : BaseDbTest() {
 
             // Attempt to save the doc in the wrong db
             doc.setValue(TEST_DOC_TAG_KEY, "bam!!!")
-            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherCollection.save(doc) }
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) {
+                otherCollection.save(doc)
+            }
         }
     }
 
@@ -198,7 +201,9 @@ class DatabaseTest : BaseDbTest() {
 
             // Attempt to save the doc in a *very* wrong db
             doc.setValue(TEST_DOC_TAG_KEY, "bam!!!")
-            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherCollection.save(doc) }
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) {
+                otherCollection.save(doc)
+            }
         } finally {
             // delete otherDb
             eraseDb(otherDb)
@@ -235,7 +240,9 @@ class DatabaseTest : BaseDbTest() {
         testDatabase.close()
         val doc = MutableDocument()
         doc.setValue(TEST_DOC_TAG_KEY, testTag)
-        assertThrowsCBLException(CBLError.Domain.CBLITE, C4Constants.LiteCoreError.NOT_OPEN) { testCollection.save(doc) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, C4Constants.LiteCoreError.NOT_OPEN) {
+            testCollection.save(doc)
+        }
     }
 
     @Test
@@ -244,7 +251,9 @@ class DatabaseTest : BaseDbTest() {
         testDatabase.delete()
         val doc = MutableDocument()
         doc.setValue(TEST_DOC_TAG_KEY, testTag)
-        assertThrowsCBLException(CBLError.Domain.CBLITE, C4Constants.LiteCoreError.NOT_OPEN) { testCollection.save(doc) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, C4Constants.LiteCoreError.NOT_OPEN) {
+            testCollection.save(doc)
+        }
     }
 
     //---------------------------------------------
@@ -284,7 +293,9 @@ class DatabaseTest : BaseDbTest() {
             assertEquals(n + 1, testCollection.count)
 
             // Delete from the wrong db
-            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherCollection.delete(doc) }
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) {
+                otherCollection.delete(doc)
+            }
         }
     }
 
@@ -301,7 +312,9 @@ class DatabaseTest : BaseDbTest() {
             assertNotSame(otherCollection, testCollection)
 
             // Delete from the different db:
-            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherCollection.delete(doc) }
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) {
+                otherCollection.delete(doc)
+            }
         } finally {
             eraseDb(otherDb)
         }
@@ -388,7 +401,9 @@ class DatabaseTest : BaseDbTest() {
             assertEquals(n + 1, otherCollection.count)
 
             // purge document against other db instance:
-            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherCollection.purge(doc) }
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) {
+                otherCollection.purge(doc)
+            }
         }
     }
 
@@ -406,7 +421,9 @@ class DatabaseTest : BaseDbTest() {
             assertEquals(0, otherCollection.count)
 
             // Purge document against other db:
-            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) { otherCollection.purge(doc) }
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) {
+                otherCollection.purge(doc)
+            }
         } finally {
             eraseDb(otherDb)
         }
@@ -593,7 +610,9 @@ class DatabaseTest : BaseDbTest() {
     fun testCloseInInBatch() {
         testDatabase.inBatch<RuntimeException> {
             // can't close a db in a transaction
-            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.TRANSACTION_NOT_CLOSED) { testDatabase.close() }
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.TRANSACTION_NOT_CLOSED) {
+                testDatabase.close()
+            }
         }
     }
 
@@ -714,7 +733,9 @@ class DatabaseTest : BaseDbTest() {
         val path = File(testDatabase.path!!)
         assertTrue(path.exists())
         testDatabase.inBatch<RuntimeException> {
-            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.TRANSACTION_NOT_CLOSED) { testDatabase.delete() }
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.TRANSACTION_NOT_CLOSED) {
+                testDatabase.delete()
+            }
         }
     }
 
@@ -761,7 +782,9 @@ class DatabaseTest : BaseDbTest() {
         assertNotNull(path)
         assertTrue(path.exists())
 
-        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.BUSY) { Database.delete(testDatabase.name, null) }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.BUSY) {
+            Database.delete(testDatabase.name, null)
+        }
     }
 
     @Test
@@ -923,7 +946,9 @@ class DatabaseTest : BaseDbTest() {
             // All of these things should throw
             assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.getDocument(doc.id) }
 
-            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.save(MutableDocument()) }
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) {
+                collection.save(MutableDocument())
+            }
 
             assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.delete(doc) }
 
@@ -1885,6 +1910,44 @@ class DatabaseTest : BaseDbTest() {
         }
     }
 
+    /**
+     * Steps
+     * 1. Create a DatabaseConfiguration object and set mmapEnabled to false.
+     * 2. Create a database with the config.
+     * 3. Get the configuration object from the database and check that the mmapEnabled is false.
+     * 4. Use c4db_config2 to confirm that its config contains the kC4DB_MmapDisabled flag
+     * 5. Set the config's mmapEnabled property true
+     * 6. Create a database with the config.
+     * 7. Get the configuration object from the database and verify that mmapEnabled is true
+     * 8. Use c4db_config2 to confirm that its config doesn't contains the kC4DB_MmapDisabled flag
+     */
+    @Test
+    fun testDatabaseWithConfiguredMMap() {
+        val config = DatabaseConfiguration()
+        config.setMMapEnabled(false)
+
+        var db = createDb("mmapdb1", config)
+        assertFalse(db.config.isMMapEnabled)
+
+        try {
+            assertEquals(
+                C4Constants.DatabaseFlags.DISABLE_MMAP,
+                C4TestUtils.getFlags(db.openC4Database) and C4Constants.DatabaseFlags.DISABLE_MMAP
+            )
+        } finally {
+            eraseDb(db)
+        }
+
+        config.setMMapEnabled(true)
+        db = createDb("mmapdb2", config)
+        assertTrue(db.config.isMMapEnabled)
+
+        try {
+            assertEquals(0, C4TestUtils.getFlags(db.openC4Database) and C4Constants.DatabaseFlags.DISABLE_MMAP)
+        } finally {
+            eraseDb(db)
+        }
+    }
 
     /////////////////////////////////   H E L P E R S   //////////////////////////////////////
 
@@ -1952,6 +2015,7 @@ class DatabaseTest : BaseDbTest() {
                 assertEquals(doc1b.toMap(), savedDoc!!.toMap())
                 assertEquals(4, savedDoc.sequence)
             }
+
             ConcurrencyControl.FAIL_ON_CONFLICT -> {
                 assertFalse(testCollection.save(doc1b, cc))
                 val savedDoc = testCollection.getDocument(doc.id)
@@ -1986,6 +2050,7 @@ class DatabaseTest : BaseDbTest() {
                 assertEquals(3, doc1b.sequence)
                 assertNull(testCollection.getDocument(doc1b.id))
             }
+
             ConcurrencyControl.FAIL_ON_CONFLICT -> {
                 assertFalse(testCollection.delete(doc1b, cc))
                 val savedDoc = testCollection.getDocument(doc.id)
@@ -2013,6 +2078,7 @@ class DatabaseTest : BaseDbTest() {
                 assertEquals(doc1b.toMap(), savedDoc!!.toMap())
                 assertEquals(2, savedDoc.sequence)
             }
+
             ConcurrencyControl.FAIL_ON_CONFLICT -> {
                 assertFalse(testCollection.save(doc1b, cc))
                 savedDoc = testCollection.getDocument(doc1b.id)
@@ -2046,6 +2112,7 @@ class DatabaseTest : BaseDbTest() {
                 assertEquals(doc1b.toMap(), savedDoc!!.toMap())
                 assertEquals(3, savedDoc.sequence)
             }
+
             ConcurrencyControl.FAIL_ON_CONFLICT -> {
                 assertFalse(testCollection.save(doc1b, cc))
                 assertNull(testCollection.getDocument(doc.id))

--- a/common/test/java/com/couchbase/lite/SimpleDatabaseTest.java
+++ b/common/test/java/com/couchbase/lite/SimpleDatabaseTest.java
@@ -39,21 +39,49 @@ public class SimpleDatabaseTest extends BaseTest {
         DatabaseConfiguration config1 = new DatabaseConfiguration();
         assertNotNull(config1.getDirectory());
         assertFalse(config1.getDirectory().isEmpty());
-        // # 1.2 TestSQLiteFullSyncDefault
-        assertEquals(Defaults.Database.FULL_SYNC, config1.isFullSync());
 
         // Custom
         DatabaseConfiguration config2 = new DatabaseConfiguration();
         String dbDir = getScratchDirectoryPath(getUniqueName("tmp"));
         config2.setDirectory(dbDir);
         assertEquals(dbDir, config2.getDirectory());
+    }
+
+    @Test
+    public void testFullSync() {
+        DatabaseConfiguration config = new DatabaseConfiguration();
+
+        // # 1.2 TestSQLiteFullSyncDefault
+        assertEquals(Defaults.Database.FULL_SYNC, config.isFullSync());
+
+        config = new DatabaseConfiguration();
 
         // # 1.3-4 TestSetGetFullSync
-        config2.setFullSync(true);
-        assertTrue(config2.isFullSync());
+        config.setFullSync(true);
+        assertTrue(config.isFullSync());
         // # 1.5-6 TestSetGetFullSync
-        config2.setFullSync(false);
-        assertFalse(config2.isFullSync());
+        config.setFullSync(false);
+        assertFalse(config.isFullSync());
+    }
+
+    /**
+     * Steps
+     * 1. Create a DatabaseConfiguration object.
+     * 2. Get and check that the value of the mmapEnabled property is true.
+     * 3. Set the mmapEnabled property to false and verify that the value is false.
+     * 4. Set the mmapEnabled property to true, and verify that the mmap value is true.
+     */
+    @Test
+    public void testMMapConfig() {
+        DatabaseConfiguration config = new DatabaseConfiguration();
+
+        assertEquals(Defaults.Database.MMAP_ENABLED, config.isMMapEnabled());
+
+        config.setMMapEnabled(false);
+        assertFalse(config.isMMapEnabled());
+
+        config.setMMapEnabled(true);
+        assertTrue(config.isMMapEnabled());
     }
 
     @Test

--- a/common/test/java/com/couchbase/lite/internal/core/C4TestUtils.java
+++ b/common/test/java/com/couchbase/lite/internal/core/C4TestUtils.java
@@ -193,7 +193,7 @@ public class C4TestUtils {
     @Nullable
     public static String idForDoc(@NonNull C4Document doc) { return doc.withPeerOrNull(C4TestUtils::getDocID); }
 
-    public static int getFlags(@NonNull C4Database db) throws LiteCoreException {
+    public static long getFlags(@NonNull C4Database db) throws LiteCoreException {
         return db.withPeerOrThrow(C4TestUtils::getFlags);
     }
 
@@ -335,7 +335,7 @@ public class C4TestUtils {
     @Nullable
     private static native String getDocID(long doc);
 
-    private static native int getFlags(long db) throws LiteCoreException;
+    private static native long getFlags(long db) throws LiteCoreException;
 
     // C4Document
 

--- a/java/test/java/com/couchbase/lite/PlatformBaseTest.java
+++ b/java/test/java/com/couchbase/lite/PlatformBaseTest.java
@@ -48,12 +48,12 @@ public abstract class PlatformBaseTest implements PlatformTest {
             new Exclusion(
                 "Not supported on Windows",
                 () -> System.getProperty("os.name").toLowerCase().contains("windows")));
-        PLATFORM_DEPENDENT_TESTS = Collections.unmodifiableMap(m);
         m.put(
             "SWEDISH UNSUPPORTED",
             new Exclusion(
                 "Swedish locale not supported",
                 () -> !Arrays.asList(Locale.getAvailableLocales()).contains(new Locale("sv"))));
+        PLATFORM_DEPENDENT_TESTS = Collections.unmodifiableMap(m);
     }
     protected static void initCouchbase() { CouchbaseLite.init(true); }
 


### PR DESCRIPTION
Also fix some deprecation annotations

I realize this is likely to change a lot, before 4.0 goes out.  This will, at least, prevent regressions and get the other useful changes
