### PR TITLE
CBL-8080: Add JNI support for per-transport MultipeerReplicator status

### DIFF
--- a/common/main/cpp/com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator.h
+++ b/common/main/cpp/com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator.h
@@ -10,10 +10,10 @@ extern "C" {
 #endif
 
 /*
- * Class:     Java_com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator
+ * Class:     com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator
  * Method:    create
- * Signature: (JLjava/lang/String;J[BJ[Lcom.couchbase.lite.internal.core.MultipeerCollectionConfiguration;[B)J
-  */
+ * Signature: (JLjava/lang/String;IJ[BJ[Lcom/couchbase/lite/internal/MultipeerReplicationCollection;[B)J
+ */
 JNIEXPORT jlong
 JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator_create(
         JNIEnv *,
@@ -28,13 +28,12 @@ JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator_c
         jbyteArray);
 
 /*
- * Class:     Java_com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator
+ * Class:     com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator
  * Method:    start
  * Signature: (J)V
  */
 JNIEXPORT void
 JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator_start(JNIEnv *, jclass, jlong);
-
 
 /*
  * Class:     com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator
@@ -45,7 +44,7 @@ JNIEXPORT void
 JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator_stop(JNIEnv *, jclass, jlong);
 
 /*
- * Class:     Java_com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator
+ * Class:     com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator
  * Method:    free
  * Signature: (J)V
  */
@@ -65,8 +64,20 @@ JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator_g
 
 /*
  * Class:     com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator
- * Method:    stop
- * Signature: (J)B[[
+ * Method:    getStatus
+ * Signature: (JI)Lcom/couchbase/lite/internal/core/C4PeerSyncStatus;
+ */
+JNIEXPORT jobject
+JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator_getStatus(
+        JNIEnv *env,
+        jclass clazz,
+        jlong peer,
+        jint protocol);
+
+/*
+ * Class:     com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator
+ * Method:    getNeighborPeers
+ * Signature: (J)[[B
  */
 JNIEXPORT jobjectArray
 JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator_getNeighborPeers(
@@ -76,8 +87,8 @@ JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator_g
 
 /*
  * Class:     com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator
- * Method:    stop
- * Signature: (JI)V
+ * Method:    getPeerInfo
+ * Signature: (J[B)Lcom/couchbase/lite/PeerInfo;
  */
 JNIEXPORT jobject
 JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator_getPeerInfo(
@@ -88,8 +99,8 @@ JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator_g
 
 /*
  * Class:     com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator
- * Method:    stop
- * Signature: (J)V
+ * Method:    setProgressLevel
+ * Signature: (JI)V
  */
 JNIEXPORT void
 JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator_setProgressLevel(

--- a/common/main/cpp/native_c4multipeerreplicator.cc
+++ b/common/main/cpp/native_c4multipeerreplicator.cc
@@ -50,7 +50,7 @@ namespace litecore::jni {
     //-------------------------------------------------------------------------
 
     // C4MultipeerReplicator
-    static jclass cls_C4MultipeerReplicator;               // global reference
+    static jclass cls_C4MultipeerReplicator;                // global reference
     static jmethodID m_C4MultipeerReplicator_createPeerInfo;
     static jmethodID m_C4MultipeerReplicator_onSyncStatusChanged;
     static jmethodID m_C4MultipeerReplicator_onAuthenticate;
@@ -58,15 +58,19 @@ namespace litecore::jni {
     static jmethodID m_C4MultipeerReplicator_onReplicatorStatusChanged;
     static jmethodID m_C4MultipeerReplicator_onDocumentEnded;
 
+    // C4PeerSyncStatus
+    static jclass cls_C4PeerSyncStatus;                     // global reference
+    static jmethodID m_C4PeerSyncStatus_init;
+
     // ReplicationCollection
-    static jclass cls_MultipeerReplColl;                             // global reference
+    static jclass cls_MultipeerReplColl;                    // global reference
     static jfieldID f_MultipeerReplColl_token;
     static jfieldID f_MultipeerReplColl_scope;
     static jfieldID f_MultipeerReplColl_name;
     static jfieldID f_MultipeerReplColl_options;
     static jfieldID f_MultipeerReplColl_pushFilter;
     static jfieldID f_MultipeerReplColl_pullFilter;
-    static jmethodID m_MultipeerReplColl_filterCallback;             // validationFunction method
+    static jmethodID m_MultipeerReplColl_filterCallback;    // validationFunction method
 
     static bool pullFilterCallback(
             C4PeerSync *,
@@ -117,7 +121,7 @@ namespace litecore::jni {
             m_C4MultipeerReplicator_onSyncStatusChanged = env->GetStaticMethodID(
                     cls_C4MultipeerReplicator,
                     "onSyncStatusChanged",
-                    "(JZIJ)V");
+                    "(JLcom/couchbase/lite/internal/core/C4PeerSyncStatus;)V");
 
             if (m_C4MultipeerReplicator_onSyncStatusChanged == nullptr)
                 return false;
@@ -199,6 +203,21 @@ namespace litecore::jni {
                     "filterCallback",
                     "(J[BLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IJZ)Z");
             if (m_MultipeerReplColl_filterCallback == nullptr)
+                return false;
+        }
+
+        // C4PeerSyncStatus, constructor
+        {
+            jclass localClass = env->FindClass("com/couchbase/lite/internal/core/C4PeerSyncStatus");
+            if (localClass == nullptr)
+                return false;
+
+            cls_C4PeerSyncStatus = reinterpret_cast<jclass>(env->NewGlobalRef(localClass));
+            if (cls_C4PeerSyncStatus == nullptr)
+                return false;
+
+            m_C4PeerSyncStatus_init = env->GetMethodID(cls_C4PeerSyncStatus, "<init>", "(IZII)V");
+            if (m_C4PeerSyncStatus_init == nullptr)
                 return false;
         }
 
@@ -286,23 +305,32 @@ namespace litecore::jni {
     // Callbacks
     //-------------------------------------------------------------------------
 
-    static void statusChangedCallback(C4PeerSync *ignored, C4PeerSyncProtocol protocol, bool started, C4Error error, void *context) {
-        // TODO: Use protocol
+    static void statusChangedCallback(C4PeerSync *ignored, C4PeerSyncProtocol protocol,
+                                      bool started, C4Error error, void *context) {
         JNIEnv *env = nullptr;
         jint envState = attachJVM(&env, "p2pStatusChanged");
         if ((envState != JNI_OK) && (envState != JNI_EDETACHED))
             return;
 
+        jobject _status = env->NewObject(
+                cls_C4PeerSyncStatus,
+                m_C4PeerSyncStatus_init,
+                (jint) protocol,
+                started ? JNI_TRUE : JNI_FALSE,
+                (jint) error.domain,
+                (jint) error.code);
+
         env->CallStaticVoidMethod(
                 cls_C4MultipeerReplicator,
                 m_C4MultipeerReplicator_onSyncStatusChanged,
                 (jlong) context,
-                started ? JNI_TRUE : JNI_FALSE,
-                (jint) error.domain,
-                (jlong) error.code);
+                _status);
 
-        if (envState == JNI_EDETACHED)
+        if (envState == JNI_EDETACHED) {
             detachJVM("p2pStatusChanged");
+        } else {
+            if (_status != nullptr) env->DeleteLocalRef(_status);
+        }
     }
 
     static bool authenticateCallback(C4PeerSync *ignored, const C4PeerID *peerId, C4Cert *certChain, void *context) {
@@ -649,6 +677,32 @@ JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator_g
         jlong peer) {
     C4PeerID peerId = c4peersync_getMyID((C4PeerSync *) peer);
     return toJByteArray(env, peerId.bytes, 32);
+}
+
+/*
+ * Class:     com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator
+ * Method:    getStatus
+ * Signature: (JI)Lcom/couchbase/lite/internal/core/C4PeerSyncStatus;
+ */
+JNIEXPORT jobject
+JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator_getStatus(
+        JNIEnv *env,
+        jclass clazz,
+        jlong peer,
+        jint protocol)  {
+    C4Error error{};
+    C4PeerSyncStatus status = c4peersync_getStatus((C4PeerSync *) peer, protocol, &error);
+    if (error.code > 0) {
+        throwError(env, error);
+        return nullptr;
+    }
+    return env->NewObject(
+            cls_C4PeerSyncStatus,
+            m_C4PeerSyncStatus_init,
+            (jint) protocol,
+            status.online ? JNI_TRUE : JNI_FALSE,
+            (jint) status.error.domain,
+            (jint) status.error.code);
 }
 
 /*

--- a/common/main/cpp/native_c4multipeerreplicator.cc
+++ b/common/main/cpp/native_c4multipeerreplicator.cc
@@ -687,12 +687,13 @@ JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator_g
 JNIEXPORT jobject
 JNICALL Java_com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator_getStatus(
         JNIEnv *env,
-        jclass clazz,
+        jclass ignore,
         jlong peer,
         jint protocol)  {
     C4Error error{};
-    C4PeerSyncStatus status = c4peersync_getStatus((C4PeerSync *) peer, protocol, &error);
-    if (error.code > 0) {
+    C4PeerSyncStatus status = c4peersync_getStatus((C4PeerSync *) peer,
+                                                   (C4PeerSyncProtocol)protocol, &error);
+    if (error.code != 0) {
         throwError(env, error);
         return nullptr;
     }

--- a/common/main/cpp/native_c4multipeerreplicator.cc
+++ b/common/main/cpp/native_c4multipeerreplicator.cc
@@ -312,7 +312,7 @@ namespace litecore::jni {
         if ((envState != JNI_OK) && (envState != JNI_EDETACHED))
             return;
 
-        jobject _status = env->NewObject(
+        jobject status = env->NewObject(
                 cls_C4PeerSyncStatus,
                 m_C4PeerSyncStatus_init,
                 (jint) protocol,
@@ -324,12 +324,12 @@ namespace litecore::jni {
                 cls_C4MultipeerReplicator,
                 m_C4MultipeerReplicator_onSyncStatusChanged,
                 (jlong) context,
-                _status);
+                status);
 
         if (envState == JNI_EDETACHED) {
             detachJVM("p2pStatusChanged");
         } else {
-            if (_status != nullptr) env->DeleteLocalRef(_status);
+            if (status != nullptr) env->DeleteLocalRef(status);
         }
     }
 

--- a/common/main/java/com/couchbase/lite/internal/core/C4Constants.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Constants.java
@@ -323,7 +323,8 @@ public final class C4Constants {
     // c4PeerSyncTypes.h
     ////////////////////////////////////
     public static final class PeerSyncProtocols {
-        public static final int DNS_SD = 0x01;
-        public static final int BLUETOOTH_LE = 0x02;
+        public static final int NONE = 0x00;                    // No protocol, or aggregate of all protocols
+        public static final int DNS_SD = 0x01;                  // DNS-SD ("Bonjour") protocol with TCP sockets.
+        public static final int BLUETOOTH_LE = 0x02;            // Bluetooth LE protocol with L2CAP sockets.
     }
 }

--- a/common/main/java/com/couchbase/lite/internal/core/C4Constants.java
+++ b/common/main/java/com/couchbase/lite/internal/core/C4Constants.java
@@ -323,7 +323,6 @@ public final class C4Constants {
     // c4PeerSyncTypes.h
     ////////////////////////////////////
     public static final class PeerSyncProtocols {
-        public static final int NONE = 0x00;                    // No protocol, or aggregate of all protocols
         public static final int DNS_SD = 0x01;                  // DNS-SD ("Bonjour") protocol with TCP sockets.
         public static final int BLUETOOTH_LE = 0x02;            // Bluetooth LE protocol with L2CAP sockets.
     }


### PR DESCRIPTION
- Implement JNI for per-transport status notifications.
- Implement JNI for getting status by transport.
- Clean up JNI API comments in the header file.