### PR TITLE
CBL-6296: Check unnest path in ArrayIndex tests

### DIFF
--- a/common/jni_android.ld
+++ b/common/jni_android.ld
@@ -17,6 +17,7 @@ CBL {
         Java_com_couchbase_lite_internal_core_C4TestUtils_getDocID;
         Java_com_couchbase_lite_internal_core_C4TestUtils_getDocument;
         Java_com_couchbase_lite_internal_core_C4TestUtils_getFlags;
+        Java_com_couchbase_lite_internal_core_C4TestUtils_getIndexOptions;
         Java_com_couchbase_lite_internal_core_C4TestUtils_getLevel;
         Java_com_couchbase_lite_internal_core_C4TestUtils_getPrivateUUID;
         Java_com_couchbase_lite_internal_core_C4TestUtils_isIndexTrained;

--- a/common/main/cpp/com_couchbase_lite_internal_core_C4TestUtils.h
+++ b/common/main/cpp/com_couchbase_lite_internal_core_C4TestUtils.h
@@ -170,6 +170,14 @@ Java_com_couchbase_lite_internal_core_C4TestUtils_isIndexTrained(
         jlong,
         jstring);
 
+/*
+ * Class:     com_couchbase_lite_internal_core_C4TestUtils
+ * Method:    getIndexOptions
+ * Signature: (J)Lcom/couchbase/lite/internal/core/C4IndexOptions;
+ */
+JNIEXPORT jobject JNICALL
+Java_com_couchbase_lite_internal_core_C4TestUtils_getIndexOptions(JNIEnv *, jclass, jlong);
+
 #ifdef __cplusplus
 }
 #endif

--- a/common/main/cpp/native_c4testutils.cc
+++ b/common/main/cpp/native_c4testutils.cc
@@ -386,7 +386,7 @@ Java_com_couchbase_lite_internal_core_C4TestUtils_getLevel(JNIEnv *env, jclass i
     return (!logDomain) ? -1 : (jint) c4log_getLevel(logDomain);
 }
 
-// C4Collection
+// C4Index
 
 /*
  * Class:     com_couchbase_lite_internal_core_C4TestUtils
@@ -409,5 +409,32 @@ Java_com_couchbase_lite_internal_core_C4TestUtils_isIndexTrained(
     }
 
     return ok ? JNI_TRUE : JNI_FALSE;
+}
+
+/*
+ * Class:     com_couchbase_lite_internal_core_C4TestUtils
+ * Method:    getIndexOptions
+ * Signature: (J)Lcom/couchbase/lite/internal/core/C4IndexOptions;
+ */
+JNIEXPORT jobject JNICALL
+Java_com_couchbase_lite_internal_core_C4TestUtils_getIndexOptions(JNIEnv *env, jclass klass, jlong idx) {
+    jmethodID ctor = env->GetStaticMethodID(
+            klass,
+            "createIndexOptions",
+            "(ZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/couchbase/lite/internal/core/C4TestUtils$C4IndexOptions;");
+    if (!ctor)
+        return nullptr;
+
+    C4IndexOptions opts;
+    c4index_getOptions((C4Index *) idx, &opts);
+
+    return env->CallStaticObjectMethod(
+            klass,
+            ctor,
+            opts.ignoreDiacritics ? JNI_TRUE : JNI_FALSE,
+            opts.disableStemming ? JNI_TRUE : JNI_FALSE,
+            UTF8ToJstring(env, opts.language),
+            UTF8ToJstring(env, opts.stopWords),
+            UTF8ToJstring(env, opts.unnestPath));
 }
 }

--- a/common/main/cpp/native_glue.hh
+++ b/common/main/cpp/native_glue.hh
@@ -59,9 +59,10 @@ namespace litecore {
 
         std::string JcharArrayToUTF8(JNIEnv *env, const jcharArray jcharArray);
 
-        std::string JcharsToUTF8(JNIEnv *env, const jchar *jchars, jsize len);
-
         jstring UTF8ToJstring(JNIEnv *env, const char *s, size_t size);
+        jstring UTF8ToJstring(JNIEnv *env, const char *s);
+
+        std::string JcharsToUTF8(const jchar *jchars, jsize len);
 
         // Creates a temporary slice value from a Java String object
         class jstringSlice {

--- a/common/main/java/com/couchbase/lite/Collection.java
+++ b/common/main/java/com/couchbase/lite/Collection.java
@@ -462,14 +462,7 @@ public final class Collection extends BaseCollection
      */
     @Nullable
     public QueryIndex getIndex(@NonNull String name) throws CouchbaseLiteException {
-        final C4Index idx;
-        try {
-            synchronized (getDbLock()) {
-                db.assertOpenChecked();
-                idx = c4Collection.getIndex(name);
-            }
-        }
-        catch (LiteCoreException e) { throw CouchbaseLiteException.convertException(e); }
+        final C4Index idx = getC4Index(name);
         return (idx == null) ? null : new QueryIndex(this, name, idx);
     }
 
@@ -824,6 +817,18 @@ public final class Collection extends BaseCollection
         }
 
         return info;
+    }
+
+    @VisibleForTesting
+    @Nullable
+    C4Index getC4Index(@NonNull String name) throws CouchbaseLiteException {
+        try {
+            synchronized (getDbLock()) {
+                db.assertOpenChecked();
+                return c4Collection.getIndex(name);
+            }
+        }
+        catch (LiteCoreException e) { throw CouchbaseLiteException.convertException(e); }
     }
 
     //-------------------------------------------------------------------------

