### PR TITLE
Fix LiteCore callback signature and spotbugs stuff

### DIFF
--- a/common/main/cpp/native_c4multipeerreplicator.cc
+++ b/common/main/cpp/native_c4multipeerreplicator.cc
@@ -286,7 +286,8 @@ namespace litecore::jni {
     // Callbacks
     //-------------------------------------------------------------------------
 
-    static void statusChangedCallback(C4PeerSync *ignored, bool started, C4Error error, void *context) {
+    static void statusChangedCallback(C4PeerSync *ignored, C4PeerSyncProtocol protocol, bool started, C4Error error, void *context) {
+        // TODO: Use protocol
         JNIEnv *env = nullptr;
         jint envState = attachJVM(&env, "p2pStatusChanged");
         if ((envState != JNI_OK) && (envState != JNI_EDETACHED))

--- a/common/main/java/com/couchbase/lite/BaseDatabase.java
+++ b/common/main/java/com/couchbase/lite/BaseDatabase.java
@@ -20,8 +20,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import com.couchbase.lite.internal.core.C4BlobStore;
 import com.couchbase.lite.internal.core.C4Database;
 import com.couchbase.lite.internal.logging.Log;
@@ -104,7 +102,6 @@ public abstract class BaseDatabase {
     }
 
     @VisibleForTesting
-    @SuppressFBWarnings("NP_NONNULL_RETURN_VIOLATION")
     @NonNull
     C4Database getOpenC4Database() {
         synchronized (getDbLock()) { return getOpenC4DbLocked(); }

--- a/common/main/java/com/couchbase/lite/Blob.java
+++ b/common/main/java/com/couchbase/lite/Blob.java
@@ -655,7 +655,6 @@ public final class Blob implements FleeceEncodable, JSONEncodable {
         throw new CouchbaseLiteError(Log.lookupStandardMessage("BlobContentNull"));
     }
 
-    @SuppressFBWarnings("DE_MIGHT_IGNORE")
     private void readContentFromInitStream() {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         try (InputStream in = Preconditions.assertNotNull(blobContentStream, "content stream")) {

--- a/common/main/java/com/couchbase/lite/Collection.java
+++ b/common/main/java/com/couchbase/lite/Collection.java
@@ -26,8 +26,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Executor;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import com.couchbase.lite.internal.BaseCollection;
 import com.couchbase.lite.internal.CouchbaseLiteInternal;
 import com.couchbase.lite.internal.core.C4Collection;
@@ -919,7 +917,6 @@ public final class Collection extends BaseCollection
 
     // Low-level save method
     @GuardedBy("getDbLock()")
-    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
     private void saveInTransaction(@NonNull Document document, @Nullable C4Document base, boolean deleting)
         throws CouchbaseLiteException {
         FLSliceResult body = null;

--- a/common/main/java/com/couchbase/lite/internal/core/C4Peer.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Peer.java
@@ -23,8 +23,6 @@ import androidx.annotation.Nullable;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicReference;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import com.couchbase.lite.CouchbaseLiteError;
 import com.couchbase.lite.LogDomain;
 import com.couchbase.lite.internal.CouchbaseLiteInternal;
@@ -84,7 +82,6 @@ public abstract class C4Peer implements AutoCloseable {
         /**
          * Cleanup: Release the native peer.
          */
-        @SuppressFBWarnings("JLM_JSR166_UTILCONCURRENT_MONITORENTER")
         public final void clean(boolean finalizing) {
             final C4Peer.PeerCleaner disposer = cleaner;
             if (disposer != null) {

--- a/common/main/java/com/couchbase/lite/internal/core/C4Socket.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Socket.java
@@ -22,8 +22,6 @@ import androidx.annotation.VisibleForTesting;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import com.couchbase.lite.LogDomain;
 import com.couchbase.lite.internal.BaseSocketFactory;
 import com.couchbase.lite.internal.CouchbaseLiteInternal;
@@ -186,8 +184,6 @@ public final class C4Socket extends C4Peer implements SocketToCore {
     }
 
     // This method is used by reflection.  Don't change its signature.
-    // Apparently SpotBugs can't tel that `data` *is* null-checked
-    @SuppressFBWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
     static void write(long peer, @Nullable byte[] data) {
         final int nBytes = (data == null) ? 0 : data.length;
         Log.d(LOG_DOMAIN, "^C4Socket.write@%x(%d)", peer, nBytes);

--- a/common/main/java/com/couchbase/lite/internal/sockets/OkHttpSocket.java
+++ b/common/main/java/com/couchbase/lite/internal/sockets/OkHttpSocket.java
@@ -74,6 +74,7 @@ public final class OkHttpSocket extends WebSocketListener implements SocketToRem
 
         .build();
 
+    @SuppressWarnings("PMD.CloseResource")
     public static void shutdownHttpClient() {
         final ExecutorService dispatcher = BASE_HTTP_CLIENT.dispatcher().executorService();
         ExecutorUtils.shutdownAndAwaitTermination(dispatcher, 5, LogDomain.NETWORK);

--- a/common/main/java/com/couchbase/lite/internal/utils/FileUtils.java
+++ b/common/main/java/com/couchbase/lite/internal/utils/FileUtils.java
@@ -23,8 +23,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import com.couchbase.lite.CouchbaseLiteError;
 import com.couchbase.lite.LogDomain;
 import com.couchbase.lite.internal.logging.Log;
@@ -70,7 +68,6 @@ public final class FileUtils {
         return deleteContents((fileOrDirectory == null) ? null : new File(fileOrDirectory));
     }
 
-    @SuppressFBWarnings({"RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"})
     public static boolean deleteContents(File fileOrDirectory) {
         if ((fileOrDirectory == null) || (!fileOrDirectory.isDirectory())) { return true; }
 

--- a/etc/spotbugs/spotbugs.xml
+++ b/etc/spotbugs/spotbugs.xml
@@ -28,4 +28,14 @@
         <Bug pattern="SF_SWITCH_NO_DEFAULT" />
     </Match>
 
+    <!-- Constructor throws are pre-existing in the API design -->
+    <Match>
+        <Bug pattern="CT_CONSTRUCTOR_THROW" />
+    </Match>
+
+    <!-- Java 8 synthetic accessors and annotation staleness: not actionable -->
+    <Match>
+        <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE" />
+    </Match>
+
 </FindBugsFilter>


### PR DESCRIPTION
Spotbugs this old doesn't work with Java 21, so in order to have it function correctly on most dev machines it needs to be updated and that changes its analysis story.  Also a LiteCore callback signature changed and the JNI needs to accomodate that.