### PR TITLE
Release candidate 3.2.3 rc 2

### DIFF
--- a/common/main/java/com/couchbase/lite/Document.java
+++ b/common/main/java/com/couchbase/lite/Document.java
@@ -38,6 +38,7 @@ import com.couchbase.lite.internal.logging.Log;
 import com.couchbase.lite.internal.utils.ClassUtils;
 import com.couchbase.lite.internal.utils.Internal;
 import com.couchbase.lite.internal.utils.Preconditions;
+import com.couchbase.lite.internal.utils.Volatile;
 
 
 /**
@@ -193,8 +194,12 @@ public class Document implements DictionaryInterface, Iterable<String> {
     /**
      * Get the document's timestamp.
      *
+     * The values returned by this method are, actually, just the document's generation
+     * number.  This is a increasing number but not, until future releases, an actual timestamp.
+     *
      * @return the document's timestamp
      */
+    @Volatile
     public long getTimestamp() {
         synchronized (lock) { return (c4Document == null) ? -1 : c4Document.getTimestamp(); }
     }
@@ -616,7 +621,7 @@ public class Document implements DictionaryInterface, Iterable<String> {
         // This seems like a great place to close the old c4Document.
         // It appears, though, that there may be other live references
         // and that closing it here can cause failures.
-        // See C4Document.finalize()
+        // See C4Document.close()
         c4Document = c4Doc;
 
         if (c4Doc != null) { revId = null; }

--- a/common/main/java/com/couchbase/lite/internal/core/C4Document.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Document.java
@@ -149,7 +149,8 @@ public final class C4Document extends C4Peer {
     //-------------------------------------------------------------------------
 
     private C4Document(@NonNull NativeImpl impl, long peer) {
-        super(peer, impl::nFree);
+        // C4Documents cannot be explicitly closed so don't gripe when they aren't
+        super(peer, impl::nFree, true);
         this.impl = impl;
     }
 

--- a/common/main/java/com/couchbase/lite/internal/core/C4Peer.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Peer.java
@@ -65,7 +65,7 @@ public abstract class C4Peer implements AutoCloseable {
         @NonNull
         private final AtomicReference<Exception> lifecycle;
 
-        PeerHolder(@NonNull String name, long peer, @Nullable PeerCleaner cleaner) {
+        PeerHolder(@NonNull String name, long peer, @Nullable PeerCleaner cleaner, boolean quiet) {
             this.id = peer;
             this.cleaner = cleaner;
 
@@ -73,8 +73,8 @@ public abstract class C4Peer implements AutoCloseable {
 
             this.name = name;
             this.createdAt = System.currentTimeMillis();
-            this.lifecycle
-                = new AtomicReference<>((!CouchbaseLiteInternal.debugging()) ? null : new Exception("Created at:"));
+            this.lifecycle = new AtomicReference<>(
+                (quiet || (!CouchbaseLiteInternal.debugging())) ? null : new Exception("Created at:"));
         }
 
         /**
@@ -100,7 +100,7 @@ public abstract class C4Peer implements AutoCloseable {
             // Keep this at the debug level and only do it if debugging.  It frightens the children.
             // Apparently this call is bizarrely expensive: just don't do it unless you really need it.
             // Definitely don't do it on the cleaner thread
-            PEER_DISPOSER.execute(() -> Log.d(LogDomain.DATABASE, "Peer %s not explicitly closed", createdAt, name));
+            PEER_DISPOSER.execute(() -> Log.d(LogDomain.DATABASE, "Peer %s not explicitly closed", origin, name));
         }
 
         @NonNull
@@ -129,7 +129,11 @@ public abstract class C4Peer implements AutoCloseable {
 
         // Log an attempt to use a closed peer.
         private void logBadCall() {
-            Log.w(LogDomain.DATABASE, "Operation on closed native peer", new Exception("Used at:", lifecycle.get()));
+            Log.w(
+                LogDomain.DATABASE,
+                "Peer %s used after close",
+                new Exception("Used at:", lifecycle.get()),
+                name);
         }
     }
 
@@ -137,8 +141,8 @@ public abstract class C4Peer implements AutoCloseable {
      * LiteCore objects that are not ref-counted must not have multiple references.
      */
     private static class UncountedPeerHolder extends PeerHolder {
-        UncountedPeerHolder(@NonNull String name, long peer, @Nullable PeerCleaner cleaner) {
-            super(name, peer, cleaner);
+        UncountedPeerHolder(@NonNull String name, long peer, @Nullable PeerCleaner cleaner, boolean quiet) {
+            super(name, peer, cleaner, quiet);
         }
 
         @Override
@@ -167,10 +171,13 @@ public abstract class C4Peer implements AutoCloseable {
     @NonNull
     final Cleaner.Cleanable cleaner;
 
-    // Most LiteCore objects are ref-counted.  There may be several references to the same object.
-    protected C4Peer(long peer, @Nullable PeerCleaner cleaner) { this(peer, cleaner, true); }
+    // Most object should bark if they are not explicitly freed
+    protected C4Peer(long peer, @Nullable PeerCleaner cleaner) { this(peer, cleaner, true, false); }
 
-    // At this moment, he following LiteCore objects not ref-counted:
+    // Most LiteCore objects are ref-counted.  There may be several references to the same object.
+    protected C4Peer(long peer, @Nullable PeerCleaner cleaner, boolean quiet) { this(peer, cleaner, true, quiet); }
+
+    // At this moment, the following LiteCore objects not ref-counted:
     //    C4BlobKey
     //    C4BlobReadStream
     //    C4BlobStore
@@ -179,13 +186,13 @@ public abstract class C4Peer implements AutoCloseable {
     //    C4Listener
     //    C4QueryObserver
     //    C4Replicator
-    protected C4Peer(long peer, @Nullable PeerCleaner cleaner, boolean refCounted) {
+    protected C4Peer(long peer, @Nullable PeerCleaner cleaner, boolean refCounted, boolean quiet) {
         this.name = getClass().getSimpleName() + ClassUtils.objId(this);
 
         Preconditions.assertNotZero(peer, "peer");
         this.peerHolder = (refCounted)
-            ? new PeerHolder(name, peer, cleaner)
-            : new UncountedPeerHolder(name, peer, cleaner);
+            ? new PeerHolder(name, peer, cleaner, quiet)
+            : new UncountedPeerHolder(name, peer, cleaner, quiet);
 
         // WARNING:
         // Anything to which the peerHolder holds a reference will be reachable until the cleaner is run

--- a/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
+++ b/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
@@ -101,11 +101,11 @@ import com.couchbase.lite.internal.utils.StringUtils;
  * To understanding what goes on here, you need to know about MessageFraming (and its API relative, ProtocolTypes).
  * Core knows all about the WebSockets protocol.  It would be glad to be pretty much completely responsible for a
  * WS connection, if we could just send the bytes across some raw byte stream.  Most of the platforms use this mode,
- * called CLIENT_FRAMING (ProtocolType.BYTE_STREAM). For better or worse, though we hired OkHTTP to do this job.
- * It is also very smart and *it* wants to handle the WS connection.  The solution, dating back to the dawn of time,
- * is that we *always* use the connection mode NO_FRAMING (ProtocolType.MESSAGE_STREAM). In this mode Core calls
- * us for state transitions, but provides on the basic payload data that must be transferred.  Java code is
- * responsible for framing the data as necessary for the remote.  We leave that to OkHttp.
+ * which we call CLIENT_FRAMING (ProtocolType.BYTE_STREAM). For better or worse, though, we hired OkHTTP as our
+ * network interface.  It is also very smart and *it* wants to handle the WS connection.  The solution, dating back
+ * to the dawn of time, is that we *always* use the other connection mode NO_FRAMING (ProtocolType.MESSAGE_STREAM).
+ * In this mode Core calls us for state transitions and provides only the basic payload data that must be transferred.
+ * Java code is responsible for framing the data as necessary for the remote.  We leave that to OkHttp.
  * <p>
  * <p>
  * This document: <a href="https://docs.google.com/document/d/1DH1heyHw_pIJdKx8K1vD1GBvwp5RVlX_IUN2DohkSg0/edit">
@@ -122,7 +122,7 @@ import com.couchbase.lite.internal.utils.StringUtils;
  * </ul>
  * <p>
  * This class operates under the assumption that its correspondents are fairly state tolerant:
- * they can cope with events that are only appropriate to states that they are no longer in.
+ * they *can* cope with events that are only appropriate to states that they are no longer in.
  * While the state machine makes a best effort at preventing out-of-state events, there are several
  * races would allow rogues.
  */

--- a/common/test/java/com/couchbase/lite/LegacyLogTest.kt
+++ b/common/test/java/com/couchbase/lite/LegacyLogTest.kt
@@ -412,8 +412,8 @@ class LegacyLogTest : BaseDbTest() {
         assertNull(fileLogger.config)
         fileLogger.config = config
         assertEquals(config, fileLogger.config)
-        fileLogger.config = LogFileConfiguration("$scratchDirPath/foo")
-        assertEquals(LogFileConfiguration("$scratchDirPath/foo"), fileLogger.config)
+        fileLogger.config = LogFileConfiguration("$scratchDirPath/legacyLogs")
+        assertEquals(LogFileConfiguration("$scratchDirPath/legacyLogs"), fileLogger.config)
     }
 
     @Test


### PR DESCRIPTION
Annotate Document.getTimestamp as @Volatile
Quiet some C4Peer hysterics
Tests that depend on the extension package are skipped if it cannot be loaded…

The actually changes here are very minor.