### PR TITLE
CBL-6879: Link with 16KB page size

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -83,7 +83,7 @@ target_include_directories( LiteCoreJNI PUBLIC
 
 set_target_properties(
     LiteCoreJNI PROPERTIES LINK_FLAGS
-    "-Wl,--version-script=${PROJECT_SOURCE_DIR}/jni_android.ld"
+    "-Wl,-z,max-page-size=16384,--version-script=${PROJECT_SOURCE_DIR}/jni_android.ld"
 )
 
 target_link_libraries( LiteCoreJNI


### PR DESCRIPTION
I don't know of a way to demonstrate that this works....
... and I'm a bit concerned because Jim's version uses a second "-Wl" in front of the second arg.  My build failed when I tried to do that ( ld: error: unknown argument '-Wl' )
I am assuming that the first -Wl on the line directs the rest of the line to the linker, which does not, of course, understand "-Wl"