--- a/common/main/java/com/couchbase/lite/internal/core/C4Index.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Index.java
@@ -1,0 +1,84 @@
+//
+// Copyright (c) 2024 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package com.couchbase.lite.internal.core;
+
+import androidx.annotation.GuardedBy;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
+import com.couchbase.lite.LiteCoreException;
+import com.couchbase.lite.LogDomain;
+import com.couchbase.lite.internal.core.impl.NativeC4Index;
+
+
+public final class C4Index extends C4NativePeer {
+    public interface NativeImpl {
+        long nBeginUpdate(long peer, int limit) throws LiteCoreException;
+        void nReleaseIndex(long peer);
+    }
+
+    @NonNull
+    private static final NativeImpl NATIVE_IMPL = new NativeC4Index();
+
+    @NonNull
+    public static C4Index create(long peer) { return new C4Index(NATIVE_IMPL, peer); }
+
+
+    private final NativeImpl impl;
+
+    @VisibleForTesting
+    C4Index(@NonNull NativeImpl impl, long peer) {
+        super(peer);
+        this.impl = impl;
+    }
+
+    @GuardedBy("Database.lock")
+    @Nullable
+    public C4IndexUpdater beginUpdate(int limit) throws LiteCoreException {
+        return nullableWithPeerOrThrow(peer -> {
+            final long updater = impl.nBeginUpdate(peer, limit);
+            return (updater == 0L) ? null : C4IndexUpdater.create(updater);
+        });
+    }
+
+    @Override
+    public void close() { closePeer(null); }
+
+    //-------------------------------------------------------------------------
+    // protected methods
+    //-------------------------------------------------------------------------
+
+    @SuppressWarnings("NoFinalizer")
+    @Override
+    protected void finalize() throws Throwable {
+        try { closePeer(LogDomain.DATABASE); }
+        finally { super.finalize(); }
+    }
+
+    //-------------------------------------------------------------------------
+    // private methods
+    //-------------------------------------------------------------------------
+
+    private void closePeer(@Nullable LogDomain domain) {
+        releasePeer(
+            domain,
+            peer -> {
+                final NativeImpl nativeImpl = impl;
+                if (nativeImpl != null) { nativeImpl.nReleaseIndex(peer); }
+            });
+    }
+}

--- a/common/main/java/com/couchbase/lite/internal/core/impl/NativeC4Index.java
+++ b/common/main/java/com/couchbase/lite/internal/core/impl/NativeC4Index.java
@@ -1,0 +1,37 @@
+//
+// Copyright (c) 2024 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package com.couchbase.lite.internal.core.impl;
+
+import com.couchbase.lite.LiteCoreException;
+import com.couchbase.lite.internal.core.C4Index;
+
+
+public class NativeC4Index implements C4Index.NativeImpl {
+    @Override
+    public long nBeginUpdate(long peer, int limit) throws LiteCoreException { return beginUpdate(peer, limit); }
+
+    @Override
+    public void nReleaseIndex(long peer) { releaseIndex(peer); }
+
+
+    //-------------------------------------------------------------------------
+    // Native Methods
+    //-------------------------------------------------------------------------
+
+    private static native long beginUpdate(long peer, int limit) throws LiteCoreException;
+
+    private static native void releaseIndex(long peer);
+}

--- a/common/test/java/com/couchbase/lite/ArrayIndexTest.kt
+++ b/common/test/java/com/couchbase/lite/ArrayIndexTest.kt
@@ -15,6 +15,7 @@
 //
 package com.couchbase.lite
 
+import com.couchbase.lite.internal.core.C4TestUtils
 import org.junit.Assert
 import org.junit.Test
 
