### PR TITLE
Immediately retain C4Socket

### DIFF
--- a/common/main/cpp/com_couchbase_lite_internal_core_impl_NativeC4Socket.h
+++ b/common/main/cpp/com_couchbase_lite_internal_core_impl_NativeC4Socket.h
@@ -26,15 +26,6 @@ JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4Socket_fromNative
 
 /*
  * Class:     com_couchbase_lite_internal_core_C4Socket
- * Method:    retain
- * Signature: (J)V
- */
-JNIEXPORT void
-JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4Socket_retain
-        (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_couchbase_lite_internal_core_C4Socket
  * Method:    opened
  * Signature: (J)V
  */

--- a/common/main/cpp/native_c4socket.cc
+++ b/common/main/cpp/native_c4socket.cc
@@ -84,6 +84,8 @@ static void socket_open(C4Socket *socket, const C4Address *addr, C4Slice options
     if ((envState != JNI_OK) && (envState != JNI_EDETACHED))
         return;
 
+    c4socket_retain(socket);
+
     jstring _scheme = toJString(env, addr->scheme);
     jstring _host = toJString(env, addr->hostname);
     jstring _path = toJString(env, addr->path);
@@ -220,19 +222,9 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Socket_fromNative(
     socketFactory.context = context;
 
     C4Socket *c4socket = c4socket_fromNative(socketFactory, context, &c4Address);
+    c4socket_retain(c4socket);
 
     return (jlong) c4socket;
-}
-
-/*
- * Class:     com_couchbase_lite_internal_core_C4Socket
- * Method:    retain
- * Signature: (J)V
- */
-JNIEXPORT void JNICALL
-Java_com_couchbase_lite_internal_core_impl_NativeC4Socket_retain(JNIEnv *env, jclass ignore, jlong jSocket) {
-    auto socket = (C4Socket *) jSocket;
-    c4socket_retain(socket);
 }
 
 /*

--- a/common/main/java/com/couchbase/lite/internal/core/C4Socket.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Socket.java
@@ -64,7 +64,6 @@ public final class C4Socket extends C4NativePeer implements SocketToCore {
     //-------------------------------------------------------------------------
 
     public interface NativeImpl {
-        void nRetain(long peer);
         long nFromNative(long token, String schema, String host, int port, String path, int framing);
         void nOpened(long peer);
         void nGotHTTPResponse(long peer, int httpStatus, @Nullable byte[] responseHeadersFleece);
@@ -72,6 +71,10 @@ public final class C4Socket extends C4NativePeer implements SocketToCore {
         void nReceived(long peer, byte[] data);
         void nCloseRequested(long peer, int status, @Nullable String message);
         void nClosed(long peer, int errorDomain, int errorCode, String message);
+
+        // this is instrumentation used only in tests
+        @VisibleForTesting
+        void nCreated(long peer);
     }
 
     @FunctionalInterface
@@ -282,16 +285,15 @@ public final class C4Socket extends C4NativePeer implements SocketToCore {
     // Constructors
     //-------------------------------------------------------------------------
 
-    // Unlike most ref-counted objects, the C C4Socket is not
-    // retained when it is created.  We have to retain it immediately
-    // whether we created it or were handed it.
     // Don't bind the socket to the peer, in the constructor, because that would
     // publish an incompletely constructed object.
     @VisibleForTesting
     C4Socket(@NonNull NativeImpl impl, long peer) {
         super(peer);
         this.impl = impl;
-        impl.nRetain(peer);
+
+        // this is instrumentation used only in tests
+        impl.nCreated(peer);
     }
 
     @Override

--- a/common/main/java/com/couchbase/lite/internal/core/impl/NativeC4Socket.java
+++ b/common/main/java/com/couchbase/lite/internal/core/impl/NativeC4Socket.java
@@ -25,14 +25,10 @@ import com.couchbase.lite.internal.core.C4Socket;
  * The C4Listener companion object
  */
 public final class NativeC4Socket implements C4Socket.NativeImpl {
-
     @Override
     public long nFromNative(long token, String schema, String host, int port, String path, int framing) {
         return fromNative(token, schema, host, port, path, framing);
     }
-
-    @Override
-    public void nRetain(long peer) { retain(peer); }
 
     @Override
     public void nOpened(long peer) { opened(peer); }
@@ -58,6 +54,10 @@ public final class NativeC4Socket implements C4Socket.NativeImpl {
         closed(peer, errorDomain, errorCode, message);
     }
 
+    // This method is only used by mocks in testing
+    @Override
+    public void nCreated(long ignore) { }
+
 
     //-------------------------------------------------------------------------
     // Native methods
@@ -74,8 +74,6 @@ public final class NativeC4Socket implements C4Socket.NativeImpl {
         int port,
         String path,
         int framing);
-
-    private static native void retain(long peer);
 
     @GuardedBy("socLock")
     private static native void opened(long peer);

--- a/common/test/java/com/couchbase/lite/internal/core/C4SocketTest.kt
+++ b/common/test/java/com/couchbase/lite/internal/core/C4SocketTest.kt
@@ -57,7 +57,7 @@ open class MockImpl : C4Socket.NativeImpl {
         framing: Int
     ) = C4BaseTest.MOCK_PEER
 
-    override fun nRetain(peer: Long) {
+    override fun nCreated(peer: Long) {
         Assert.assertEquals(0L, this.peer)
         this.peer = peer
         verifyPeer(peer)
@@ -245,6 +245,7 @@ class C4SocketTest : BaseTest() {
     @Test
     fun testSocketAckOpenToCore() {
         val impl = object : MockImpl() {
+
             var peer: Long? = null
             var status: Int? = null
             var headers: ByteArray? = null

--- a/common/test/java/com/couchbase/lite/logging/LogTest.kt
+++ b/common/test/java/com/couchbase/lite/logging/LogTest.kt
@@ -564,6 +564,7 @@ class LogTest : BaseDbTest() {
     // log from the LiteCore callback thread.  A an attempt to log from some other thread
     // during the callback, will be blocked until the callback returns but cannot, directly,
     // deadlock.
+    @Ignore("CBL-6787 still not fixed in LiteCore")
     @Test
     fun testRecursiveLogging() {
         val logSinks = assertNonNull(LogSinksImpl.getLogSinks())

--- a/common/test/java/com/couchbase/lite/mock/ReplicatorMocks.kt
+++ b/common/test/java/com/couchbase/lite/mock/ReplicatorMocks.kt
@@ -23,7 +23,7 @@ import com.couchbase.lite.internal.core.C4Socket
 import com.couchbase.lite.internal.fleece.FLSliceResult
 
 open class MockNativeSocket : C4Socket.NativeImpl {
-    override fun nRetain(peer: Long) = Unit
+    override fun nCreated(peer: Long) = Unit
     override fun nFromNative(
         token: Long,
         schema: String?,


### PR DESCRIPTION
I don't think this actually affect anything.  None the less I think it is a workwhile improvement.

The `nCreate` method is new, but is used only in testing so that the tests can verify the creation of the socket.
There is no corresponding native method.

c4socket_retain is now called, in the JNI, immediately upon receipt of the socket from LiteCore.  I believe I have checked all of the paths and I believe they all end in a call to `closed` which calls c4socket_release.