### PR TITLE
Remove unused includes from native_c4replutils.cc

### DIFF
--- a/common/main/cpp/native_c4replutils.cc
+++ b/common/main/cpp/native_c4replutils.cc
@@ -17,11 +17,8 @@
 //
 
 #include <vector>
-//#include "c4PeerSync.h"
-#include "c4PeerSyncTypes.h"
 #include "native_glue.hh"
 #include "native_c4replutils.hh"
-#include "com_couchbase_lite_internal_core_impl_NativeC4MultipeerReplicator.h"
 
 using namespace litecore;
 using namespace litecore::jni;


### PR DESCRIPTION
Removed unused includes which causes CE build failure from native_c4replutils.cc