### PR TITLE
CBL-6688: Fix FLSliceResult and add unbind method

### DIFF
--- a/common/main/cpp/com_couchbase_lite_internal_fleece_impl_NativeFLEncoder.h
+++ b/common/main/cpp/com_couchbase_lite_internal_fleece_impl_NativeFLEncoder.h
@@ -179,15 +179,6 @@ JNIEXPORT jobject
 JNICALL Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish2
         (JNIEnv * , jclass, jlong);
 
-/*
- * Class:     com_couchbase_lite_internal_fleece_impl_NativeFLEncoder
- * Method:    finish3
- * Signature: (J)Lcom/couchbase/lite/internal/fleece/FLSliceResult
- */
-JNIEXPORT jobject
-JNICALL Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish3
-        (JNIEnv * , jclass, jlong);
-
 // ----------------------------------------------------------------------------
 // JsonEncoder
 // ----------------------------------------------------------------------------

--- a/common/main/cpp/native_c4collection.cc
+++ b/common/main/cpp/native_c4collection.cc
@@ -247,6 +247,8 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Collection_getIndexesInfo(
         throwError(env, error);
         return 0;
     }
+    // !!! If this slice is freed while the FLValue is being used,
+    // it will cause a crash! So who is freeing it???
     return (jlong) FLValue_FromData({data.buf, data.size}, kFLTrusted);
 }
 

