### PR TITLE
CBL-7412 : Couchbase Lite uses discontinued convenience method from okhttp

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractReplicatorConfiguration.java
+++ b/common/main/java/com/couchbase/lite/AbstractReplicatorConfiguration.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import okhttp3.internal.Util;
 
 import com.couchbase.lite.internal.BaseReplicatorConfiguration;
 import com.couchbase.lite.internal.ImmutableReplicatorConfiguration;
@@ -71,9 +70,17 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
     // which is not entirely kosher
     @SuppressWarnings("PMD.PreserveStackTrace")
     private static int verifyHeartbeat(int heartbeat) {
-        try { Util.checkDuration("heartbeat", heartbeat, TimeUnit.SECONDS); }
+        try { checkDuration("heartbeat", heartbeat); }
         catch (IllegalStateException e) { throw new IllegalArgumentException(e.getMessage()); }
         return heartbeat;
+    }
+
+    private static void checkDuration(String name, long duration) {
+        Preconditions.assertNotNegative(duration, name);
+        final long millis = TimeUnit.SECONDS.toMillis(duration);
+        if (millis > Integer.MAX_VALUE || (millis == 0L && duration > 0L)) {
+            throw new IllegalArgumentException(name + (millis > Integer.MAX_VALUE ? " too large." : " too small."));
+        }
     }
 
     @Nullable


### PR DESCRIPTION
- Removed the import and usage of check duration from internal api of okhttp
- Used method for same checkDuration Logic