### PR TITLE
Revert mistaken non-load of LiteCore shared library

### DIFF
--- a/common/test/java/com/couchbase/lite/logging/LogTest.kt
+++ b/common/test/java/com/couchbase/lite/logging/LogTest.kt
@@ -631,7 +631,6 @@ class LogTest : BaseDbTest() {
     // This test verifies that the destructor will run to completion, even while a callback is taking place.
     // This is a stronger guarantee than the re-entrant case.  This guarantees that running the destructor
     // cannot cause a deadlock even if the thread calling it blocks the LiteCore logging callback thread.
-    // !!! CBL-7125: the call to c4Log does not acutally log anything
     @Test
     fun testDeleteLiteCoreLoggerInCallback() {
         val query = C4Query.create(testDatabase.getC4Db, QueryLanguage.N1QL, "SELECT 1 FROM _")
@@ -675,7 +674,6 @@ class LogTest : BaseDbTest() {
         Assert.assertTrue(success)
     }
 
-    // !!! CBL-7125: the call to c4Log does not acutally log anything
     @Test
     fun testNonASCII() {
         val prefix = "HEBREW: "

--- a/java/main/java/com/couchbase/lite/internal/NativeLibrary.java
+++ b/java/main/java/com/couchbase/lite/internal/NativeLibrary.java
@@ -57,6 +57,7 @@ final class NativeLibrary {
     private static final String ARCH_UNIVERSAL = "universal";
 
     private static final String LIB_JNI = "LiteCoreJNI";
+    private static final String LIB_LITE_CORE = "LiteCore";
 
     private static final String WINDOWS_OS_DIR = "windows";
     private static final String LINUX_OS_DIR = "linux";
@@ -82,6 +83,8 @@ final class NativeLibrary {
 
         final String os = System.getProperty("os.name");
         final String arch = System.getProperty("os.arch");
+
+        loadLibrary(LIB_LITE_CORE, getCoreArchDir(os, arch), os, arch, scratchDir);
 
         loadLibrary(LIB_JNI, getJniArchDir(os, arch), os, arch, scratchDir);
     }


### PR DESCRIPTION
Java still needs it, it is Android that doesn't.  Also delete some stale comments.