### PR TITLE
Add the JNI method to create a CA signed certificate

### DIFF
--- a/common/main/cpp/com_couchbase_lite_internal_core_impl_NativeC4KeyPair.h
+++ b/common/main/cpp/com_couchbase_lite_internal_core_impl_NativeC4KeyPair.h
@@ -19,6 +19,15 @@ JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4KeyPair_generateSelfS
 
 /*
  * Class:     com_couchbase_lite_internal_core_impl_NativeC4KeyPair
+ * Method:    generateSelfSignedCertificate
+ * Signature: (JBI[B[B[[Ljava/lang/String;BJ)[B
+ */
+JNIEXPORT jbyteArray
+JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4KeyPair_generateCACertificate
+        (JNIEnv *, jclass, jlong, jbyteArray, jbyteArray, jobjectArray, jbyte, jlong);
+
+/*
+ * Class:     com_couchbase_lite_internal_core_impl_NativeC4KeyPair
  * Method:    fromExternal
  * Signature: (BIJ)J
  */


### PR DESCRIPTION
This is labeled as insecure because that's exactly what it is.  The CA key is right there in the function call, so the user will need a really good reason if they are going to use it in production, but it's useful for testing and for environments that are secured by other means.

This method is very similar to the self signed generate method, so I refactored it into another common method that will vary based on if caKey and caCertificate are both non null or not.  If they are both non null, they get passed to signRequest instead of the subject key and null.

The result will be a certificate that is signed by an Android key store key and issued by the provided CA.