### PR TITLE
Debugging

### DIFF
--- a/java/main/java/com/couchbase/lite/internal/NativeLibrary.java
+++ b/java/main/java/com/couchbase/lite/internal/NativeLibrary.java
@@ -127,7 +127,9 @@ final class NativeLibrary {
     @SuppressWarnings({
         "PMD.AvoidCatchingThrowable",
         "PMD.AvoidInstanceofChecksInCatchClause",
-        "PMD.PreserveStackTrace"})
+        "PMD.PreserveStackTrace",
+        "PMD.SystemPrintln",
+        "RegexpSinglelineJava"})
     private static void loadLibrary(
         @NonNull String libName,
         @NonNull String resDirPath,
@@ -136,7 +138,7 @@ final class NativeLibrary {
         @NonNull File scratchDir) {
         final String lib = System.mapLibraryName(libName);
 
-        final String libPath;
+        String libPath;
         File targetDir = null;
         try {
             targetDir = computeTargetDirectory(scratchDir, resDirPath, lib);
@@ -148,7 +150,19 @@ final class NativeLibrary {
             throw new CouchbaseLiteError("Failed extracting library resource: " + lib + " to " + targetDir, e);
         }
 
-        try { System.load(libPath); }
+        try {
+            if (isLinux(os) && LIB_LITE_CORE.equals(libName)) {
+                final File curDir = new File(".").getCanonicalFile();
+                libPath = new File(
+                    new File(
+                        curDir.getParentFile().getParentFile().getParentFile().getParentFile(),
+                        "common/lite-core/linux/x86_64/lib"),
+                    lib)
+                    .getCanonicalPath();
+            }
+            System.out.println("##### LOADING LIBRARY: " + libPath);
+            System.load(libPath);
+        }
         catch (Throwable e) {
             final Exception err = (e instanceof Exception) ? (Exception) e : new Exception(e);
             throw new CouchbaseLiteError(


### PR DESCRIPTION
Another try at getting symbols into the Linux crash.
Pointing at, not the LiteCore lib that is pulled out of the CBL binary, but the one downloaded from latestbuilds, and next to the symbols file.