### PR TITLE
Suppress SwitchFallThrough warning in AbstractReplicator’s statusChanged()

### DIFF
--- a/common/main/java/com/couchbase/lite/AbstractReplicator.java
+++ b/common/main/java/com/couchbase/lite/AbstractReplicator.java
@@ -776,6 +776,7 @@ public abstract class AbstractReplicator extends BaseReplicator
         }
     }
 
+    @SuppressWarnings("PMD.ImplicitSwitchFallThrough")
     private void statusChanged(@NonNull C4ReplicatorStatus c4Status) {
         final ReplicatorChange change;
         final Set<ReplicatorChangeListenerToken> listenerTokens;


### PR DESCRIPTION
The Switch-Fall-Through is by intention instead of duplicating the same code.