### PR TITLE
CBL-8317 : Fix Copy Database Tests

### DIFF
--- a/common/test/java/com/couchbase/lite/DatabaseTest.kt
+++ b/common/test/java/com/couchbase/lite/DatabaseTest.kt
@@ -1252,9 +1252,13 @@ class DatabaseTest : BaseDbTest() {
 
         val dbName = getUniqueName("test_copy_db")
         val config = testDatabase.getConfig()
+        val dbPath = testDatabase.path!!
+
+        // Close the db before copying
+        closeDb(testDatabase)
 
         // Copy the db
-        Database.copy(File(testDatabase.path!!), dbName, config)
+        Database.copy(File(dbPath), dbName, config)
 
         // Verify that it exists
         Assert.assertTrue(Database.exists(dbName, File(config.directory)))
@@ -1269,7 +1273,7 @@ class DatabaseTest : BaseDbTest() {
             Assert.assertEquals(n + docs.size.toLong(), otherCollection.count)
 
             QueryBuilder.select(SelectResult.expression(Meta.id))
-                .from(DataSource.collection(testCollection))
+                .from(DataSource.collection(otherCollection))
                 .execute()
                 .use { rs ->
                     for (r in rs) {

--- a/common/test/java/com/couchbase/lite/internal/core/C4DatabaseTest.kt
+++ b/common/test/java/com/couchbase/lite/internal/core/C4DatabaseTest.kt
@@ -439,13 +439,20 @@ class C4DatabaseTest : C4BaseTest() {
         createRev("doc002", REV_ID_1, fleeceBody)
         Assert.assertEquals(2L, c4Collection.documentCount)
 
-
         val dbName = getUniqueName("c4_copy_test_db")
         val dstParentDirPath = getScratchDirectoryPath(getUniqueName("c4_test_2"))
-        C4Database.copyDb(c4Database.dbPath!!, dstParentDirPath, dbName, testDbFlags)
+        val dbPath = c4Database.dbPath!!
+
+        // Close database before copying
+        c4Database.closeDb()
+        c4Database = null // prevent @after from closing the database again
+
+        C4Database.copyDb(dbPath, dstParentDirPath, dbName, testDbFlags)
         val copyDb = C4Database.getDatabase(dstParentDirPath, dbName, testDbFlags)
+        val copyCollection = copyDb.getCollection(c4Collection.scope, c4Collection.name)
+        assertNonNull(copyCollection)
         Assert.assertNotNull(copyDb)
-        Assert.assertEquals(2L, c4Collection.documentCount)
+        Assert.assertEquals(2L, copyCollection?.documentCount)
     }
 
     @Test
@@ -458,6 +465,11 @@ class C4DatabaseTest : C4BaseTest() {
         createRev(targetDb.defaultCollection, "doc001", REV_ID_1, fleeceBody)
         Assert.assertEquals(1L, targetDb.defaultCollection.documentCount)
         targetDb.close()
+
+        // Close database before copying
+        c4Database.closeDb()
+        c4Database = null // prevent @after from closing the database again
+
         try {
             C4Database.copyDb(
                 srcDbPath!!,


### PR DESCRIPTION
LiteCore is now returning an error when copying the database if the database is not closed. Update the copying database tests to close the database before copying.