### PR TITLE
CBL-7354 : Updated Kotlinx's delay to Thread.sleep

### DIFF
--- a/common/test/java/com/couchbase/lite/logging/LogTest.kt
+++ b/common/test/java/com/couchbase/lite/logging/LogTest.kt
@@ -15,7 +15,6 @@ import com.couchbase.lite.internal.core.CBLVersion
 import com.couchbase.lite.internal.logging.Log
 import com.couchbase.lite.internal.logging.LogSinksImpl
 import com.couchbase.lite.internal.logging.writeToLog
-import kotlinx.coroutines.*
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -142,16 +141,14 @@ class LogTest : BaseDbTest() {
         // worst case is when warning and verbose are used as they have more characters to write in log file(plain text)
         // worst case header size is 56 bytes with 192 bytes of info like serial no, path etc
         // 1024 - 56 - 192 = 776 ~ 15 * 59
-         runBlocking {
-            repeat(15) {
-                delay(1)    // delay added to prevent same filename
-                c4Log.logToCore(LogDomain.DATABASE, LogLevel.DEBUG, message)
-                c4Log.logToCore(LogDomain.DATABASE, LogLevel.VERBOSE, message)
-                c4Log.logToCore(LogDomain.DATABASE, LogLevel.INFO, message)
-                c4Log.logToCore(LogDomain.DATABASE, LogLevel.WARNING, message)
-                c4Log.logToCore(LogDomain.DATABASE, LogLevel.ERROR, message)
-            }
-         }
+        repeat(15) {
+            Thread.sleep(1)   // delay added to prevent same filename
+            c4Log.logToCore(LogDomain.DATABASE, LogLevel.DEBUG, message)
+            c4Log.logToCore(LogDomain.DATABASE, LogLevel.VERBOSE, message)
+            c4Log.logToCore(LogDomain.DATABASE, LogLevel.INFO, message)
+            c4Log.logToCore(LogDomain.DATABASE, LogLevel.WARNING, message)
+            c4Log.logToCore(LogDomain.DATABASE, LogLevel.ERROR, message)
+        }
 
         // each level should have rolled over once
         // and there may have been a few extra things logged as well.


### PR DESCRIPTION
Updated Kotlinx's delay to thread.sleep as import failure while mobile jenkins build