### PR TITLE
CCV-239: Replace Array.equals with MessageDigest.isEqual in proxy authenticator

### DIFF
--- a/common/main/java/com/couchbase/lite/ProxyAuthenticator.java
+++ b/common/main/java/com/couchbase/lite/ProxyAuthenticator.java
@@ -17,6 +17,8 @@ package com.couchbase.lite;
 
 import androidx.annotation.NonNull;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -71,7 +73,10 @@ public final class ProxyAuthenticator extends BaseAuthenticator {
         if (this == o) { return true; }
         if (!(o instanceof ProxyAuthenticator)) { return false; }
         final ProxyAuthenticator other = (ProxyAuthenticator) o;
-        return username.equals(other.username) && Arrays.equals(password, other.password);
+        return username.equals(other.username)
+            && MessageDigest.isEqual(
+            new String(password).getBytes(StandardCharsets.UTF_8),
+            new String(other.password).getBytes(StandardCharsets.UTF_8));
     }
 
 

--- a/common/main/java/com/couchbase/lite/internal/logging/Log.java
+++ b/common/main/java/com/couchbase/lite/internal/logging/Log.java
@@ -265,7 +265,7 @@ public final class Log {
 
         // only generate logs >= current priority.
         final LogSinksImpl logSinks = LogSinksImpl.getLogSinks();
-        if (!logSinks.shouldLog(level, domain)) { return; }
+        if ((logSinks == null) || (!logSinks.shouldLog(level, domain))) { return; }
 
         String message;
         if (msg == null) { message = ""; }

--- a/common/main/java/com/couchbase/lite/internal/logging/LogSinksImpl.java
+++ b/common/main/java/com/couchbase/lite/internal/logging/LogSinksImpl.java
@@ -35,7 +35,6 @@ import com.couchbase.lite.LogLevel;
 import com.couchbase.lite.internal.CouchbaseLiteInternal;
 import com.couchbase.lite.internal.core.C4Log;
 import com.couchbase.lite.internal.core.CBLVersion;
-import com.couchbase.lite.internal.utils.Preconditions;
 import com.couchbase.lite.logging.BaseLogSink;
 import com.couchbase.lite.logging.ConsoleLogSink;
 import com.couchbase.lite.logging.FileLogSink;
@@ -49,8 +48,8 @@ public final class LogSinksImpl implements LogSinks {
     @NonNull
     private static final AtomicReference<LogSinksImpl> LOG_SINKS = new AtomicReference<>();
 
-    @NonNull
-    public static LogSinksImpl getLogSinks() { return Preconditions.assertNotNull(LOG_SINKS.get(), "log sink impl"); }
+    @Nullable
+    public static LogSinksImpl getLogSinks() { return LOG_SINKS.get(); }
 
     // The center of log system initialization.
     public static void initLogging() {
@@ -219,6 +218,25 @@ public final class LogSinksImpl implements LogSinks {
         catch (Exception e) { logFailure("Custom", e); }
     }
 
+    // Something in the Logging system has failed.
+    // Try to log the failure to the console.
+    // If that doesn't wor, log to System err
+    @SuppressWarnings({"RegexpSinglelineJava", "PMD.SystemPrintln"})
+    public void logFailure(@NonNull String name, @Nullable Exception err) {
+        String msg = name + " log failure";
+        if (err != null) { msg += "\n" + Log.formatStackTrace(err); }
+
+        final ConsoleLogSink console = consoleLogSink;
+        if (console != null) {
+            try {
+                console.log(LogLevel.WARNING, LogDomain.DATABASE, msg);
+                return;
+            }
+            catch (Exception ignore) { }
+        }
+        System.err.println("WARNING: " + msg);
+    }
+
     public boolean shouldLog(@NonNull LogLevel level, @NonNull LogDomain domain) {
         return (logLevel.get().compareTo(level) <= 0) && logDomains.get().contains(domain);
     }
@@ -291,22 +309,6 @@ public final class LogSinksImpl implements LogSinks {
             LogDomain.DATABASE,
             "Database.log.getFile().getConfig() is now null: logging is disabled.  "
                 + "Log files required for product support are not being generated.");
-    }
-
-    // One of the loggers has failed.  Try to log the failure to the console.
-    // If that fails, log to System err
-    @SuppressWarnings({"RegexpSinglelineJava", "PMD.SystemPrintln"})
-    private void logFailure(@NonNull String name, @NonNull Exception err) {
-        final String msg = name + " log failure" + Log.formatStackTrace(err);
-        final ConsoleLogSink console = consoleLogSink;
-        if (console != null) {
-            try {
-                console.log(LogLevel.WARNING, LogDomain.DATABASE, msg);
-                return;
-            }
-            catch (Exception ignore) { }
-        }
-        System.err.println("WARNING: " + msg);
     }
 
     // Log to a non-null sink

--- a/common/test/java/com/couchbase/lite/logging/LogTest.kt
+++ b/common/test/java/com/couchbase/lite/logging/LogTest.kt
@@ -93,7 +93,7 @@ class LogTest : BaseDbTest() {
     fun testC4LogLevel() {
         val mark = "$$$ ${UUID.randomUUID()}"
 
-        val c4Log = LogSinksImpl.getLogSinks().c4Log
+        val c4Log = assertNonNull(LogSinksImpl.getLogSinks()).c4Log
         c4Log.initFileLogging(scratchDirPath, LogLevel.DEBUG, 10, 1024, true, "$$$ TEST")
 
         for (level in LogLevel.values()) {
@@ -133,7 +133,7 @@ class LogTest : BaseDbTest() {
 
     @Test
     fun testC4MaxFileSize() {
-        val c4Log = LogSinksImpl.getLogSinks().c4Log
+        val c4Log = assertNonNull(LogSinksImpl.getLogSinks()).c4Log
         c4Log.initFileLogging(scratchDirPath, LogLevel.DEBUG, 10, 1024, true, "$$$$ TEST")
         c4Log.setLogLevel(LogDomain.DATABASE, LogLevel.DEBUG)
 


### PR DESCRIPTION
Also, prevent logging calls during LiteCore log callback