### PR TITLE
CBL-7454 : URLEndpointListenerTests Failed on Java

### DIFF
--- a/common/main/cpp/native_c4listener.cc
+++ b/common/main/cpp/native_c4listener.cc
@@ -712,7 +712,10 @@ static jbyteArray generateCertificate(
 
     C4Cert *cert = c4cert_signRequest(csr, &issuerParams, issuerKey, issuerCert, &error);
     DEFER {
-        c4keypair_release(issuerKey);
+        // Release issuerKey only if it's not the `c4KeyPair` passed to this function.
+        if (issuerKey != keys) {
+            c4keypair_release(issuerKey);
+        }
         c4cert_release(issuerCert);
         c4cert_release(cert);
     };

--- a/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
+++ b/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
@@ -752,8 +752,8 @@ public abstract class AbstractCBLWebSocket implements SocketFromCore, SocketFrom
         // TrustManager for server cert verification:
         final CBLTrustManager trustManager = new CBLTrustManager(
             pinnedServerCert,
-            acceptOnlySelfSignedServerCert,
             acceptAllCerts,
+            acceptOnlySelfSignedServerCert,
             new AbstractCBLTrustManager.ServerCertsListener() {
                 @Override
                 public void certsPresented(@NonNull List<Certificate> certs) {


### PR DESCRIPTION
-  Fix crash when generating a self-signed certificate without an issuer. In native_c4listener::generateCertificate(), do not release issuerKey if it is the same C4KeyPair passed from Java (owned and managed by the Java side).

- Fix acceptOnlySelfSignedServerCert not working due to incorrect parameter order passed to the CBLTrustManager constructor.