### PR TITLE
Tests for CBSE-19205

### DIFF
--- a/common/jni_android.ld
+++ b/common/jni_android.ld
@@ -21,6 +21,7 @@ CBL {
         Java_com_couchbase_lite_internal_core_C4TestUtils_getLevel;
         Java_com_couchbase_lite_internal_core_C4TestUtils_getPrivateUUID;
         Java_com_couchbase_lite_internal_core_C4TestUtils_isIndexTrained;
+        Java_com_couchbase_lite_internal_core_C4TestUtils_log;
         Java_com_couchbase_lite_internal_core_C4TestUtils_next;
         Java_com_couchbase_lite_internal_core_C4TestUtils_openStore;
         Java_com_couchbase_lite_internal_core_C4TestUtils_put;

--- a/common/main/cpp/com_couchbase_lite_internal_core_C4TestUtils.h
+++ b/common/main/cpp/com_couchbase_lite_internal_core_C4TestUtils.h
@@ -156,6 +156,19 @@ JNIEXPORT jint
 JNICALL Java_com_couchbase_lite_internal_core_C4TestUtils_getLevel
         (JNIEnv *, jclass, jstring);
 
+/*
+ * Class:     com_couchbase_lite_internal_core_C4TestUtils
+ * Method:    log
+ * Signature: (Ljava/lang/String;I;Ljava/lang/String)V
+ */
+JNIEXPORT void JNICALL
+Java_com_couchbase_lite_internal_core_C4TestUtils_log(
+        JNIEnv *env,
+        jclass ignore,
+        jstring jdomain,
+        jint level,
+        jstring jmessage);
+
 // C4Collection
 
 /*
@@ -177,6 +190,7 @@ Java_com_couchbase_lite_internal_core_C4TestUtils_isIndexTrained(
  */
 JNIEXPORT jobject JNICALL
 Java_com_couchbase_lite_internal_core_C4TestUtils_getIndexOptions(JNIEnv *, jclass, jlong);
+
 
 #ifdef __cplusplus
 }

--- a/common/main/cpp/native_c4testutils.cc
+++ b/common/main/cpp/native_c4testutils.cc
@@ -386,6 +386,20 @@ Java_com_couchbase_lite_internal_core_C4TestUtils_getLevel(JNIEnv *env, jclass i
     return (!logDomain) ? -1 : (jint) c4log_getLevel(logDomain);
 }
 
+JNIEXPORT void JNICALL
+Java_com_couchbase_lite_internal_core_C4TestUtils_log(
+        JNIEnv *env,
+        jclass ignore,
+        jstring jdomain,
+        jint level,
+        jstring jmessage) {
+    jstringSlice domain(env, jdomain);
+    jstringSlice message(env, jmessage);
+    C4LogDomain logDomain = c4log_getDomain(domain.c_str(), true);
+    if (logDomain != nullptr)
+        c4log(logDomain, (C4LogLevel) level, "%s", message.c_str());
+}
+
 // C4Index
 
 /*
@@ -437,4 +451,4 @@ Java_com_couchbase_lite_internal_core_C4TestUtils_getIndexOptions(JNIEnv *env, j
             UTF8ToJstring(env, opts.stopWords),
             UTF8ToJstring(env, opts.unnestPath));
 }
-}
+} // extern "C"

--- a/common/test/java/com/couchbase/lite/internal/core/C4TestUtils.java
+++ b/common/test/java/com/couchbase/lite/internal/core/C4TestUtils.java
@@ -210,6 +210,10 @@ public class C4TestUtils {
 
     public static int getLogLevel(String domain) { return getLevel(domain); }
 
+    public static void forceLog(@NonNull String domain, int level, @NonNull String message) {
+        log(domain, level, message);
+    }
+
     // C4Index
 
     public static boolean isIndexTrained(C4Collection collection, @NonNull String name) throws LiteCoreException {
@@ -304,6 +308,8 @@ public class C4TestUtils {
     // C4Log
 
     private static native int getLevel(@NonNull String domain);
+
+    private static native void log(@NonNull String domain, int level, @NonNull String message);
 
     // C4Index
 


### PR DESCRIPTION
Two tests, one for each of the two failure modes.
Instrumentation to support them.
The same instrumentation supports the previously commented out NonASCII test.

... and, fwiw, I found another call to c4log_getDomain and protected it as well.  It is very unlikely that it would ever be called from within the callback.