### PR TITLE
CBL-7418 : Update getCollections() Deprecation Message

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractReplicatorConfiguration.java
+++ b/common/main/java/com/couchbase/lite/AbstractReplicatorConfiguration.java
@@ -647,6 +647,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
      * Return the list of collections in the replicator configuration
      *
      * @deprecated Use getCollectionConfigs() instead.
+     * This method will return {@code Set<CollectionConfiguration>} in the next major release.
      */
     @Deprecated
     @NonNull
@@ -656,6 +657,7 @@ public abstract class AbstractReplicatorConfiguration extends BaseReplicatorConf
      * Returns a copy of the collection configurations associated with this replicator configuration.
      *
      * @return a set of {@link CollectionConfiguration} objects.
+     * @apiNote This method will be renamed to {@code getCollections()} in the next major release.
      */
     @NonNull
     public final Set<CollectionConfiguration> getCollectionConfigs() {


### PR DESCRIPTION
* Update ReplicatorConfiguration#getCollections() deprecation message to state it will return Set<CollectionConfiguration> instead of Set<Collection> in the next major release.

* Related to the deprecation message update, add an API note to getCollectionConfigs() indicating it will be renamed to getCollections() in the next major release.