### PR TITLE
CBL-8318: Fix executor concurrency and inside executor tracking

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/exec/CBLExecutor.java
+++ b/common/main/java/com/couchbase/lite/internal/exec/CBLExecutor.java
@@ -130,7 +130,7 @@ public class CBLExecutor extends ThreadPoolExecutor {
                 }
             });
 
-        allowCoreThreadTimeOut(true);
+        allowCoreThreadTimeOut(false);
 
         this.name = name;
     }

--- a/common/main/java/com/couchbase/lite/internal/exec/CBLExecutor.java
+++ b/common/main/java/com/couchbase/lite/internal/exec/CBLExecutor.java
@@ -97,7 +97,7 @@ public class CBLExecutor extends ThreadPoolExecutor {
     private float m2;
 
     // A fixed sized pool backed by a very large queue.
-    public CBLExecutor(@NonNull String name) { this(name, 0, POOL_SIZE, new LinkedBlockingQueue<>()); }
+    public CBLExecutor(@NonNull String name) { this(name, POOL_SIZE, POOL_SIZE, new LinkedBlockingQueue<>()); }
 
     public CBLExecutor(@NonNull String name, int min, int max, @NonNull BlockingQueue<Runnable> workQueue) {
         this(name, min, max, 30, workQueue);  // unused threads die after 30 sec

--- a/common/main/java/com/couchbase/lite/internal/exec/ConcurrentExecutor.java
+++ b/common/main/java/com/couchbase/lite/internal/exec/ConcurrentExecutor.java
@@ -49,7 +49,8 @@ class ConcurrentExecutor implements ExecutionService.CloseableExecutor {
     @GuardedBy("this")
     private int running;
 
-    private long currentThread = -1;
+    @NonNull
+    private final ThreadLocal<Boolean> insideExecutor = new ThreadLocal<>();
 
     ConcurrentExecutor(@NonNull ThreadPoolExecutor executor) {
         Preconditions.assertNotNull(executor, "executor");
@@ -76,7 +77,7 @@ class ConcurrentExecutor implements ExecutionService.CloseableExecutor {
         Preconditions.assertNotNull(task, "task");
         synchronized (this) {
             if (stopLatch != null) { throw new ExecutorClosedException("Executor has been stopped"); }
-            executeTask(new InstrumentedTask(task, this::finishTask));
+            executeTask(new InstrumentedTask(wrapTask(task), this::finishTask));
         }
     }
 
@@ -107,9 +108,7 @@ class ConcurrentExecutor implements ExecutionService.CloseableExecutor {
     }
 
     @Override
-    public boolean isInsideExecutor() {
-        return Thread.currentThread().getId() == currentThread;
-    }
+    public boolean isInsideExecutor() { return Boolean.TRUE.equals(insideExecutor.get()); }
 
     @NonNull
     @Override
@@ -137,14 +136,26 @@ class ConcurrentExecutor implements ExecutionService.CloseableExecutor {
         if (latch != null) { latch.countDown(); }
     }
 
+    @NonNull
+    private Runnable wrapTask(@NonNull Runnable task) {
+        return new Runnable() {
+            @Override
+            public void run() {
+                insideExecutor.set(true);
+                try { task.run(); }
+                finally { insideExecutor.remove(); }
+            }
+
+            @NonNull
+            @Override
+            public String toString() { return task.toString(); }
+        };
+    }
+
     @GuardedBy("this")
     private void executeTask(@NonNull InstrumentedTask newTask) {
         try {
-            executor.execute(() -> {
-                currentThread = Thread.currentThread().getId();
-                newTask.run();
-                currentThread = -1;
-            });
+            executor.execute(newTask);
             running++;
         }
         catch (RuntimeException e) {

--- a/common/main/java/com/couchbase/lite/internal/exec/SerialExecutor.java
+++ b/common/main/java/com/couchbase/lite/internal/exec/SerialExecutor.java
@@ -165,8 +165,8 @@ class SerialExecutor implements ExecutionService.CloseableExecutor {
 
         try { executor.execute(() -> {
             currentThread = Thread.currentThread().getId();
-            nextTask.run();
-            currentThread = -1;
+            try { nextTask.run(); }
+            finally { currentThread = -1; }
         }); }
         catch (RuntimeException e) {
             Log.w(LogDomain.DATABASE, "Catastrophic executor failure (Serial Executor)!", e);

--- a/common/test/java/com/couchbase/lite/internal/ExecutionServiceTest.kt
+++ b/common/test/java/com/couchbase/lite/internal/ExecutionServiceTest.kt
@@ -210,6 +210,50 @@ class ExecutionServiceTest : BaseTest() {
         Assert.assertTrue(executor.stop(5, TimeUnit.SECONDS)) // everything should be done shortly
     }
 
+    @Test
+    fun testInsideSerialExecutor() {
+        val executor = cblService.serialExecutor
+        val finishLatch = CountDownLatch(1)
+
+        Assert.assertFalse(executor.isInsideExecutor())
+
+        val insideExecutor = BooleanArray(1)
+        executor.execute {
+            insideExecutor[0] = executor.isInsideExecutor()
+            finishLatch.countDown()
+        }
+
+        Assert.assertTrue(finishLatch.await(STD_TIMEOUT_SEC, TimeUnit.SECONDS))
+        Assert.assertTrue(insideExecutor[0])
+        Assert.assertFalse(executor.isInsideExecutor())
+    }
+
+    @Test
+    fun testInsideConcurrentExecutor() {
+        val executor = getExecutionService(CBLExecutor("Inside concurrent test worker", 2, 2, LinkedBlockingQueue()))
+            .concurrentExecutor
+
+        val startLatch = CountDownLatch(2)
+        val finishLatch = CountDownLatch(2)
+        val insideExecutor = BooleanArray(2)
+
+        Assert.assertFalse(executor.isInsideExecutor())
+
+        for (i in 0..1) {
+            executor.execute {
+                startLatch.countDown()
+                Assert.assertTrue(startLatch.await(STD_TIMEOUT_SEC, TimeUnit.SECONDS))
+                insideExecutor[i] = executor.isInsideExecutor()
+                finishLatch.countDown()
+            }
+        }
+
+        Assert.assertTrue(finishLatch.await(STD_TIMEOUT_SEC, TimeUnit.SECONDS))
+        Assert.assertTrue(insideExecutor[0])
+        Assert.assertTrue(insideExecutor[1])
+        Assert.assertFalse(executor.isInsideExecutor())
+    }
+
     // The Concurrent Executor throws on fail
     @Test
     fun testConcurrentExecutorThrowAndDumpOnFail() {


### PR DESCRIPTION
- Reverted the default CBLExecutor to a fixed-size pool by using POOL_SIZE as both the core and max pool size. With corePoolSize = 0 and an unbounded LinkedBlockingQueue, ThreadPoolExecutor queues additional work instead of growing the pool, making the concurrent executor behave effectively single-threaded.

- Fixed ConcurrentExecutor.isInsideExecutor() to work with overlapping tasks by keeping the insideExecutor flag inside thread local, and ensure SerialExecutor clears its current-thread state in a finally block.

- Added tests covering isInsideExecutor() for both serial and concurrent executors.