### PR TITLE
Backport CBL-6489: ReplicatorConfiguration.setAuthenticator should not take a ProxyAuthenticator

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractReplicator.java
+++ b/common/main/java/com/couchbase/lite/AbstractReplicator.java
@@ -796,14 +796,14 @@ public abstract class AbstractReplicator extends BaseReplicator
         final ReplicatorStatus oldStatus = status;
         status = new ReplicatorStatus(c4Status);
 
-        final CouchbaseLiteException err = status.getError();
-        if (c4Status.getErrorCode() != 0) { lastError = err; }
+        final int errCode = c4Status.getErrorCode();
+        if (errCode != 0) { lastError = status.getError(); }
 
         Log.i(
             LOG_DOMAIN,
-            "%s: state changed %s => %s(%d/%d)",
-            err,
+            "%s: state changed(%d): %s => %s(%d/%d)",
             getId(),
+            errCode,
             oldStatus.getActivityLevel(),
             status.getActivityLevel(),
             c4Status.getProgressUnitsCompleted(),

--- a/common/main/java/com/couchbase/lite/BasicAuthenticator.java
+++ b/common/main/java/com/couchbase/lite/BasicAuthenticator.java
@@ -31,7 +31,7 @@ import com.couchbase.lite.internal.utils.Preconditions;
  * auth with the given username and password. This should only be used over an SSL/TLS connection,
  * as otherwise it's very easy for anyone sniffing network traffic to read the password.
  */
-public final class BasicAuthenticator extends BaseAuthenticator {
+public final class BasicAuthenticator extends BaseAuthenticator implements Authenticator {
 
     //---------------------------------------------
     // member variables

--- a/common/main/java/com/couchbase/lite/SessionAuthenticator.java
+++ b/common/main/java/com/couchbase/lite/SessionAuthenticator.java
@@ -30,7 +30,7 @@ import com.couchbase.lite.internal.utils.StringUtils;
  * SessionAuthenticator class is an authenticator that will authenticate by using the session ID of
  * the session created by a Sync Gateway
  */
-public final class SessionAuthenticator extends BaseAuthenticator {
+public final class SessionAuthenticator extends BaseAuthenticator implements Authenticator {
 
     private static final String DEFAULT_SYNC_GATEWAY_SESSION_ID_NAME = "SyncGatewaySession";
 

--- a/common/main/java/com/couchbase/lite/internal/BaseAuthenticator.java
+++ b/common/main/java/com/couchbase/lite/internal/BaseAuthenticator.java
@@ -17,9 +17,7 @@ package com.couchbase.lite.internal;
 
 import java.util.Map;
 
-import com.couchbase.lite.Authenticator;
 
-
-public abstract class BaseAuthenticator implements Authenticator {
+public abstract class BaseAuthenticator {
     protected abstract void authenticate(Map<String, Object> options);
 }


### PR DESCRIPTION
Also,  Backport: Don't print redundant stacktrace in replicator status change

These are both just backports of code previously pr'ed  into 4.0