### PR TITLE
CBL-8161 : Restore the close database timeout waiting for active processes

### DIFF
--- a/.github/workflows/warn_release.yml
+++ b/.github/workflows/warn_release.yml
@@ -1,5 +1,6 @@
 on:
   pull_request:
+    types: [opened]
     branches: ['**/release/**']
 
 jobs:

--- a/common/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/common/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -92,7 +92,7 @@ abstract class AbstractDatabase extends BaseDatabase
     private static final LogDomain DOMAIN = LogDomain.DATABASE;
 
     // Max time to wait for active processes to finish.
-    private static final int DB_CLOSE_PROCESS_TIMEOUT_SECS = 10;
+    private static final int DB_CLOSE_PROCESS_TIMEOUT_SECS = 30;
     // Backoff between BUSY retries on close.
     private static final int DB_CLOSE_RETRY_DELAY_SECS = 2;
     // Max number of BUSY retries before giving up.
@@ -1257,7 +1257,9 @@ abstract class AbstractDatabase extends BaseDatabase
         try {
             verifyActiveProcesses();
             if (!closeLatch.await(DB_CLOSE_PROCESS_TIMEOUT_SECS, TimeUnit.SECONDS)) {
-                throw new CouchbaseLiteException("Shutdown failed", CBLError.Domain.CBLITE, CBLError.Code.BUSY);
+                // Java-side process tracking can lag (stuck callbacks, stale entries);
+                // let LiteCore be the ground truth on whether close is actually possible.
+                Log.w(DOMAIN, "Timed out waiting for active processes to finish; attempting close anyway");
             }
 
             for (int i = 0; ; i++) {


### PR DESCRIPTION
* The previous fix reduce the timeout waiting for the active processes to 10 seconds which is too low (e.g. WebSocket close timeout is 9 seconds). Restore the timeout back to 30 seconds.

* Restore the previous logic that will try to close the database anyway even though the active processes are not all finished.

* Noted that the original code before the fix has a bug that the dabase close only retries once after getting BUSY error but wait for total 30 seconds then timeout after.