### PR TITLE
CBL-7494 : allCerts is accepted when pinnedcerts is used

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
+++ b/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
@@ -752,8 +752,8 @@ public abstract class AbstractCBLWebSocket implements SocketFromCore, SocketFrom
         // TrustManager for server cert verification:
         final CBLTrustManager trustManager = new CBLTrustManager(
             pinnedServerCert,
-            acceptAllCerts,
             acceptOnlySelfSignedServerCert,
+            acceptAllCerts,
             new AbstractCBLTrustManager.ServerCertsListener() {
                 @Override
                 public void certsPresented(@NonNull List<Certificate> certs) {

--- a/java/main/java/com/couchbase/lite/internal/replicator/CBLTrustManager.java
+++ b/java/main/java/com/couchbase/lite/internal/replicator/CBLTrustManager.java
@@ -27,8 +27,8 @@ import java.security.cert.X509Certificate;
 public class CBLTrustManager extends AbstractCBLTrustManager {
     public CBLTrustManager(
         @Nullable X509Certificate pinnedServerCert,
-        boolean acceptAllCertificates, // ignore this and hardwire "false"
         boolean acceptOnlySelfSignedServerCertificate,
+        boolean acceptAllCertificates, // ignore this and hardwire "false"
         @NonNull ServerCertsListener serverCertsListener) {
         super(pinnedServerCert, acceptOnlySelfSignedServerCertificate, false, serverCertsListener);
     }


### PR DESCRIPTION
- Reverted the order of CBLTrustManager in AbstractCBLWebSocket 
- Updated Constructor CBLTrustManager for Java