### PR TITLE
Fix null deference in getPeerInfo method

### DIFF
--- a/common/main/cpp/native_c4multipeerreplicator.cc
+++ b/common/main/cpp/native_c4multipeerreplicator.cc
@@ -669,6 +669,9 @@ JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator_g
     memcpy(peerId.bytes, peerIdSlice.buf, sizeof(peerId.bytes));
 
     C4PeerInfo *info = c4peersync_getPeerInfo((C4PeerSync *) peer, peerId);
+    if(info == nullptr) {
+        return nullptr;
+    }
 
     C4SliceResult rawCertChain = c4cert_copyChainData(info->certificate);
     jbyteArray certChain = toJByteArray(env, rawCertChain);


### PR DESCRIPTION
The c4peersync_getPeerInfo method will return null for an unknown peer.  I noticed a crash with the following trace:

```
#00 pc 00000000001d4a5c  /data/app/~~qmcEhVEnDkSR-95aAW4d3w==/com.couchbase.lite.android.mobiletest-54Ma2ww7zK7jRXqZD1D5uQ==/base.apk!libLiteCore.so (offset 0x868000) (BuildId: 9315f8e045c5a84a2c48171af8f0a5f1de7c6334)
#01 pc 00000000001d33ac  /data/app/~~qmcEhVEnDkSR-95aAW4d3w==/com.couchbase.lite.android.mobiletest-54Ma2ww7zK7jRXqZD1D5uQ==/base.apk!libLiteCore.so (offset 0x868000) (c4cert_copyChainData+20) (BuildId: 9315f8e045c5a84a2c48171af8f0a5f1de7c6334)
#02 pc 000000000001b288  /data/app/~~qmcEhVEnDkSR-95aAW4d3w==/com.couchbase.lite.android.mobiletest-54Ma2ww7zK7jRXqZD1D5uQ==/base.apk!libLiteCoreJNI.so (offset 0xc000) (Java_com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator_getPeerInfo+112) (BuildId: 21bb3bb08e1d362a7f6848bbf083032e78d0de9d)
```

So I'm pretty sure that what happened is that info was null in the following:  `c4cert_copyChainData(info->certificate)`