### PR TITLE
CBL-7407: Removing deprecated build failing tests

### DIFF
--- a/common/test/kotlin/com/couchbase/lite/CommonConfigFactoryTest.kt
+++ b/common/test/kotlin/com/couchbase/lite/CommonConfigFactoryTest.kt
@@ -79,27 +79,6 @@ class CommonConfigFactoryTest : BaseTest() {
     }
 
     @Test
-    fun testLogFileConfigurationFactory() {
-        val config = LogFileConfigurationFactory.newConfig(directory = CONFIG_FACTORY_TEST_STRING, maxSize = 4096L)
-        Assert.assertEquals(CONFIG_FACTORY_TEST_STRING, config.directory)
-        Assert.assertEquals(4096L, config.maxSize)
-    }
-
-    @Test
-    fun testLogFileConfigurationFactoryNullDir() {
-        Assert.assertThrows(IllegalArgumentException::class.java) { LogFileConfigurationFactory.newConfig() }
-    }
-
-    @Test
-    fun testLogFileConfigurationFactoryCopy() {
-        val config1 = LogFileConfigurationFactory.newConfig(directory = CONFIG_FACTORY_TEST_STRING, maxSize = 4096L)
-        val config2 = config1.newConfig(maxSize = 1024L)
-        Assert.assertNotEquals(config1, config2)
-        Assert.assertEquals(CONFIG_FACTORY_TEST_STRING, config2.directory)
-        Assert.assertEquals(1024L, config2.maxSize)
-    }
-
-    @Test
     fun testFileLogSinkFactory() {
         val dir = getScratchDirectoryPath(getUniqueName("sink-dir"))
         FileLogSinkFactory.install(directory = dir, maxFileSize = 4096L)

--- a/common/test/kotlin/com/couchbase/lite/FlowTest.kt
+++ b/common/test/kotlin/com/couchbase/lite/FlowTest.kt
@@ -30,56 +30,6 @@ import java.util.concurrent.TimeUnit
 
 @Suppress("BlockingMethodInNonBlockingContext")
 class FlowTest : BaseReplicatorTest() {
-    @Suppress("DEPRECATION")
-    @Test
-    fun testDatabaseChangeFlow() {
-        val docIds = mutableListOf<String>()
-
-        runBlocking {
-            val latch = CountDownLatch(1)
-
-            val collector = launch(Dispatchers.Default) {
-                testDatabase.databaseChangeFlow(testSerialExecutor)
-                    .map {
-                        Assert.assertEquals("change on wrong db", testDatabase, it.database)
-                        it.documentIDs
-                    }
-                    .onEach { ids ->
-                        docIds.addAll(ids)
-                        if (docIds.size >= 10) {
-                            latch.countDown()
-                        }
-                    }
-                    .catch {
-                        latch.countDown()
-                        throw it
-                    }
-                    .collect()
-            }
-
-            launch(Dispatchers.Default) {
-                // Hate this: wait until the collector starts
-                delay(20L)
-
-                // make 10 db changes
-                for (i in 0..9) {
-                    val doc = MutableDocument("doc-${i}")
-                    doc.setValue("type", "demo")
-                    saveDocInCollection(doc, testDatabase.defaultCollection)
-                }
-            }
-
-            Assert.assertTrue("Timeout", latch.await(1, TimeUnit.SECONDS))
-            collector.cancel()
-        }
-
-        Assert.assertEquals(10, docIds.size)
-        for (i in 0..9) {
-            val id = "doc-${i}"
-            Assert.assertTrue("missing ${id}", docIds.contains(id))
-        }
-    }
-
      @Test
     fun testDocumentChangeFlowOnSave() {
         val changes = mutableListOf<DocumentChange>()


### PR DESCRIPTION
- Removed the test cases which were using deprecated tests