@@ -50,15 +51,15 @@ class ArrayIndexTest : BaseDbTest() {
      * 1. Create a ArrayIndexConfiguration object.
      *     - path: "contacts"
      *     - expressions: []
-     * 2. Check that an invalid arument exception is thrown.
+     * 2. Check that an invalid argument exception is thrown.
      * 3. Create a ArrayIndexConfiguration object.
      *     - path: "contacts"
      *     - expressions: [""]
-     * 4. Check that an invalid arument exception is thrown.
+     * 4. Check that an invalid argument exception is thrown.
      * 5. Create a ArrayIndexConfiguration object. This case can be ignore if the platform doesn't allow null.
      *     - path: "contacts"
      *     - expressions: ["address.state", null, "address.city"]
-     * 6. Check that an invalid arument exception is thrown.
+     * 6. Check that an invalid argument exception is thrown.
      */
     @Test
     fun testArrayIndexConfigInvalidExpressions1() = assertThrows(IllegalArgumentException::class.java) {
@@ -108,7 +109,7 @@ class ArrayIndexTest : BaseDbTest() {
         Assert.assertEquals(1, idx.size)
         Assert.assertEquals("", idx[0])
 
-        // !!! check the path
+        Assert.assertEquals("contacts", profilesCollection.getPathForIndex("contacts"))
     }
 
     /**
@@ -136,7 +137,7 @@ class ArrayIndexTest : BaseDbTest() {
 
         profilesCollection.createIndex("contacts", ArrayIndexConfiguration("contacts", exprs))
 
-        // !!! check the path
+        Assert.assertEquals("contacts", profilesCollection.getPathForIndex("contacts"))
 
         val idx = profilesCollection.getIndexExpressions("contacts")
         Assert.assertNotNull(idx)
@@ -149,4 +150,8 @@ class ArrayIndexTest : BaseDbTest() {
         this.getIndexInfo()
             .firstOrNull { it[Collection.INDEX_KEY_NAME] == indexName }
             ?.let { (it[Collection.INDEX_KEY_EXPR] as? String)?.split(",") } ?: emptyList()
+
+    private fun Collection.getPathForIndex(indexName: String) =
+        C4TestUtils.getIndexOptions(assertNonNull(this.getC4Index(indexName))).unnestPath
 }
+

--- a/common/test/java/com/couchbase/lite/internal/core/C4TestUtils.java
+++ b/common/test/java/com/couchbase/lite/internal/core/C4TestUtils.java
@@ -30,6 +30,30 @@ import com.couchbase.lite.internal.fleece.FLSliceResult;
 
 // It is worth considering breaking this up.  You know, OOP and all...
 public class C4TestUtils {
+    public static class C4IndexOptions {
+        @Nullable
+        public final String language;
+        @Nullable
+        public final String stopWords;
+        @Nullable
+        public final String unnestPath;
+        public final boolean ignoreDiacritics;
+        public final boolean disableStemming;
+
+        C4IndexOptions(
+            @Nullable String language,
+            boolean ignoreDiacritics,
+            boolean disableStemming,
+            @Nullable String stopWords,
+            @Nullable String unnestPath) {
+            this.language = language;
+            this.ignoreDiacritics = ignoreDiacritics;
+            this.disableStemming = disableStemming;
+            this.stopWords = stopWords;
+            this.unnestPath = unnestPath;
+        }
+    }
+
     public static class C4DocEnumerator extends C4NativePeer {
         public C4DocEnumerator(long db, int flags) throws LiteCoreException { this(enumerateAllDocs(db, flags)); }
 
@@ -186,12 +210,26 @@ public class C4TestUtils {
 
     public static int getLogLevel(String domain) { return getLevel(domain); }
 
-    // C4Collection
+    // C4Index
 
     public static boolean isIndexTrained(C4Collection collection, @NonNull String name) throws LiteCoreException {
         return collection.withPeerOrThrow(peer -> isIndexTrained(peer, name));
     }
 
+    @NonNull
+    public static C4IndexOptions getIndexOptions(@NonNull C4Index idx) throws CouchbaseLiteException {
+        return idx.withPeerOrThrow(C4TestUtils::getIndexOptions);
+    }
+
+    // This method is called by reflection.  Don't change its signature.
+    public static C4IndexOptions createIndexOptions(
+        boolean ignoreDiacritics,
+        boolean disableStemming,
+        @Nullable String language,
+        @Nullable String stopWords,
+        @Nullable String unnestPath) {
+        return new C4IndexOptions(language, ignoreDiacritics, disableStemming, stopWords, unnestPath);
+    }
 
     //-------------------------------------------------------------------------
     // native methods
@@ -270,4 +308,6 @@ public class C4TestUtils {
     // C4Index
 
     private static native boolean isIndexTrained(long collection, @NonNull String name) throws LiteCoreException;
+
+    private static native C4IndexOptions getIndexOptions(long idx) throws CouchbaseLiteException;
 }


### PR DESCRIPTION
Plumb c4Index_getOptions into the JNI and use it in the ArrayIndex tests