--- a/common/main/cpp/native_c4prediction.cc
+++ b/common/main/cpp/native_c4prediction.cc
@@ -65,6 +65,7 @@ static C4SliceResult prediction(void *token, FLDict input, C4Database *c4db, C4E
                 (jlong) c4db);
         if (sliceResult != nullptr) {
             res = fromJavaFLSliceResult(env, sliceResult);
+            unbindJavaFLSliceResult(env, sliceResult);
             env->DeleteLocalRef(sliceResult);
         }
     } else if (getEnvStat == JNI_EDETACHED) {
@@ -75,8 +76,10 @@ static C4SliceResult prediction(void *token, FLDict input, C4Database *c4db, C4E
                     (jlong) token,
                     (jlong) input,
                     (jlong) c4db);
-            if (sliceResult != nullptr)
+            if (sliceResult != nullptr) {
                 res = fromJavaFLSliceResult(env, sliceResult);
+                unbindJavaFLSliceResult(env, sliceResult);
+            }
             if (gJVM->DetachCurrentThread() != 0)
                 C4Warn("doRequestClose(): Failed to detach the current thread from a Java VM");
         } else {

--- a/common/main/cpp/native_fleece.cc
+++ b/common/main/cpp/native_fleece.cc
@@ -498,7 +498,7 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLValue_toJSON5(
 }
 
 // ----------------------------------------------------------------------------
-// FLSliceResult
+// NativeFLSliceResult
 // ----------------------------------------------------------------------------
 
 /*

--- a/common/main/cpp/native_flencoder.cc
+++ b/common/main/cpp/native_flencoder.cc
@@ -273,23 +273,6 @@ Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish2(JNIEnv *env
 
 /*
  * Class:     com_couchbase_lite_internal_fleece_impl_NativeFLEncoder
- * Method:    finish3
- * Signature: (J)Lcom/couchbase/lite/internal/fleece/FLSliceResult
- */
-JNIEXPORT jobject JNICALL
-Java_com_couchbase_lite_internal_fleece_impl_NativeFLEncoder_finish3(JNIEnv *env, jclass ignore, jlong jenc) {
-    FLError error = kFLNoError;
-    FLSliceResult res = FLEncoder_Finish((FLEncoder) jenc, &error);
-    if (error != kFLNoError) {
-        throwError(env, {FleeceDomain, error}, FLEncoder_GetErrorMessage((FLEncoder) jenc));
-        return nullptr;
-    }
-
-    return toJavaUnmanagedFLSliceResult(env, res);
-}
-
-/*
- * Class:     com_couchbase_lite_internal_fleece_impl_NativeFLEncoder
  * Method:    reset
  * Signature: (J)V
  */

--- a/common/main/cpp/native_glue.cc
+++ b/common/main/cpp/native_glue.cc
@@ -39,14 +39,14 @@ static jmethodID m_HashSet_add;                   // add
 
 // Java FLSliceResult class
 static jclass cls_FLSliceResult;                  // global class reference
-static jmethodID m_FLSliceResult_createManaged;   // static constructor
-static jmethodID m_FLSliceResult_createUnmanaged; // static constructor
-static jfieldID f_FLSliceResult_base;             // field: base
-static jfieldID f_FLSliceResult_size;             // field: size
+static jmethodID m_FLSliceResult_createSliceResult; // static constructor
+static jmethodID m_FLSliceResult_getBase;         // get slice base
+static jmethodID m_FLSliceResult_getSize;         // get slice size
+static jmethodID m_FLSliceResult_unbind;          // mark the Java slice as invalid
 
 // Java LiteCoreException class
-static jclass cls_LiteCoreException;             // global reference
-static jmethodID m_LiteCoreException_throw;      // static throw
+static jclass cls_LiteCoreException;              // global reference
+static jmethodID m_LiteCoreException_throw;       // static throw
 
 
 static bool initC4Glue(JNIEnv *env) {
@@ -93,28 +93,24 @@ static bool initC4Glue(JNIEnv *env) {
         if (cls_FLSliceResult == nullptr)
             return false;
 
-        m_FLSliceResult_createManaged = env->GetStaticMethodID(
+        m_FLSliceResult_createSliceResult = env->GetStaticMethodID(
                 cls_FLSliceResult,
-                "createManagedSlice",
+                "create",
                 "(JJ)Lcom/couchbase/lite/internal/fleece/FLSliceResult;");
-        if (m_FLSliceResult_createManaged == nullptr)
+        if (m_FLSliceResult_createSliceResult == nullptr)
             return false;
 
-        m_FLSliceResult_createUnmanaged = env->GetStaticMethodID(
-                cls_FLSliceResult,
-                "createUnmanagedSlice",
-                "(JJ)Lcom/couchbase/lite/internal/fleece/FLSliceResult;");
-        if (m_FLSliceResult_createUnmanaged == nullptr)
+        m_FLSliceResult_getBase = env->GetMethodID(cls_FLSliceResult, "getBase", "()J");
+        if (m_FLSliceResult_getBase == nullptr)
             return false;
 
-        f_FLSliceResult_base = env->GetFieldID(cls_FLSliceResult, "base", "J");
-        if (f_FLSliceResult_base == nullptr)
+        m_FLSliceResult_getSize = env->GetMethodID(cls_FLSliceResult, "getSize", "()J");
+        if (m_FLSliceResult_getSize == nullptr)
             return false;
 
-        f_FLSliceResult_size = env->GetFieldID(cls_FLSliceResult, "size", "J");
-        if (f_FLSliceResult_size == nullptr)
+        m_FLSliceResult_unbind = env->GetMethodID(cls_FLSliceResult, "unbind", "()V");
+        if (m_FLSliceResult_unbind == nullptr)
             return false;
-
     }
     {
         jclass localClass = env->FindClass("com/couchbase/lite/LiteCoreException");
@@ -167,361 +163,353 @@ JNI_OnLoad(JavaVM *jvm, void *ignore) {
     return JNI_ERR;
 }
 
-namespace litecore {
-    namespace jni {
+namespace litecore::jni {
 
-        // ----------------------------------------------------------------------------
-        // JVM
-        // ----------------------------------------------------------------------------
-        JavaVM *gJVM;
+    // ----------------------------------------------------------------------------
+    // JVM
+    // ----------------------------------------------------------------------------
+    JavaVM *gJVM;
 
-        int attachCurrentThread(JNIEnv **env) {
+    int attachCurrentThread(JNIEnv **env) {
 #ifdef JNI_VERSION_1_8
-            return gJVM->AttachCurrentThread(reinterpret_cast<void **>(env), NULL);
+        return gJVM->AttachCurrentThread(reinterpret_cast<void **>(env), NULL);
 #else
-            return gJVM->AttachCurrentThread(env, nullptr);
+        return gJVM->AttachCurrentThread(env, nullptr);
+#endif
+    }
+
+    // ----------------------------------------------------------------------------
+    // Exception Handling
+    // ----------------------------------------------------------------------------
+
+    void throwError(JNIEnv *env, C4Error error, jstring msg) {
+        if (env->ExceptionOccurred())
+            return;
+
+        env->CallStaticVoidMethod(
+                cls_LiteCoreException,
+                m_LiteCoreException_throw,
+                (jint) error.domain,
+                (jint) error.code,
+                msg);
+
+        if (msg != nullptr)env->DeleteLocalRef(msg);
+    }
+
+    void throwError(JNIEnv *env, C4Error error) {
+        C4SliceResult msgSlice = c4error_getMessage(error);
+        jstring msg = toJString(env, msgSlice);
+        c4slice_free(msgSlice);
+        throwError(env, error, msg);
+    }
+
+    void throwError(JNIEnv *env, C4Error error, char const *message) {
+        if (message != nullptr) {
+            jstring msg = UTF8ToJstring(env, message, sizeof(message));
+            if (msg != nullptr) {
+                throwError(env, error, msg);
+                return;
+            }
+        }
+        throwError(env, error);
+    }
+
+    // ----------------------------------------------------------------------------
+    // String Conversions
+    // ----------------------------------------------------------------------------
+
+    /**
+     * Java uses Modified-UTF-8, not UTF-8: Attempting to decode a real UTF-8 string will cause a failure that
+     * looks like:
+     *   art/runtime/check_jni.cc:65] JNI DETECTED ERROR IN APPLICATION: input is not valid Modified UTF-8: illegal start byte ...
+     *   art/runtime/check_jni.cc:65]     string: ...
+     *   art/runtime/check_jni.cc:65]     in call to NewStringUTF
+     *  See:
+     *    https://stackoverflow.com/questions/35519823/jni-detected-error-in-application-input-is-not-valid-modified-utf-8-illegal-st
+     *  The strategy here is to use standard C functions to convert the UTF-8 directly to UTF-16,
+     *  which Java handles nicely. These functions are derived from this code
+     *      (https://github.com/incanus/android-jni/blob/master/app/src/main/jni/JNI.cpp#L57-L86):
+     *  ??? Creating the wstring_convert is expensive.  It would be nice to create one
+     *      and to re-use it.  It is *NOT*, however, threadsafe.
+     *  ??? On failure, just return a nullptr.
+     */
+    jstring UTF8ToJstring(JNIEnv *env, const char *s, size_t size) {
+        std::u16string ustr;
+        try {
+#ifdef _MSC_VER
+            auto tmpstr = std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t>().from_bytes(s, s + size);
+    ustr = reinterpret_cast<const char16_t *>(tmpstr.data());
+#else
+            ustr = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>().from_bytes(s, s + size);
 #endif
         }
-
-        // ----------------------------------------------------------------------------
-        // Exception Handling
-        // ----------------------------------------------------------------------------
-
-        void throwError(JNIEnv *env, C4Error error, jstring msg) {
-            if (env->ExceptionOccurred())
-                return;
-
-            env->CallStaticVoidMethod(
-                    cls_LiteCoreException,
-                    m_LiteCoreException_throw,
-                    (jint)
-                            error.domain,
-                    (jint) error.code,
-                    msg);
-
-            if (msg != nullptr)env->DeleteLocalRef(msg);
+        catch (const std::bad_alloc &x) {
+            jniLog("Failed allocating space to convert string: %s", x.what());
+            return nullptr;
+        }
+        catch (const std::exception &x) {
+            // sadly, we better not try to log the actual string...
+            jniLog("Failed to convert string from UTF-8 to UTF-16: %s", x.what());
+            return nullptr;
         }
 
-        void throwError(JNIEnv *env, C4Error error) {
-            C4SliceResult msgSlice = c4error_getMessage(error);
-            jstring msg = toJString(env, msgSlice);
-            c4slice_free(msgSlice);
-            throwError(env, error, msg);
-        }
-
-        void throwError(JNIEnv *env, C4Error error, char const *message) {
-            if (message != nullptr) {
-                jstring msg = UTF8ToJstring(env, message, sizeof(message));
-                if (msg != nullptr) {
-                    throwError(env, error, msg);
-                    return;
-                }
-            }
+        jstring jstr = env->NewString(reinterpret_cast<const jchar *>(ustr.c_str()), ustr.size());
+        if (jstr == nullptr) {
+            C4Error error = {LiteCoreDomain, kC4ErrorMemoryError, 0};
             throwError(env, error);
+            return nullptr;
         }
 
-        // ----------------------------------------------------------------------------
-        // String Conversions
-        // ----------------------------------------------------------------------------
+        return jstr;
+    }
 
-        /**
-         * Java uses Modified-UTF-8, not UTF-8: Attempting to decode a real UTF-8 string will cause a failure that
-         * looks like:
-         *   art/runtime/check_jni.cc:65] JNI DETECTED ERROR IN APPLICATION: input is not valid Modified UTF-8: illegal start byte ...
-         *   art/runtime/check_jni.cc:65]     string: ...
-         *   art/runtime/check_jni.cc:65]     in call to NewStringUTF
-         *  See:
-         *    https://stackoverflow.com/questions/35519823/jni-detected-error-in-application-input-is-not-valid-modified-utf-8-illegal-st
-         *  The strategy here is to use standard C functions to convert the UTF-8 directly to UTF-16,
-         *  which Java handles nicely. These functions are derived from this code
-         *      (https://github.com/incanus/android-jni/blob/master/app/src/main/jni/JNI.cpp#L57-L86):
-         *  ??? Creating the wstring_convert is expensive.  It would be nice to create one
-         *      and to re-use it.  It is *NOT*, however, threadsafe.
-         *  ??? On failure, just return a nullptr.
-         */
-        jstring UTF8ToJstring(JNIEnv *env, const char *s, size_t size) {
-            std::u16string ustr;
+    std::string JcharsToUTF8(const jchar *chars, jsize len) {
+        std::string str;
+
+        if (chars == nullptr) {
+            str = std::string();
+        } else {
             try {
 #ifdef _MSC_VER
-                auto tmpstr = std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t>().from_bytes(s, s + size);
-        ustr = reinterpret_cast<const char16_t *>(tmpstr.data());
+                str = std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t>()
+                            .to_bytes(reinterpret_cast<const int16_t *>(chars),
+                                      reinterpret_cast<const int16_t *>(chars + len));
 #else
-                ustr = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>().from_bytes(s, s + size);
+                str = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>()
+                        .to_bytes(reinterpret_cast<const char16_t *>(chars),
+                                  reinterpret_cast<const char16_t *>(chars + len));
 #endif
-            }
-            catch (const std::bad_alloc &x) {
-                jniLog("Failed allocating space to convert string: %s", x.what());
-                return nullptr;
+
             }
             catch (const std::exception &x) {
-                // sadly, we better not try to log the actual string...
-                jniLog("Failed to convert string from UTF-8 to UTF-16: %s", x.what());
-                return nullptr;
-            }
-
-            jstring jstr = env->NewString(reinterpret_cast<const jchar *>(ustr.c_str()), ustr.size());
-            if (jstr == nullptr) {
-                C4Error error = {LiteCoreDomain, kC4ErrorMemoryError, 0};
-                throwError(env, error);
-                return nullptr;
-            }
-
-            return jstr;
-        }
-
-        std::string JcharsToUTF8(const jchar *chars, jsize len) {
-            std::string str;
-
-            if (chars == nullptr) {
                 str = std::string();
+            }
+        }
+
+        return str;
+    }
+
+    jstring UTF8ToJstring(JNIEnv *env, const char *s) {
+        return (s == nullptr) ? nullptr : UTF8ToJstring(env, s, strlen(s));
+    }
+
+    // ??? Callers can't handle exceptions so we just ignore errors and return an empty string.
+    std::string JstringToUTF8(JNIEnv *env, jstring jstr) {
+        jsize len = env->GetStringLength(jstr);
+        if (len <= 0)
+            return std::string();
+
+        const jchar *chars = env->GetStringChars(jstr, nullptr);
+        std::string ret = JcharsToUTF8(chars, len);
+        env->ReleaseStringChars(jstr, chars);
+        return ret;
+    }
+
+    // ??? Callers can't handle exceptions so we just ignore errors and return an empty string.
+    std::string JcharArrayToUTF8(JNIEnv *env, jcharArray jcharArray) {
+        jsize len = env->GetArrayLength(jcharArray);
+        if (len <= 0)
+            return std::string();
+
+        jchar *chars = env->GetCharArrayElements(jcharArray, nullptr);
+        std::string ret = JcharsToUTF8(chars, len);
+        env->ReleaseCharArrayElements(jcharArray, chars, JNI_ABORT);
+        return ret;
+    }
+
+    // ----------------------------------------------------------------------------
+    // jstringSlice
+    // ----------------------------------------------------------------------------
+
+    jstringSlice::jstringSlice(JNIEnv *env, jstring js) {
+        assert(env != nullptr);
+        if (js == nullptr) {
+            _slice = kFLSliceNull;
+        } else {
+            _str = JstringToUTF8(env, js);
+            _slice = FLStr(_str.c_str());
+        }
+    }
+
+    jstringSlice::jstringSlice(JNIEnv *env, jcharArray jchars) {
+        assert(env != nullptr);
+        if (jchars == nullptr) {
+            _slice = kFLSliceNull;
+        } else {
+            _str = JcharArrayToUTF8(env, jchars);
+            _slice = FLStr(_str.c_str());
+        }
+    }
+
+    const char *jstringSlice::c_str() {
+        return (const char *) _slice.buf;
+    }
+
+    // ----------------------------------------------------------------------------
+    // jbyteArraySlice
+    // ----------------------------------------------------------------------------
+
+    // ATTN: In critical, cannot call any other JNI methods.
+    // http://docs.oracle.com/javase/6/docs/technotes/guides/jni/spec/functions.html
+    // Just don't set it true.
+    jbyteArraySlice::jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, bool critical)
+            : jbyteArraySlice(env, false, jbytes, critical) {}
+
+    jbyteArraySlice::jbyteArraySlice(JNIEnv *env, bool delRef, jbyteArray jbytes, bool critical)
+            : jbyteArraySlice(
+            env,
+            delRef,
+            jbytes,
+            (size_t) (!jbytes ? 0 : env->GetArrayLength(jbytes)),
+            critical) {}
+
+    jbyteArraySlice::jbyteArraySlice(JNIEnv *env, bool delRef, jbyteArray jbytes, size_t length, bool critical)
+            : _env(env),
+              _jbytes(jbytes),
+              _critical(critical),
+              _delRef(delRef) {
+        if ((jbytes == nullptr) || (length <= 0)) {
+            _slice = kFLSliceNull;
+            return;
+        }
+
+        void *data;
+        if (critical) {
+            data = env->GetPrimitiveArrayCritical(jbytes, nullptr);
+        } else {
+            data = env->GetByteArrayElements(jbytes, nullptr);
+        }
+
+        _slice = {data, length};
+    }
+
+    jbyteArraySlice::~jbyteArraySlice() {
+        if (_slice.buf != nullptr) {
+            if (_critical) {
+                _env->ReleasePrimitiveArrayCritical(_jbytes, (void *) _slice.buf, JNI_ABORT);
             } else {
-                try {
-#ifdef _MSC_VER
-                    str = std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t>()
-                                .to_bytes(reinterpret_cast<const int16_t *>(chars),
-                                          reinterpret_cast<const int16_t *>(chars + len));
-#else
-                    str = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>()
-                            .to_bytes(reinterpret_cast<const char16_t *>(chars),
-                                      reinterpret_cast<const char16_t *>(chars + len));
-#endif
-
-                }
-                catch (const std::exception &x) {
-                    str = std::string();
-                }
-            }
-
-            return str;
-        }
-
-        jstring UTF8ToJstring(JNIEnv *env, const char *s) {
-            return (s == nullptr) ? nullptr : UTF8ToJstring(env, s, strlen(s));
-        }
-
-        // ??? Callers can't handle exceptions so we just ignore errors and return an empty string.
-        std::string JstringToUTF8(JNIEnv *env, jstring jstr) {
-            jsize len = env->GetStringLength(jstr);
-            if (len <= 0)
-                return std::string();
-
-            const jchar *chars = env->GetStringChars(jstr, nullptr);
-            std::string ret = JcharsToUTF8(chars, len);
-            env->ReleaseStringChars(jstr, chars);
-            return ret;
-        }
-
-        // ??? Callers can't handle exceptions so we just ignore errors and return an empty string.
-        std::string JcharArrayToUTF8(JNIEnv *env, jcharArray jcharArray) {
-            jsize len = env->GetArrayLength(jcharArray);
-            if (len <= 0)
-                return std::string();
-
-            jchar *chars = env->GetCharArrayElements(jcharArray, nullptr);
-            std::string ret = JcharsToUTF8(chars, len);
-            env->ReleaseCharArrayElements(jcharArray, chars, JNI_ABORT);
-            return ret;
-        }
-
-        // ----------------------------------------------------------------------------
-        // jstringSlice
-        // ----------------------------------------------------------------------------
-
-        jstringSlice::jstringSlice(JNIEnv *env, jstring js) {
-            assert(env != nullptr);
-            if (js == nullptr) {
-                _slice = kFLSliceNull;
-            } else {
-                _str = JstringToUTF8(env, js);
-                _slice = FLStr(_str.c_str());
+                _env->ReleaseByteArrayElements(_jbytes, (jbyte *) _slice.buf, JNI_ABORT);
             }
         }
+        if (_jbytes && _delRef) _env->DeleteLocalRef(_jbytes);
+    }
 
-        jstringSlice::jstringSlice(JNIEnv *env, jcharArray jchars) {
-            assert(env != nullptr);
-            if (jchars == nullptr) {
-                _slice = kFLSliceNull;
-            } else {
-                _str = JcharArrayToUTF8(env, jchars);
-                _slice = FLStr(_str.c_str());
-            }
-        }
+    FLSliceResult jbyteArraySlice::copy(JNIEnv *env, jbyteArray jbytes) {
+        jbyteArraySlice bytes(env, jbytes, true);
+        return FLSlice_Copy(bytes);
+    }
 
-        const char *jstringSlice::c_str() {
-            return (const char *) _slice.buf;
-        }
+    // ----------------------------------------------------------------------------
+    // Other Glue
+    // ----------------------------------------------------------------------------
 
-        // ----------------------------------------------------------------------------
-        // jbyteArraySlice
-        // ----------------------------------------------------------------------------
+    jstring toJString(JNIEnv *env, C4Slice s) {
+        if (s.buf == nullptr)
+            return nullptr;
+        return UTF8ToJstring(env, (char *) s.buf, s.size);
+    }
 
-        // ATTN: In critical, cannot call any other JNI methods.
-        // http://docs.oracle.com/javase/6/docs/technotes/guides/jni/spec/functions.html
-        // Just don't set it true.
-        jbyteArraySlice::jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, bool critical)
-                : jbyteArraySlice(env, false, jbytes, critical) {}
+    jstring toJString(JNIEnv *env, C4SliceResult s) {
+        return toJString(env, (C4Slice) s);
+    }
 
-        jbyteArraySlice::jbyteArraySlice(JNIEnv *env, bool delRef, jbyteArray jbytes, bool critical)
-                : jbyteArraySlice(
-                env,
-                delRef,
-                jbytes,
-                (size_t) (!jbytes ? 0 : env->GetArrayLength(jbytes)),
-                critical) {}
+    // NOTE: this creates a *copy* of the passed slice
+    jbyteArray toJByteArray(JNIEnv *env, C4Slice s) {
+        if (s.buf == nullptr)
+            return nullptr;
+        jbyteArray array = env->NewByteArray((jsize) s.size);
+        if (array != nullptr)
+            env->SetByteArrayRegion(array, 0, (jsize) s.size, (const jbyte *) s.buf);
+        return array;
+    }
 
-        jbyteArraySlice::jbyteArraySlice(JNIEnv *env, bool delRef, jbyteArray jbytes, size_t length, bool critical)
-                : _env(env),
-                  _jbytes(jbytes),
-                  _critical(critical),
-                  _delRef(delRef) {
-            if ((jbytes == nullptr) || (length <= 0)) {
-                _slice = kFLSliceNull;
-                return;
-            }
+    jbyteArray toJByteArray(JNIEnv *env, C4SliceResult s) {
+        return toJByteArray(env, (C4Slice) s);
+    }
 
-            void *data;
-            if (critical) {
-                data = env->GetPrimitiveArrayCritical(jbytes, nullptr);
-            } else {
-                data = env->GetByteArrayElements(jbytes, nullptr);
-            }
+    jobject toJavaFLSliceResult(JNIEnv *const env, const FLSliceResult &sr) {
+        return env->CallStaticObjectMethod(
+                cls_FLSliceResult,
+                m_FLSliceResult_createSliceResult,
+                (jlong) sr.buf,
+                (jlong) sr.size);
+    }
 
-            _slice = {data, length};
-        }
+    FLSliceResult fromJavaFLSliceResult(JNIEnv *const env, jobject jsr) {
+        C4SliceResult sliceResult{
+                (const void *) env->CallLongMethod(jsr, m_FLSliceResult_getBase),
+                (size_t) env->CallLongMethod(jsr, m_FLSliceResult_getSize)
+        };
+        return sliceResult;
+    }
 
-        jbyteArraySlice::~jbyteArraySlice() {
-            if (_slice.buf != nullptr) {
-                if (_critical) {
-                    _env->ReleasePrimitiveArrayCritical(_jbytes, (void *) _slice.buf, JNI_ABORT);
-                } else {
-                    _env->ReleaseByteArrayElements(_jbytes, (jbyte *) _slice.buf, JNI_ABORT);
-                }
-            }
-            if (_jbytes && _delRef) _env->DeleteLocalRef(_jbytes);
-        }
+    void unbindJavaFLSliceResult(JNIEnv *const env, jobject jsr) { env->CallVoidMethod(jsr, m_FLSliceResult_unbind); }
 
-        FLSliceResult jbyteArraySlice::copy(JNIEnv *env, jbyteArray jbytes) {
-            jbyteArraySlice bytes(env, jbytes, true);
-            return FLSlice_Copy(bytes);
-        }
+    jobject toStringList(JNIEnv *env, const FLMutableArray array) {
+        uint32_t n = FLArray_Count(array);
+        jobject result = env->NewObject(cls_ArrayList, m_ArrayList_init, (jint) n);
 
-        // ----------------------------------------------------------------------------
-        // Other Glue
-        // ----------------------------------------------------------------------------
-
-        jstring toJString(JNIEnv *env, C4Slice s) {
-            if (s.buf == nullptr)
-                return nullptr;
-            return UTF8ToJstring(env, (char *) s.buf, s.size);
-        }
-
-        jstring toJString(JNIEnv *env, C4SliceResult s) {
-            return toJString(env, (C4Slice) s);
-        }
-
-        // NOTE: this creates a *copy* of the passed slice
-        jbyteArray toJByteArray(JNIEnv *env, C4Slice s) {
-            if (s.buf == nullptr)
-                return nullptr;
-            jbyteArray array = env->NewByteArray((jsize) s.size);
-            if (array != nullptr)
-                env->SetByteArrayRegion(array, 0, (jsize) s.size, (const jbyte *) s.buf);
-            return array;
-        }
-
-        jbyteArray toJByteArray(JNIEnv *env, C4SliceResult s) {
-            return toJByteArray(env, (C4Slice) s);
-        }
-
-        jobject toJavaFLSliceResult(JNIEnv *const env, const FLSliceResult &sr) {
-            return env->CallStaticObjectMethod(
-                    cls_FLSliceResult,
-                    m_FLSliceResult_createManaged,
-                    (jlong) sr.buf,
-                    (jlong) sr.size);
-        }
-
-        jobject toJavaUnmanagedFLSliceResult(JNIEnv *const env, const FLSliceResult &sr) {
-            return env->CallStaticObjectMethod(
-                    cls_FLSliceResult,
-                    m_FLSliceResult_createUnmanaged,
-                    (jlong) sr.buf,
-                    (jlong) sr.size);
-        }
-
-        FLSliceResult fromJavaFLSliceResult(JNIEnv *const env, jobject jsr) {
-            auto base = (const void *) env->GetLongField(jsr, f_FLSliceResult_base);
-            auto size = (size_t) env->GetLongField(jsr, f_FLSliceResult_size);
-            C4SliceResult sliceResult{base, size};
-            return sliceResult;
-        }
-
-        jobject toStringList(JNIEnv *env, const FLMutableArray array) {
-            uint32_t n = FLArray_Count(array);
-            jobject result = env->NewObject(cls_ArrayList, m_ArrayList_init, (jint) n);
-
-            if (array == nullptr)
-                return result;
-
-            for (int i = 0; i < n; i++) {
-                FLValue arrayElem = FLArray_Get(array, (uint32_t) i);
-                if (arrayElem == nullptr) continue;
-
-                FLSlice str = FLValue_AsString(arrayElem);
-                if (!str) continue;
-
-                jstring jstr = toJString(env, str);
-                if (!jstr) continue;
-
-                env->CallBooleanMethod(result, m_ArrayList_add, jstr);
-
-                env->DeleteLocalRef(jstr);
-            }
-
+        if (array == nullptr)
             return result;
+
+        for (int i = 0; i < n; i++) {
+            FLValue arrayElem = FLArray_Get(array, (uint32_t) i);
+            if (arrayElem == nullptr) continue;
+
+            FLSlice str = FLValue_AsString(arrayElem);
+            if (!str) continue;
+
+            jstring jstr = toJString(env, str);
+            if (!jstr) continue;
+
+            env->CallBooleanMethod(result, m_ArrayList_add, jstr);
+
+            env->DeleteLocalRef(jstr);
         }
 
-        jobject toStringSet(JNIEnv *env, const FLMutableArray array) {
-            uint32_t n = FLArray_Count(array);
-            jobject result = env->NewObject(cls_HashSet, m_HashSet_init, (jint) n);
+        return result;
+    }
 
-            if (!array)
-                return result;
+    jobject toStringSet(JNIEnv *env, const FLMutableArray array) {
+        uint32_t n = FLArray_Count(array);
+        jobject result = env->NewObject(cls_HashSet, m_HashSet_init, (jint) n);
 
-            for (int i = 0; i < n; i++) {
-                FLValue arrayElem = FLArray_Get(array, (uint32_t) i);
-                if (arrayElem == nullptr) continue;
-
-                FLSlice str = FLValue_AsString(arrayElem);
-                if (!str) continue;
-
-                jstring jstr = toJString(env, str);
-                if (!jstr) continue;
-
-                env->CallBooleanMethod(result, m_HashSet_add, jstr);
-
-                env->DeleteLocalRef(jstr);
-            }
-
+        if (!array)
             return result;
+
+        for (int i = 0; i < n; i++) {
+            FLValue arrayElem = FLArray_Get(array, (uint32_t) i);
+            if (arrayElem == nullptr) continue;
+
+            FLSlice str = FLValue_AsString(arrayElem);
+            if (!str) continue;
+
+            jstring jstr = toJString(env, str);
+            if (!jstr) continue;
+
+            env->CallBooleanMethod(result, m_HashSet_add, jstr);
+
+            env->DeleteLocalRef(jstr);
         }
 
-        bool getEncryptionKey(JNIEnv *env, jint keyAlg, jbyteArray jKeyBytes, C4EncryptionKey *outKey) {
-            outKey->algorithm = (C4EncryptionAlgorithm) keyAlg;
-            if (keyAlg == kC4EncryptionNone)
-                return true;
+        return result;
+    }
 
-            jbyteArraySlice keyBytes(env, jKeyBytes);
-            FLSlice keySlice = keyBytes;
-            if ((!keySlice) || (keySlice.size > sizeof(outKey->bytes))) {
-                throwError(env, C4Error{LiteCoreDomain, kC4ErrorCrypto});
-                return false;
-            }
-
-            memset(outKey->bytes, 0, sizeof(outKey->bytes));
-            memcpy(outKey->bytes, keySlice.buf, keySlice.size);
-
+    bool getEncryptionKey(JNIEnv *env, jint keyAlg, jbyteArray jKeyBytes, C4EncryptionKey *outKey) {
+        outKey->algorithm = (C4EncryptionAlgorithm) keyAlg;
+        if (keyAlg == kC4EncryptionNone)
             return true;
+
+        jbyteArraySlice keyBytes(env, jKeyBytes);
+        FLSlice keySlice = keyBytes;
+        if ((!keySlice) || (keySlice.size > sizeof(outKey->bytes))) {
+            throwError(env, C4Error{LiteCoreDomain, kC4ErrorCrypto});
+            return false;
         }
+
+        memset(outKey->bytes, 0, sizeof(outKey->bytes));
+        memcpy(outKey->bytes, keySlice.buf, keySlice.size);
+
+        return true;
     }
 }

--- a/common/main/cpp/native_glue.hh
+++ b/common/main/cpp/native_glue.hh
@@ -48,6 +48,7 @@ namespace litecore {
         bool initC4Socket(JNIEnv *);     // Implemented in native_c4socket.cc
 
 #ifdef COUCHBASE_ENTERPRISE
+
         bool initC4Prediction(JNIEnv *); // Implemented in native_c4prediction.cc
         bool initC4Listener(JNIEnv *);   // Implemented in native_c4listener.cc
 #endif
@@ -66,6 +67,7 @@ namespace litecore {
         std::string JstringToUTF8(JNIEnv *env, jstring jstr);
 
         jstring UTF8ToJstring(JNIEnv *env, const char *s, size_t size);
+
         jstring UTF8ToJstring(JNIEnv *env, const char *s);
 
         std::string JcharsToUTF8(const jchar *jchars, jsize len);
@@ -78,7 +80,7 @@ namespace litecore {
             jstringSlice(JNIEnv *env, jcharArray jchars);
 
             jstringSlice(jstringSlice &&s) noexcept
-                : _str(std::move(s._str)), _slice(s._slice) { s._slice = kFLSliceNull; }
+                    : _str(std::move(s._str)), _slice(s._slice) { s._slice = kFLSliceNull; }
 
             operator FLSlice() { return _slice; }
 
@@ -138,14 +140,13 @@ namespace litecore {
         // Copy a FLMutableArray of strings to a Java HashSet<String>
         jobject toStringSet(JNIEnv *env, FLMutableArray array);
 
-        // Copy a native FLSliceResult to a Managed Java FLSliceResult
+        // Copy a native FLSliceResult to a Java FLSliceResult
         jobject toJavaFLSliceResult(JNIEnv *const env, const FLSliceResult &sr);
-
-        // Copy a native FLSliceResult to an Unmanaged Java FLSliceResult
-        jobject toJavaUnmanagedFLSliceResult(JNIEnv *const env, const FLSliceResult &sr);
 
         // Copy a Java FLSliceResult to a native FLSliceResult
         FLSliceResult fromJavaFLSliceResult(JNIEnv *const env, jobject jsr);
+
+        void unbindJavaFLSliceResult(JNIEnv *const env, jobject jsr);
 
         // Copies an encryption key to a C4EncryptionKey. Returns false on exception.
         bool getEncryptionKey(

--- a/common/main/java/com/couchbase/lite/internal/fleece/FLEncoder.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/FLEncoder.java
@@ -62,8 +62,6 @@ public abstract class FLEncoder extends C4NativePeer {
         @NonNull
         FLSliceResult nFinish2(long peer) throws LiteCoreException;
         @NonNull
-        FLSliceResult nFinish3(long peer) throws LiteCoreException;
-        @NonNull
         String nFinishJSON(long peer) throws LiteCoreException;
         void nFree(long peer);
     }
@@ -342,9 +340,4 @@ public abstract class FLEncoder extends C4NativePeer {
     // NOTE: the FLSliceResult returned by this method must be released by the caller
     @NonNull
     public FLSliceResult finish2() throws LiteCoreException { return impl.nFinish2(getPeer()); }
-
-    // NOTE: We expect the FLSliceResult returned by this method to be handed, immediately,
-    // to someone else (LiteCore) who will release it.  Java does release the memory.
-    @NonNull
-    public FLSliceResult finish3() throws LiteCoreException { return impl.nFinish3(getPeer()); }
 }

--- a/common/main/java/com/couchbase/lite/internal/fleece/impl/NativeFLEncoder.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/impl/NativeFLEncoder.java
@@ -85,10 +85,6 @@ public final class NativeFLEncoder implements FLEncoder.NativeImpl {
 
     @NonNull
     @Override
-    public FLSliceResult nFinish3(long peer) throws LiteCoreException { return finish3(peer); }
-
-    @NonNull
-    @Override
     public String nFinishJSON(long peer) throws LiteCoreException { return finishJSON(peer); }
 
     @Override
@@ -144,7 +140,4 @@ public final class NativeFLEncoder implements FLEncoder.NativeImpl {
 
     @NonNull
     private static native FLSliceResult finish2(long peer) throws LiteCoreException;
-
-    @NonNull
-    private static native FLSliceResult finish3(long peer) throws LiteCoreException;
 }

--- a/common/main/java/com/couchbase/lite/internal/fleece/impl/NativeFLSliceResult.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/impl/NativeFLSliceResult.java
@@ -24,7 +24,7 @@ public final class NativeFLSliceResult implements FLSliceResult.NativeImpl {
 
     @Override
     @Nullable
-    public byte[]  nGetBuf(long base, long size) { return getBuf(base, size); }
+    public byte[] nGetBuf(long base, long size) { return getBuf(base, size); }
 
     @Override
     public void nRelease(long base, long size) { release(base, size); }


### PR DESCRIPTION
Some renaming, but mostly add an `unbind` method to FLSliceResult and get rid of the Unmanaged and Managed subclasses 