### PR TITLE
CBL-7910 : Remove use of c4doc_getRevisionBody in favor of c4doc_getProperties

### DIFF
--- a/common/main/cpp/native_c4document.cc
+++ b/common/main/cpp/native_c4document.cc
@@ -256,13 +256,10 @@ Java_com_couchbase_lite_internal_core_impl_NativeC4Document_getSelectedBody2(
         JNIEnv *ignore1,
         jclass ignore2,
         jlong jdoc) {
-    C4Slice body = c4doc_getRevisionBody((C4Document *) jdoc);
-    if (body.size == 0)
-        return (jlong) nullptr;
-
-    FLValue data = FLValue_FromData(body, kFLTrusted);
-
-    return (jlong) FLValue_AsDict(data);
+    // NOTE: This use to call c4doc_getRevisionBody but that's no longer advisable
+    // since each call potentially invalidates the results of the previous one
+    // when using version vectors
+    return (jlong)c4doc_getProperties((C4Document *) jdoc);
 }
 
 // - Conflict resolution


### PR DESCRIPTION
Ported the fix from 4.0 branch (f8835f88199860752c69dca3288c5383926dec2f)

--

The former has a quirk in version vector mode that the latter doesn't, resulting in hard to understand buggy behavior.  Basically sometimes the original slice is invalidated by a subsequent call and so there is crashing and invalid data when trying to convert documents to Java maps, etc
