### PR TITLE
replace assert with warning

### DIFF
--- a/common/main/cpp/native_c4replicator.cc
+++ b/common/main/cpp/native_c4replicator.cc
@@ -321,8 +321,13 @@ static void documentEndedCallback(
         size_t numDocs,
         const C4DocumentEnded *documentEnded[],
         void *token) {
-    assert(numDocs < 16384);
     int nDocs = (int) numDocs;
+    if (nDocs <= 0) {
+        C4Warn("Ignoring documentEndedCallback for %d documents", nDocs);
+        return;
+    }
+    if (nDocs > 10000)
+        C4Warn("documentEndedCallback for a *LOT* of documents: %d", nDocs);
 
     JNIEnv *env = nullptr;
     jint getEnvStat = gJVM->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6);

--- a/common/main/java/com/couchbase/lite/internal/core/C4Peer.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Peer.java
@@ -52,7 +52,7 @@ public abstract class C4Peer implements AutoCloseable {
 
     /**
      * Most PeerHolders are for ref-counted objects.  There may be several references
-     * to the same object, so <code></code>.equals<code></code> means the exact same PeerHolder (Java default).
+     * to the same object, so <code>.equals</code> means the exact same PeerHolder (Java default).
      */
     private static class PeerHolder implements Cleaner.Cleanable {
         @Nullable


### PR DESCRIPTION
Ignore negative (or very large) doc-end bundles and warn on big ones.