### PR TITLE
Made ReplicatorConfiguration consistent with MultipeerReplicatorConfiguration

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractReplicatorConfiguration.java
+++ b/common/main/java/com/couchbase/lite/AbstractReplicatorConfiguration.java
@@ -268,7 +268,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
      * @param config     its configuration
      * @return this
      *
-     * @deprecated Use ReplicatorConfiguration(java.util.Collection, Endpoint)} instead.
+     * @deprecated Use ReplicatorConfiguration(java.util.Collection&lt;CollectionConfiguration&gt;, Endpoint) instead.
      */
     @Deprecated
     @NonNull
@@ -290,7 +290,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
      * @param config      the configuration to be applied to all of the collections
      * @return this
      *
-     * @deprecated Use ReplicatorConfiguration(java.util.Collection, Endpoint)} instead.
+     * @deprecated Use ReplicatorConfiguration(java.util.Collection&lt;CollectionConfiguration&gt;, Endpoint) instead.
      */
     @Deprecated
     @NonNull
@@ -309,7 +309,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
      * @param collection the collection to be removed
      * @return this
      *
-     * @deprecated Use ReplicatorConfiguration(java.util.Collection, Endpoint)} instead.
+     * @deprecated Use ReplicatorConfiguration(java.util.Collection&lt;CollectionConfiguration&gt;, Endpoint) instead.
      */
     @Deprecated
     @NonNull
