### PR TITLE
Several small changes:

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/core/C4Log.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Log.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.couchbase.lite.LogDomain;
@@ -51,6 +50,35 @@ public final class C4Log {
     @VisibleForTesting
     public interface CallbackInstrumentation {
         void onCallback(@Nullable String c4Domain, int c4Level, @Nullable String message);
+    }
+
+    // Prevent the LiteCore thread that invokes the logging callback,
+    // from making a direct recursive call to the LiteCore logger.
+    // Note that this actually leaves a couple of big holes:
+    // - Before the logging thread ever gets here, it has to attach the JVM. That will probably cause allocation
+    //   which may, in turn run GC code on the calling thread, which may attempt to free a LiteCore object... which
+    //   may cause logging
+    // - Anything this thread does that causes a call into LiteCore (allocation, like the above case, or
+    //   a call to some rando LiteCore function) may cause LiteCore to try to log something.  Boom.
+    private static final class CallbackGuard extends ThreadLocal<Boolean> {
+        @NonNull
+        @Override
+        protected Boolean initialValue() { return Boolean.FALSE; }
+
+        public boolean isInUse() {
+            final Boolean val = super.get();
+            return (val != null) && val;
+        }
+
+        public void setInUse(boolean val) { super.set(val); }
+
+        // Just being careful....
+        @Override
+        public void set(@Nullable Boolean value) { throw new UnsupportedOperationException("set not supported"); }
+
+        @Nullable
+        @Override
+        public Boolean get() { throw new UnsupportedOperationException("get not supported"); }
     }
 
     @NonNull
@@ -138,21 +166,21 @@ public final class C4Log {
         LOGGING_DOMAIN_TO_CANONICAL_C4 = Collections.unmodifiableMap(m);
     }
 
-    private static final AtomicBoolean IN_CALLBACK = new AtomicBoolean(false);
+    private static final CallbackGuard CALLBACK = new CallbackGuard();
 
     private static final AtomicReference<CallbackInstrumentation> CALLBACK_INSTRUMENTATION
         = new AtomicReference<>(null);
 
     // This method is used by reflection.  Don't change its signature.
     public static void logCallback(@Nullable String c4Domain, int c4Level, @Nullable String message) {
-        IN_CALLBACK.set(true);
+        CALLBACK.setInUse(true);
 
         final CallbackInstrumentation instrumentation = CALLBACK_INSTRUMENTATION.get();
         if (instrumentation != null) { instrumentation.onCallback(c4Domain, c4Level, message); }
 
         LogSinksImpl.logFromCore(getLogLevelForC4Level(c4Level), getLoggingDomainForC4Domain(c4Domain), message);
 
-        IN_CALLBACK.set(false);
+        CALLBACK.setInUse(false);
     }
 
     @NonNull
@@ -177,8 +205,8 @@ public final class C4Log {
     private C4Log(@NonNull NativeImpl impl) { this.impl = impl; }
 
     public void logToCore(@NonNull LogDomain domain, @NonNull LogLevel level, @NonNull String message) {
-        if (IN_CALLBACK.get()) {
-            LogSinksImpl.logFailure("Recursive logging", null);
+        if (CALLBACK.isInUse()) {
+            LogSinksImpl.logFailure("logToCore", message, null);
             return;
         }
         // Yes, there is a small race here...
@@ -239,8 +267,8 @@ public final class C4Log {
     }
 
     private void setLogLevel(@NonNull String domain, int level) {
-        if (IN_CALLBACK.get()) {
-            LogSinksImpl.logFailure("Log Level", null);
+        if (CALLBACK.isInUse()) {
+            LogSinksImpl.logFailure("setLogLevel", null, null);
             return;
         }
         // Yes, there is a small race here...

--- a/common/main/java/com/couchbase/lite/internal/core/C4Peer.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Peer.java
@@ -85,7 +85,7 @@ public abstract class C4Peer implements AutoCloseable {
             final C4Peer.PeerCleaner disposer = cleaner;
             if (disposer != null) {
                 if (!finalizing) { disposeRef(disposer); }
-                else { CORE_CLEANER.execute(() -> disposeRef(disposer)); }
+                else { PEER_DISPOSER.execute(() -> disposeRef(disposer)); }
             }
 
             final Exception origin = lifecycle.get();
@@ -100,7 +100,7 @@ public abstract class C4Peer implements AutoCloseable {
             // Keep this at the debug level and only do it if debugging.  It frightens the children.
             // Apparently this call is bizarrely expensive: just don't do it unless you really need it.
             // Definitely don't do it on the cleaner thread
-            CORE_CLEANER.execute(() -> Log.d(LogDomain.DATABASE, "Peer %s not explicitly closed", createdAt, name));
+            PEER_DISPOSER.execute(() -> Log.d(LogDomain.DATABASE, "Peer %s not explicitly closed", createdAt, name));
         }
 
         @NonNull
@@ -151,9 +151,12 @@ public abstract class C4Peer implements AutoCloseable {
     }
 
     @VisibleForTesting
-    static final Cleaner CLEANER = new Cleaner("c4peer");
+    static final Cleaner CLEANER = new Cleaner("peer");
+    // Executor holds 3 threads that expire after 5 minutes
+    // Java Executors make it difficult to do what I'd really like to do, here:
+    // always have 1 thread available but grow to 3 threads before enqueuing anything.
     @VisibleForTesting
-    static final CBLExecutor CORE_CLEANER = new CBLExecutor("CoreCleaner", 3, 3, new LinkedBlockingQueue<>());
+    static final CBLExecutor PEER_DISPOSER = new CBLExecutor("peer-free", 3, 3, 60 * 5, new LinkedBlockingQueue<>());
 
 
     @NonNull
@@ -199,6 +202,12 @@ public abstract class C4Peer implements AutoCloseable {
     @Override
     @CallSuper
     public void close() { cleaner.clean(false); }
+
+    // WARNING!! This method is absurdly expensive.  Don't use it in production code!
+    public final void dumpStats() {
+        Log.w(LogDomain.DATABASE, CLEANER.getStats().toString());
+        PEER_DISPOSER.dumpState();
+    }
 
     protected final <E extends Exception> void voidWithPeerOrWarn(@NonNull Fn.ConsumerThrows<Long, E> fn) throws E {
         synchronized (getPeerLock()) {

--- a/common/main/java/com/couchbase/lite/internal/exec/Cleaner.java
+++ b/common/main/java/com/couchbase/lite/internal/exec/Cleaner.java
@@ -290,8 +290,7 @@ public final class Cleaner {
         void clean(boolean finalizing);
     }
 
-    @VisibleForTesting
-    public static class Stats {
+    public static final class Stats {
         public final long timeIn;
         public final int minSize;
         public final int maxSize;
@@ -302,6 +301,12 @@ public final class Cleaner {
             this.minSize = minSize;
             this.maxSize = maxSize;
             this.alive = alive;
+        }
+
+        @Override
+        @NonNull
+        public String toString() {
+            return "CleanerStats{" + timeIn + ", " + minSize + ", " + maxSize + ", " + alive + "}";
         }
     }
 
@@ -315,7 +320,7 @@ public final class Cleaner {
     Cleaner(@NonNull String name, int timeoutMs) {
         // WARNING: Don't "fix" this to assign to this.impl!
         // If the lambda holds a reference to this.impl this Cleaner object will forever be reachable.
-        final CleanerImpl impl = new CleanerImpl(name + "-cleaner", timeoutMs);
+        final CleanerImpl impl = new CleanerImpl(name + "-clean", timeoutMs);
         impl.register(this, ignore -> impl.stopCleaner());
 
         this.impl = impl;
@@ -331,13 +336,13 @@ public final class Cleaner {
     @NonNull
     public Cleanable register(@NonNull Object obj, @NonNull Cleanable cleaner) { return impl.register(obj, cleaner); }
 
+    // This is quite expensive: don't use it in production.
+    @NonNull
+    public Stats getStats() { return impl.getStats(); }
+
     @VisibleForTesting
     void stop() { impl.stopCleaner(); }
 
     @VisibleForTesting
     boolean isStopped() { return impl.isStopped(); }
-
-    @VisibleForTesting
-    @NonNull
-    public Stats getStats() { return impl.getStats(); }
 }

--- a/common/test/java/com/couchbase/lite/internal/ExecutionServiceTest.kt
+++ b/common/test/java/com/couchbase/lite/internal/ExecutionServiceTest.kt
@@ -30,7 +30,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
-import java.util.*
+import java.util.Stack
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.CyclicBarrier
 import java.util.concurrent.LinkedBlockingQueue


### PR DESCRIPTION
- Only block the LiteCore callback thread from recursive calls to logging
- Extend the lifetime of the C4Peer cleaner threads from 30 seconds to 5 minutes
- When the logging system fails, add any dropped log message to the failure warning
 - Shorten c4Peer/Cleaner thread names so that they make it under the 15-char limit
 - Add dumpStats method to c4Peers
