### PR TITLE
CBL-7415 : Update Database APIs to Return or Throw NotOpen Error for Closed Database Cases

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/common/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -290,7 +290,7 @@ abstract class AbstractDatabase extends BaseDatabase
 
     public boolean performMaintenance(MaintenanceType type) throws CouchbaseLiteException {
         synchronized (getDbLock()) {
-            try { return getOpenC4DbLocked().performMaintenance(type); }
+            try { return getC4DbOrThrowLocked().performMaintenance(type); }
             catch (LiteCoreException e) { throw CouchbaseLiteException.convertException(e); }
         }
     }
@@ -518,7 +518,7 @@ abstract class AbstractDatabase extends BaseDatabase
 
         boolean commit = false;
         synchronized (getDbLock()) {
-            final C4Database db = getOpenC4DbLocked();
+            final C4Database db = getC4DbOrThrowLocked();
 
             try {
                 db.beginTransaction();
@@ -545,9 +545,9 @@ abstract class AbstractDatabase extends BaseDatabase
      * @return the Query object
      */
     @NonNull
-    public Query createQuery(@NonNull String query) {
+    public Query createQuery(@NonNull String query) throws CouchbaseLiteException {
         synchronized (getDbLock()) {
-            assertOpenUnchecked();
+            assertOpenChecked();
             return new N1qlQuery(this, query);
         }
     }
@@ -1224,7 +1224,7 @@ abstract class AbstractDatabase extends BaseDatabase
             Log.d(DOMAIN, "Shutdown (%b, %b)", failIfClosed, open);
             if (!(failIfClosed || open)) { return; }
 
-            c4Db = getOpenC4DbLocked();
+            c4Db = getC4DbOrThrowLocked();
             setC4DatabaseLocked(null);
             // mustBeOpen will now fail, which should prevent any new processes from being registered.
 

--- a/common/main/java/com/couchbase/lite/QueryBuilder.java
+++ b/common/main/java/com/couchbase/lite/QueryBuilder.java
@@ -60,7 +60,7 @@ public final class QueryBuilder {
      * @return database The database against which the query will be run.
      */
     @NonNull
-    public static Query createQuery(@NonNull String query, @NonNull Database database) {
+    public static Query createQuery(@NonNull String query, @NonNull Database database) throws CouchbaseLiteException {
         return database.createQuery(query);
     }
 }

--- a/common/test/java/com/couchbase/lite/DatabaseTest.kt
+++ b/common/test/java/com/couchbase/lite/DatabaseTest.kt
@@ -596,7 +596,7 @@ class DatabaseTest : BaseDbTest() {
         Assert.assertTrue(testDatabase.isOpen)
         testDatabase.close()
         Assert.assertFalse(testDatabase.isOpen)
-        Assert.assertThrows(CouchbaseLiteError::class.java) {
+        Assert.assertThrows(CouchbaseLiteException::class.java) {
             testDatabase.inBatch<RuntimeException> { }
         }
     }
@@ -616,7 +616,7 @@ class DatabaseTest : BaseDbTest() {
         Assert.assertTrue(testDatabase.isOpen)
         testDatabase.close()
         Assert.assertFalse(testDatabase.isOpen)
-        Assert.assertThrows(CouchbaseLiteError::class.java) { testDatabase.delete() }
+        Assert.assertThrows(CouchbaseLiteException::class.java) { testDatabase.delete() }
     }
 
     //---------------------------------------------
@@ -640,7 +640,7 @@ class DatabaseTest : BaseDbTest() {
         Assert.assertFalse(path.exists())
 
         // second delete should fail
-        Assert.assertThrows(CouchbaseLiteError::class.java) { testDatabase.delete() }
+        Assert.assertThrows(CouchbaseLiteException::class.java) { testDatabase.delete() }
     }
 
     @Test
@@ -718,7 +718,7 @@ class DatabaseTest : BaseDbTest() {
         Assert.assertTrue(path.exists())
         testDatabase.delete()
         Assert.assertFalse(path.exists())
-        Assert.assertThrows(CouchbaseLiteError::class.java) {
+        Assert.assertThrows(CouchbaseLiteException::class.java) {
             testDatabase.inBatch<RuntimeException> { }
         }
     }

--- a/common/test/java/com/couchbase/lite/QueryTest.java
+++ b/common/test/java/com/couchbase/lite/QueryTest.java
@@ -3069,7 +3069,7 @@ public class QueryTest extends BaseQueryTest {
     }
 
     @Test
-    public void testN1QLSelect() {
+    public void testN1QLSelect() throws CouchbaseLiteException {
         loadDocuments(100);
 
         Query query = getTestDatabase().createQuery(
@@ -3105,7 +3105,7 @@ public class QueryTest extends BaseQueryTest {
     }
 
     @Test
-    public void testN1QLSelectStarFromCollection() {
+    public void testN1QLSelectStarFromCollection() throws CouchbaseLiteException {
         loadDocuments(100);
 
         verifyQuery(


### PR DESCRIPTION
- Updated getOpenC4DbLocked() to getC4DbOrThrowLocked(), which throws CouchbaseLiteException with NOT_OPEN code in performanceMaintenance method
-  Updated assertOpenUnchecked() to assertOpenChecked(), which throws CouchbaseLiteException with NOT_OPEN code in performanceMaintenance method
-  Updated createQuery to throw exception
-  Updated testcases which were throwing CouchbaseLiteError when db is not opened to CouchbaseLiteException