@@ -903,8 +903,10 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
     @SuppressFBWarnings(
         {"NP_NULL_ON_SOME_PATH", "NP_LOAD_OF_KNOWN_NULL_VALUE", "RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE"})
     private void addCollectionConfig(@NonNull Collection collection, @NonNull CollectionConfiguration config) {
-        Preconditions.assertThat(config.getCollection() == null,
-                "CollectionConfiguration created with a Collection is not allowed.");
+        Preconditions.assertThat(
+                config.getCollection() == null || config.getCollection() == collection,
+                "CollectionConfiguration collection must be null or match the given collection."
+        );
         final Database db = Preconditions.assertNotNull(collection, "collection").getDatabase();
         if (database == null) { database = db; }
         else {

--- a/common/main/java/com/couchbase/lite/CollectionConfiguration.java
+++ b/common/main/java/com/couchbase/lite/CollectionConfiguration.java
@@ -47,7 +47,7 @@ public class CollectionConfiguration {
      * Creates a configuration instance.
      *
      * @deprecated This constructor is deprecated. Use {@link #CollectionConfiguration(Collection)}
-     * and setter methods to configure channels, filters, and a cusom conflict resolver.
+     * and setter methods to configure channels, filters, and a custom conflict resolver.
      */
     @Deprecated
     public CollectionConfiguration() { }
@@ -56,7 +56,7 @@ public class CollectionConfiguration {
      * Creates a configuration instance.
      *
      * @deprecated This constructor is deprecated. Use {@link #CollectionConfiguration(Collection)}
-     * and setter methods to configure channels, filters, and a cusom conflict resolver.
+     * and setter methods to configure channels, filters, and a custom conflict resolver.
      *
      * @param channels           The list of channels to pull from Sync Gateway.
      * @param documentIDs        The list of document IDs to filter replication.

--- a/common/main/java/com/couchbase/lite/internal/logging/LogSinksImpl.java
+++ b/common/main/java/com/couchbase/lite/internal/logging/LogSinksImpl.java
@@ -205,6 +205,7 @@ public final class LogSinksImpl implements LogSinks {
     public BaseLogSink getCustom() { return customLogSink; }
 
     @Override
+    @SuppressWarnings("PMD.CloseResource")
     public void setCustom(@Nullable BaseLogSink newSink) {
         forbidNewAndLegacyLogging(newSink);
         customLogSink = newSink;

--- a/common/test/java/com/couchbase/lite/BaseReplicatorTest.kt
+++ b/common/test/java/com/couchbase/lite/BaseReplicatorTest.kt
@@ -136,13 +136,14 @@ abstract class BaseReplicatorTest : BaseDbTest() {
     }
 
     protected fun makeCollectionConfig(
+        collection: Collection = testCollection,
         channels: List<String>? = null,
         docIds: List<String>? = null,
         pullFilter: ReplicationFilter? = null,
         pushFilter: ReplicationFilter? = null,
         resolver: ConflictResolver? = null
     ): CollectionConfiguration {
-        val config = CollectionConfiguration()
+        val config = CollectionConfiguration(collection)
         channels?.let { config.channels = it }
         docIds?.let { config.documentIDs = it }
         pullFilter?.let { config.pullFilter = it }
@@ -153,33 +154,8 @@ abstract class BaseReplicatorTest : BaseDbTest() {
 
     protected fun makeSimpleReplConfig(
         target: Endpoint = mockURLEndpoint,
-        source: kotlin.collections.Collection<Collection> = setOf(testCollection),
-        srcConfig: CollectionConfiguration? = null,
-        type: ReplicatorType? = null,
-        continuous: Boolean? = null,
-        authenticator: Authenticator? = null,
-        headers: Map<String, String>? = null,
-        pinnedServerCert: Certificate? = null,
-        maxAttempts: Int = 1,
-        maxAttemptWaitTime: Int = 1,
-        autoPurge: Boolean = true
-    ) = makeReplConfig(
-        target,
-        mapOf(source to srcConfig),
-        type,
-        continuous,
-        authenticator,
-        headers,
-        pinnedServerCert,
-        maxAttempts,
-        maxAttemptWaitTime,
-        autoPurge
-    )
-
-    protected fun makeReplConfig(
-        target: Endpoint = mockURLEndpoint,
-        source: Map<out kotlin.collections.Collection<Collection>, CollectionConfiguration?> =
-            mapOf(setOf(testCollection) to null),
+        source: kotlin.collections.Collection<CollectionConfiguration> =
+            CollectionConfiguration.fromCollections(setOf(testCollection)),
         type: ReplicatorType? = null,
         continuous: Boolean? = null,
         authenticator: Authenticator? = null,
@@ -189,9 +165,7 @@ abstract class BaseReplicatorTest : BaseDbTest() {
         maxAttemptWaitTime: Int = 1,
         autoPurge: Boolean = true
     ): ReplicatorConfiguration {
-        val config = ReplicatorConfiguration(target)
-
-        source.forEach { config.addCollections(it.key, it.value) }
+        val config = ReplicatorConfiguration(source, target)
         type?.let { config.type = it }
         continuous?.let { config.isContinuous = it }
         authenticator?.let { config.setAuthenticator(it) }

--- a/common/test/java/com/couchbase/lite/ConflictResolutionTest.kt
+++ b/common/test/java/com/couchbase/lite/ConflictResolutionTest.kt
@@ -380,8 +380,9 @@ class ConflictResolutionTest : BaseReplicatorTest() {
         // An instrumented replicator: it counts documentEnded calls.
         val conflictedCount = AtomicInteger()
         val unconflictedCount = AtomicInteger()
-        val repl: AbstractReplicator = object :
-            AbstractReplicator(ReplicatorConfiguration(mockURLEndpoint).addCollection(testCollection, null)) {
+
+        val configs: Set<CollectionConfiguration> = CollectionConfiguration.fromCollections(setOf(testCollection))
+        val repl: AbstractReplicator = object : AbstractReplicator(ReplicatorConfiguration(configs, mockURLEndpoint)) {
             override fun createReplicatorForTarget(target: Endpoint): C4Replicator = TODO("Not implemented")
             override fun handleOffline(state: ReplicatorActivityLevel, online: Boolean) = TODO("Not implemented")
 

--- a/common/test/java/com/couchbase/lite/ReplicatorConfigurationTest.kt
+++ b/common/test/java/com/couchbase/lite/ReplicatorConfigurationTest.kt
@@ -61,8 +61,8 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     // Can't test the EE parameter (self-signed only) here
     @Test
     fun testCreateConfigDefaults() {
-        val config = ReplicatorConfiguration(mockURLEndpoint)
-        config.addCollection(testCollection, null)
+        val collectionConfigs = CollectionConfiguration.fromCollections(setOf(testCollection))
+        val config = ReplicatorConfiguration(collectionConfigs, mockURLEndpoint)
 
         val immutableConfig = ImmutableReplicatorConfiguration(config)
         Assert.assertEquals(Defaults.Replicator.TYPE, immutableConfig.type)
@@ -91,8 +91,8 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     // Can't test the EE parameter (self-signed only) here
     @Test
     fun testCreateConfigCompatibility() {
-        val config = ReplicatorConfiguration(mockURLEndpoint)
-        config.addCollection(testCollection, null)
+        val collectionConfigs = CollectionConfiguration.fromCollections(setOf(testCollection))
+        val config = ReplicatorConfiguration(collectionConfigs, mockURLEndpoint)
 
         config.heartbeat = 6
         config.maxAttempts = 6
@@ -390,6 +390,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
 
     // 8.13.6a Create a config object with ReplicatorConfiguration.init(endpoint: endpoint).
     // Access collections property and an empty collection list should be returned.\
+    @Suppress("DEPRECATION")
     @Test
     fun testCreateConfigWithEndpointOnly1() {
         val replConfig1 = ReplicatorConfiguration(mockURLEndpoint)
@@ -423,6 +424,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     // the returned configs of both collections. The returned configs should be
     // different instances. The conflict resolver and filters of both configs should be
     // all NULL.
+    @Suppress("DEPRECATION")
     @Test
     fun testAddCollectionsWithoutCollectionConfig() {
         val collectionA = testDatabase.createCollection("colA", "scopeA")
@@ -467,6 +469,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     // returned configs of both collections should be different instances. The conflict
     // resolver and filters of both configs should be the same as what was specified
     // when calling addCollections().
+    @Suppress("DEPRECATION")
     @Test
     fun testAddCollectionsWithCollectionConfig() {
         val collectionA = testDatabase.createCollection("colA", "scopeA")
@@ -517,6 +520,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     // returned config of the colA should contain all NULL values. The returned config
     // of the colB should contain the values according to the config used when adding
     // the collection.
+    @Suppress("DEPRECATION")
     @Test
     fun testAddCollection() {
         val collectionA = testDatabase.createCollection("colA", "scopeA")
@@ -579,6 +583,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     // Use getCollectionConfig() to get the collection config for colA and colB. Check
     // the returned configs of both collections and ensure that both configs contain
     // the updated values correctly.
+    @Suppress("DEPRECATION")
     @Test
     fun testUpdateCollectionConfigA() {
         val collectionA = testDatabase.createCollection("colA", "scopeA")
@@ -722,6 +727,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     //
     // Use getCollectionConfig() to get the collection config for colA and colB. The
     // returned config for the colB should be NULL.
+    @Suppress("DEPRECATION")
     @Test
     fun testRemoveCollection() {
         val collectionA = testDatabase.createCollection("colA", "scopeA")
@@ -764,6 +770,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     //
     // Use addCollection() to add colB. An invalid argument exception should be thrown
     // as the collections are from different database instances.
+    @Suppress("DEPRECATION")
     @Test
     fun testAddCollectionsFromDifferentDatabaseInstancesA() {
         val collectionA = testDatabase.createCollection("colA", "scopeA")
@@ -789,6 +796,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     //
     // Use addCollection() to add colB. An invalid argument exception should be thrown
     // as the collections are from different database instances.
+    @Suppress("DEPRECATION")
     @Test
     fun testAddCollectionsFromDifferentDatabaseInstancesB() {
         val collectionA = testDatabase.createCollection("colA", "scopeA")
@@ -814,6 +822,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     // Use addCollection() to add colA. Ensure that the colA has been added correctly.
     //
     // Use addCollection() to add colB. An invalid argument exception should be thrown as an added collection has been deleted.
+    @Suppress("DEPRECATION")
     @Test
     fun testAddDeletedCollectionsA() {
         val collectionA = testDatabase.createCollection("colA", "scopeA")
@@ -840,6 +849,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     // Use addCollection() to add colA. Ensure that the colA has been added correctly.
     //
     // Use addCollection() to add colB. An invalid argument exception should be thrown as an added collection has been deleted.
+    @Suppress("DEPRECATION")
     @Test
     fun testAddDeletedCollectionsB() {
         val collectionA = testDatabase.createCollection("colA", "scopeA")
@@ -870,6 +880,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     // Use addCollection() to add colA. Ensure that the colA has been added correctly.
     //
     // Use addCollection() to add colB. An invalid argument exception should be thrown as an added collection has been deleted.
+    @Suppress("DEPRECATION")
     @Test
     fun testAddDeletedCollectionsC() {
         testDatabase.createCollection("colA", "scopeA")
@@ -885,6 +896,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     // CBL-3736
     // Attempting to configure a replicator with no collection
     // should throw an illegal argument exception.
+    @Suppress("DEPRECATION")
     @Test
     fun testCreateReplicatorWithNoCollections() {
         Assert.assertThrows(IllegalArgumentException::class.java) { Replicator(ReplicatorConfiguration(mockURLEndpoint)) }


### PR DESCRIPTION
* CBL-7237 : Deprecated ReplicatorConfiguration API for managing collection configurations

* CBL-7239 : Deprecated CollectionConfiguration's constructors without collection and added Set<CollectionConfiguration> getCollectionConfigs().

* In AbstractReplicatorConfiguration's base constructor, extracted from the first collection configurations when the configurations are not null.

* In AbstractReplicatorConfiguration's addCollection() and addCollections() method, asserted that the CollectionConfiguration doesn’t contain the collection object. Basically, the specified CollectionConfiguration object must be created by using the old API.

* In AbstractReplicatorConfiguration, suppress PMD.ExcessivePublicCount, otherwise PMD validation will fail.

* Refactors utility functions in base test class for creating replicator configuration to use the new API.
