### PR TITLE
CBL-8389 : Add Kotlin serialization-based APIs

### DIFF
--- a/common/main/java/com/couchbase/lite/Document.java
+++ b/common/main/java/com/couchbase/lite/Document.java
@@ -33,6 +33,7 @@ import com.couchbase.lite.internal.core.C4Document;
 import com.couchbase.lite.internal.fleece.FLDict;
 import com.couchbase.lite.internal.fleece.FLEncoder;
 import com.couchbase.lite.internal.fleece.FLSliceResult;
+import com.couchbase.lite.internal.fleece.FLValue;
 import com.couchbase.lite.internal.fleece.JSONEncodable;
 import com.couchbase.lite.internal.fleece.MRoot;
 import com.couchbase.lite.internal.utils.ClassUtils;
@@ -132,6 +133,12 @@ public class Document implements DictionaryInterface, JSONEncodable, Iterable<St
     @GuardedBy("lock")
     @Nullable
     private String revId;
+
+    // Set by setData(FLSliceResult,boolean) to keep the Fleece backing store from being GC'd.
+    // (This is kind of a hack, and it's only used ephemerally by Kotlin serialization.)
+    @GuardedBy("lock")
+    @Nullable
+    private FLSliceResult extraBackingStore;
 
     //---------------------------------------------
     // Constructors
@@ -619,6 +626,15 @@ public class Document implements DictionaryInterface, JSONEncodable, Iterable<St
         synchronized (lock) {
             updateC4DocumentLocked(c4doc);
             setContentLocked(((c4doc == null) || c4doc.isRevDeleted()) ? null : c4doc.getSelectedBody2(), mutable);
+        }
+    }
+
+    // for use by CollectionExtensions.kt
+    void setContent(@NonNull FLSliceResult fleeceData, boolean mutable) {
+        synchronized (lock) {
+            var data = FLValue.fromData(fleeceData).asFLDict();
+            extraBackingStore = fleeceData;
+            setContentLocked(data, mutable);
         }
     }
 

--- a/common/main/java/com/couchbase/lite/Result.java
+++ b/common/main/java/com/couchbase/lite/Result.java
@@ -523,13 +523,27 @@ public final class Result
     public Iterator<String> iterator() { return getKeys().iterator(); }
 
     //---------------------------------------------
+    // package access -- for use by QueryExtensions.kt
+    //---------------------------------------------
+
+    @NonNull
+    List<FLValue> getFLValues() { return values; }
+
+    @NonNull
+    List<String> getColumnNames() { return context.getResultSet().getColumnNames(); }
+
+    int getIndexForKey(String key) {
+        final int index = context.getResultSet().getColumnIndex(Preconditions.assertNotNull(key, "key"));
+        if (index < 0) { return -1; }
+        if ((missingColumns & (1L << index)) != 0) { return -1; }
+        return (!isInBounds(index)) ? -1 : index;
+    }
+
+    //---------------------------------------------
     // private access
     //---------------------------------------------
 
     private int getColumnCount() { return context.getResultSet().getColumnCount(); }
-
-    @NonNull
-    private List<String> getColumnNames() { return context.getResultSet().getColumnNames(); }
 
     @Nullable
     private Object getFleeceAt(int index) {
@@ -544,13 +558,6 @@ public final class Result
     private FLValue getFLValueAt(int index) {
         assertValid(index);
         return values.get(index);
-    }
-
-    private int getIndexForKey(@Nullable String key) {
-        final int index = context.getResultSet().getColumnIndex(Preconditions.assertNotNull(key, "key"));
-        if (index < 0) { return -1; }
-        if ((missingColumns & (1L << index)) != 0) { return -1; }
-        return (!isInBounds(index)) ? -1 : index;
     }
 
     @NonNull

--- a/common/main/java/com/couchbase/lite/internal/fleece/FLValue.java
+++ b/common/main/java/com/couchbase/lite/internal/fleece/FLValue.java
@@ -73,7 +73,7 @@ public class FLValue {
         long nAsInt(long value);
         float nAsFloat(long value);
         double nAsDouble(long value);
-        @NonNull
+        @Nullable
         String nAsString(long value);
         long nAsArray(long value);
         long nAsDict(long value);
@@ -269,7 +269,7 @@ public class FLValue {
      *
      * @return String
      */
-    @NonNull
+    @Nullable
     public String asString() { return impl.nAsString(peer); }
 
     @NonNull
@@ -325,6 +325,6 @@ public class FLValue {
     <T> T withContent(@NonNull Fn.NonNullFunction<Long, T> fn) { return fn.apply(peer); }
 
     @NonNull
-    FLArray asFLArray() { return FLArray.create(impl.nAsArray(peer)); }
+    public FLArray asFLArray() { return FLArray.create(impl.nAsArray(peer)); }
 }
 

--- a/common/main/kotlin/com/couchbase/lite/CollectionExtensions.kt
+++ b/common/main/kotlin/com/couchbase/lite/CollectionExtensions.kt
@@ -1,0 +1,184 @@
+//
+// Copyright (c) 2026 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.couchbase.lite
+
+import com.couchbase.lite.internal.core.C4Document
+import com.couchbase.lite.internal.fleece.*
+import kotlinx.serialization.*
+
+
+/** Document model classes must implement this interface.
+ *  It adds a [documentMeta] property that's used by Couchbase Lite. */
+interface DocumentModel {
+    /** This tags the model instance with the document ID and revision it was read from,
+     *  which enables conflict detection when it's later saved.
+     *  You may read this property, but DO NOT alter it.
+     *  It should be implemented as a stored property defaulting to `null`, for example:
+     *  `@Transient override var documentMeta: DocumentMeta? = null` */
+    @Transient var documentMeta: DocumentMeta?
+}
+
+/** Stores the Couchbase Lite metadata of a document. Used by the [DocumentModel] interface. */
+class DocumentMeta internal constructor(val collection: Collection?, // [Result] leaves it null
+                                        val id: String,
+                                        val revisionID: String)
+
+
+/** Gets an existing document with the given ID, and uses Kotlin Serialization to create an
+ *  instance of class [T] from it. [T] must implement [DocumentModel].
+ *  If a document with the given ID doesn't exist in the collection, returns null. */
+@ExperimentalSerializationApi
+inline fun <reified T: DocumentModel> Collection.getDocumentAs(id: String): T? =
+    getDocumentAs(id, serializer())
+
+@ExperimentalSerializationApi
+fun <T: DocumentModel> Collection.getDocumentAs(id: String, deserializer: DeserializationStrategy<T>): T? =
+    modelFromC4Doc(this, id, getC4Document(id), deserializer)
+
+
+/** Saves a [DocumentModel] instance as a document in the collection.
+ *  After a successful save, its [DocumentModel.documentMeta] property is updated to the current state.
+ *  @param model  The [DocumentModel] instance to save.
+ *  @param docID  The document ID to save a new unsaved model as, or `null` to generate a unique ID.
+ *                If the model has already been saved, this should be omitted or left `null`.
+ *  @param conflictHandler  A callback to resolve conflicts between the model and a more recently
+ *                          saved document revision. If `null` (the default), the last-writer-wins
+ *                          strategy is used: the save always succeeds, overwriting any
+ *                          conflicting revision.
+ *  @return  True on success, false on an unresolved conflict.
+ *  */
+@ExperimentalSerializationApi
+inline fun <reified T: DocumentModel> Collection.save(model: T,
+                                                      docID: String? = null,
+                                                      noinline conflictHandler: ModelConflictHandler<T>? = null) =
+    save(model, serializer(), serializer(), docID, conflictHandler)
+
+/** Saves a [DocumentModel] instance as a document in the collection, explicitly passing the
+ *  serialization strategy. (This overload is rarely needed.) */
+@ExperimentalSerializationApi
+fun <T: DocumentModel> Collection.save(model: T,
+                                       serializer: SerializationStrategy<T>,
+                                       deserializer: DeserializationStrategy<T>,
+                                       docID: String? = null,
+                                       conflictHandler: ModelConflictHandler<T>? = null): Boolean
+{
+    // Get or create the Document:
+    val meta = model.documentMeta
+    val doc: MutableDocument
+    if (meta == null) {
+        doc = MutableDocument(docID)
+    } else {
+        require(meta.collection == this || meta.collection == null) {"saving document to wrong collection"}
+        require(docID == null || docID == meta.id) {"docID parameter does not match documentMeta.id"}
+        doc = getDocument(meta.id)?.toMutable() ?: MutableDocument(meta.id)
+    }
+
+    // Subroutine that calls the ModelConflictHandler & updates the model accordingly:
+    fun handleConflict(doc: MutableDocument?, curDoc: Document?): Boolean {
+        if (conflictHandler == null)
+            return true // conflict handler defaults to last-write-wins
+        val curModel = curDoc?.let {modelFromC4Doc(this, it.id, it.c4doc, deserializer)}
+        val ok = conflictHandler(model, curModel)
+        if (ok)
+            doc?.setContentFromModel(model, serializer)
+        return ok
+    }
+
+    if (doc.revisionID != meta?.revisionID) {
+        // Model is out of date -- have to resolve the conflict
+        if (!handleConflict(null, doc))
+            return false
+    }
+
+    // Replace the document's content with the serialized model:
+    if (doc.collection == null) {
+        doc.collection = this
+    }
+    doc.setContentFromModel(model, serializer)
+
+    // Save:
+    val ok = if (conflictHandler != null) {
+        save(doc) {savingDoc, curDoc -> handleConflict(savingDoc, curDoc) }
+    } else {
+        save(doc)
+        true
+    }
+    if (ok)
+        model.documentMeta = DocumentMeta(this, doc.id, doc.revisionID!!)
+    return ok
+}
+
+
+/** Model-based conflict handler callback, used by [Collection.save] with [DocumentModel] objects.
+ *  The first parameter is the [DocumentModel] you are saving.
+ *  The second parameter is a [DocumentModel] deserialized from the conflicting revision in the
+ *  collection, or `null` if the document has been deleted.
+ *
+ *  The callback may modify the first [DocumentModel] -- the one being saved -- to incorporate
+ *  changes from the other [DocumentModel] (the revision in the database), then return true.
+ *  (But it must NOT modify its [DocumentModel.documentMeta] property.)
+ *
+ *  Or it may return false to signal that it can't handle the conflict, in which case the
+ *  [Collection.save] method will return false without saving anything. */
+typealias ModelConflictHandler<T> = (T, T?)-> Boolean
+
+
+/** Deletes a model's document from the collection.
+ *  @throws CouchbaseLiteException if the [DocumentModel.documentMeta] property is null. */
+fun Collection.delete(model: DocumentModel, concurrencyControl: ConcurrencyControl = ConcurrencyControl.LAST_WRITE_WINS): Boolean {
+    val meta = model.documentMeta ?: throw CouchbaseLiteException("DocumentModel has no document ID")
+    require(meta.collection == this || meta.collection == null) {"deleting document from wrong collection"}
+    val doc = getDocument(meta.id) ?: return true
+    if (doc.revisionID != meta.revisionID && concurrencyControl == ConcurrencyControl.FAIL_ON_CONFLICT)
+        return false
+    if (!delete(doc, concurrencyControl))
+        return false
+    model.documentMeta = null
+    return true
+}
+
+
+/** Purges a model's document from the collection.
+ *  @throws CouchbaseLiteException if the [DocumentModel.documentMeta] property is null,
+ *                                 or the document doesn't exist in the collection. */
+fun Collection.purge(model: DocumentModel) {
+    val id = model.documentMeta?.id ?: throw CouchbaseLiteException("DocumentModel has no document ID")
+    purge(id)
+    model.documentMeta = null
+}
+
+
+/** Creates a [DocumentModel] instance from a [C4Document]. */
+private fun <T:DocumentModel> modelFromC4Doc(collection: Collection,
+                                             docID: String,
+                                             c4doc: C4Document?,
+                                             deserializer: DeserializationStrategy<T>): T?
+{
+    if (c4doc == null || c4doc.isDocDeleted) return null
+    val properties = c4doc.selectedBody2 ?: return null
+    val model = deserializeFromFleece(properties.toFLValue(), deserializer)
+    model.documentMeta = DocumentMeta(collection, docID, c4doc.revID!!)
+    return model
+}
+
+
+/** Extension of [MutableDocument], that updates its content from a [DocumentModel] object. */
+private fun <T:DocumentModel> MutableDocument.setContentFromModel(model: T, serializer: SerializationStrategy<T>) {
+    setContent(serializeToFleece(serializer, model), false)
+}

--- a/common/main/kotlin/com/couchbase/lite/QueryExtensions.kt
+++ b/common/main/kotlin/com/couchbase/lite/QueryExtensions.kt
@@ -1,0 +1,129 @@
+//
+// Copyright (c) 2026 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.couchbase.lite
+
+import com.couchbase.lite.internal.fleece.*
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.descriptors.StructureKind
+import kotlinx.serialization.serializer
+
+
+/** Uses Kotlin Serialization to create an object of type [T] from a query result.
+ *  If the [key] parameter is non-null, it uses the result's value for that key as the source,
+ *  instead of the entire result.
+ *
+ *  For example, if your query is `SELECT name, age, shoeSize FROM people` and you have a
+ *  serializable `Person` class with properties `name`, `age` and `shoeSize`, you can call:
+ *  `val person = result.data<Person>()`
+ *
+ *  Or you could use the query `SELECT * as person FROM people` and create the `Person` with
+ *  `val person = result.data<Person>("person")`.
+ *  */
+@ExperimentalSerializationApi
+inline fun <reified T> Result.data(key: String? = null): T =
+    data(serializer(), key)
+
+/** Uses Kotlin Serialization to create a [DocumentModel] instance of type [T] from the query result.
+ *  This is a specialization of the one-parameter [data] method that adds a [metaKey] parameter.
+ *
+ *  The [metaKey] parameter is the name of the result property whose value comes from the N1QL
+ *  `meta()` function; this is used to set the [DocumentModel.documentMeta] property of the result.
+ *
+ *  For example, if your query is `SELECT * as person, meta() as meta FROM people`, you would call
+ *  `result.data<Person>("person", "meta")`.
+ */
+@ExperimentalSerializationApi
+inline fun <reified T: DocumentModel> Result.data(key: String? = null,
+                                                  metaKey: String? = null): T =
+    data(serializer(), key, metaKey)
+
+@ExperimentalSerializationApi
+fun <T> Result.data(deserializer: DeserializationStrategy<T>,
+                    key: String? = null,
+                    metaKey: String? = null): T
+{
+    val columns = flValues
+    val result = if (key == null) {
+        if (deserializer.descriptor as? StructureKind == StructureKind.LIST) {
+            // Deserializer wants a List, so pass the column values directly:
+            deserializeFromFleece(columns, deserializer)
+        } else {
+            // Deserializer wants a Map, so smush the column names and values together:
+            val size = columns.size
+            val names = columnNames
+            val iter = object: Iterator<Map.Entry<String,FLValue>> {
+                var i = 0
+                override fun hasNext() = i < size
+                override fun next(): Map.Entry<String,FLValue> {
+                    val entry = Entry(names[i], columns[i])
+                    i++
+                    return entry
+                }
+            }
+            deserializeFromFleece(iter, size, deserializer)
+        }
+    } else {
+        // Deserializing a single value from the result:
+        val i = getIndexForKey(key)
+        if (i < 0) throw CouchbaseLiteError("Query result has no property '$key'")
+        deserializeFromFleece(columns[i], deserializer)
+    }
+    if (result is DocumentModel && metaKey != null)
+        result.documentMeta = getDocumentMeta(metaKey)
+    return result
+}
+
+
+/** Returns the query rows transformed by Kotlin Serialization into instances of [T]. */
+@ExperimentalSerializationApi
+inline fun <reified T> ResultSet.data(key: String? = null): Sequence<T> =
+    data(serializer(), key)
+
+@ExperimentalSerializationApi
+inline fun <reified T: DocumentModel> ResultSet.data(key: String? = null,
+                                                     metaKey: String? = null): Sequence<T> =
+    data(serializer(), key, metaKey)
+
+/** Returns the query rows transformed by Kotlin Serialization into instances of [T]. */
+@ExperimentalSerializationApi
+fun <T> ResultSet.data(deserializer: DeserializationStrategy<T>,
+                       key: String? = null,
+                       metaKey: String? = null): Sequence<T> =
+    sequence {
+        while (true) {
+            val result = next() ?: break
+            yield(result.data(deserializer, key, metaKey))
+        }
+    }
+
+
+// A trivial implementation of [Map.Entry].
+private class Entry(override val key: String, override val value: FLValue) : Map.Entry<String,FLValue>
+
+
+// Creates a [DocumentMeta] from the "meta" column of a Result. (Note: It can't set the `collection`.)
+private fun Result.getDocumentMeta(key: String): DocumentMeta? {
+    val i = getIndexForKey(key)
+    if (i < 0) throw CouchbaseLiteError("Query result has no property '$key'")
+    val col = flValues[i]
+    if (col.type != FLValue.DICT) return null
+    val meta = col.asFLDict()
+    val id = meta["id"]?.asString() ?: return null
+    val revID = meta["revisionID"]?.asString() ?: return null
+    return DocumentMeta(null, id, revID)
+}

--- a/common/main/kotlin/com/couchbase/lite/internal/fleece/FLValueExtensions.kt
+++ b/common/main/kotlin/com/couchbase/lite/internal/fleece/FLValueExtensions.kt
@@ -1,0 +1,111 @@
+//
+// Copyright (c) 2026 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.couchbase.lite.internal.fleece
+
+
+/** Returns a []Collection<FLValue>] with the same contents as this FLArray. */
+val FLArray.asCollection: Collection<FLValue> get() = FLArrayAsCollection(this)
+
+
+private class FLArrayAsCollection(val array: FLArray): Collection<FLValue> {
+    override val size: Int = array.count().toInt()
+
+    override fun isEmpty(): Boolean = (size == 0)
+
+    override fun contains(element: FLValue): Boolean {
+        for (i in 0L ..< size.toLong())
+            if (array[i] == element) return true
+        return false
+    }
+
+    override fun containsAll(elements: Collection<FLValue>): Boolean =
+        elements.all { this.contains(it) }
+
+    override fun iterator(): Iterator<FLValue> {
+        return object: Iterator<FLValue> {
+            var i = 0L
+            val end = array.count()
+
+            override fun hasNext(): Boolean = i < end
+
+            override fun next(): FLValue {
+                if (i >= end) {throw IndexOutOfBoundsException()}
+                return array[i++]
+            }
+        }
+    }
+}
+
+
+/** Returns a [Map<String,FLValue>] with the same contents as this FLDict. */
+val FLDict.asMap: Map<String,FLValue> get() = FLDictAsMap(this)
+
+private class FLDictAsMap(val dict: FLDict): Map<String,FLValue> {
+    override val size: Int = dict.count().toInt()
+
+    override fun isEmpty(): Boolean = (dict.count() == 0L)
+
+    override fun get(key: String): FLValue? = dict.get(key)
+
+    override fun containsKey(key: String): Boolean = (dict.get(key) != null)
+
+    override fun containsValue(value: FLValue): Boolean {
+        dict.iterator().use { iter ->
+        while (iter.key != null) {
+            if (iter.value == value) return true
+            iter.next()
+        }
+            }
+        return false
+    }
+
+    class Entry(override val key: String, override val value: FLValue) : Map.Entry<String,FLValue>
+
+    override val entries: Set<Map.Entry<String, FLValue>> get() {
+        return buildSet {
+            dict.iterator().use { iter ->
+                while (true) {
+                    val key = iter.key ?: break
+                    add(Entry(key, iter.value))
+                    iter.next()
+                }
+            }
+        }
+    }
+
+    override val keys: Set<String> get() {
+        return buildSet {
+            dict.iterator().use { iter ->
+                while (true) {
+                    add(iter.key ?: break)
+                    iter.next()
+                }
+            }
+        }
+    }
+
+    override val values: Collection<FLValue> get() {
+        return buildList {
+            dict.iterator().use { iter ->
+                while (iter.key != null) {
+                    add(iter.value)
+                    iter.next()
+                }
+            }
+        }
+    }
+}

--- a/common/main/kotlin/com/couchbase/lite/internal/fleece/FleeceDeserialization.kt
+++ b/common/main/kotlin/com/couchbase/lite/internal/fleece/FleeceDeserialization.kt
@@ -1,0 +1,300 @@
+//
+// Copyright (c) 2026 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.couchbase.lite.internal.fleece
+
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
+
+
+/** Decodes an object from a Fleece [FLValue] using Kotlin Serialization. */
+@ExperimentalSerializationApi
+fun <T> deserializeFromFleece(root: FLValue, deserializer: DeserializationStrategy<T>): T =
+    ValueDecoder(root).decodeSerializableValue(deserializer)
+
+/** Decodes an object from a Fleece [FLValue] using Kotlin Serialization. */
+@ExperimentalSerializationApi
+inline fun <reified T> deserializeFromFleece(root: FLValue): T =
+    deserializeFromFleece(root, serializer())
+
+/** Decodes an object from a [Collection<FLValue>] using Kotlin Serialization. */
+@ExperimentalSerializationApi
+fun <T> deserializeFromFleece(root: Collection<FLValue>, deserializer: DeserializationStrategy<T>): T =
+    CollectionRootDecoder(root).decodeSerializableValue(deserializer)
+
+
+/** Decodes an object from a [Collection<FLValue>] using Kotlin Serialization. */
+@ExperimentalSerializationApi
+inline fun <reified T> deserializeFromFleece(root: Collection<FLValue>): T =
+    deserializeFromFleece(root, serializer())
+
+
+/** Decodes an object from a [Map] iterator using Kotlin Serialization. */
+@ExperimentalSerializationApi
+fun <T> deserializeFromFleece(iterator: Iterator<Map.Entry<String,FLValue>>,
+                              size: Int,
+                              deserializer: DeserializationStrategy<T>): T =
+    MapRootDecoder(iterator, size).decodeSerializableValue(deserializer)
+
+/** Decodes an object from a [Map] iterator using Kotlin Serialization. */
+@ExperimentalSerializationApi
+inline fun <reified T> deserializeFromFleece(iterator: Iterator<Map.Entry<String,FLValue>>,
+                                             size: Int): T =
+    deserializeFromFleece(iterator, size, serializer())
+
+
+/** Root decoder for a `Collection<FLValue>` */
+private class CollectionRootDecoder(val collection: Collection<FLValue>): AbstractDecoder() {
+    override val serializersModule: SerializersModule = EmptySerializersModule()
+
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
+        throw FleeceSerializationException("not a scalar value")
+    }
+
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
+        return when (descriptor.kind) {
+            StructureKind.LIST -> ArrayDecoder(collection)
+            else -> throw FleeceSerializationException("unsupported SerialDescriptor kind ${descriptor.kind}")
+        }
+    }
+}
+
+
+/** Root decoder for a `Map<String,FLValue>` */
+private class MapRootDecoder(val iter: Iterator<Map.Entry<String,FLValue>>,
+                             val size: Int): AbstractDecoder()
+{
+    override val serializersModule: SerializersModule = EmptySerializersModule()
+
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
+        throw FleeceSerializationException("not a scalar value")
+    }
+
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
+        return when (descriptor.kind) {
+            StructureKind.MAP -> {
+                val keyDescriptor = descriptor.getElementDescriptor(0)
+                if (keyDescriptor.kind != PrimitiveKind.STRING)
+                    throw FleeceSerializationException("Map keys must be Strings, not ${keyDescriptor.serialName}")
+                MapDecoder(iter, size)
+            }
+            StructureKind.CLASS -> {
+                ClassDecoder(iter)
+            }
+            else -> throw FleeceSerializationException("unsupported SerialDescriptor kind ${descriptor.kind}")
+        }
+    }
+}
+
+
+/** Base class of ValueDecoder and ArrayDecoder. */
+private abstract class AbstractValueDecoder(val size: Int): AbstractDecoder() {
+    protected var index = -1
+
+    override val serializersModule: SerializersModule = EmptySerializersModule()
+
+    override fun decodeSequentially(): Boolean = true
+
+    override fun decodeCollectionSize(descriptor: SerialDescriptor): Int = size
+
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int =
+        if (++index >= size) CompositeDecoder.DECODE_DONE else index
+
+    abstract val value: FLValue
+
+    override fun decodeBoolean(): Boolean   = value.asBool()
+    override fun decodeByte(): Byte         = decodeLong().toByte()
+    override fun decodeShort(): Short       = decodeLong().toShort()
+    override fun decodeChar(): Char         = Char(decodeInt())
+    override fun decodeInt(): Int           = decodeLong().toInt()
+    override fun decodeLong(): Long         = value.asInt()
+    override fun decodeFloat(): Float       = value.asFloat()
+    override fun decodeDouble(): Double     = value.asDouble()
+    override fun decodeString(): String     = value.asString() ?: ""
+
+    override fun decodeInline(descriptor: SerialDescriptor): Decoder = this
+
+    override fun decodeEnum(enumDescriptor: SerialDescriptor): Int = decodeInt()
+
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder =
+        decoderForStructure(value, descriptor)
+}
+
+
+/** Root decoder for a [FLValue].
+ *  Decodes scalars, and delegates collections to [ArrayDecoder] or [MapDecoder]. */
+private class ValueDecoder(override val value: FLValue): AbstractValueDecoder(1)
+
+
+/** Decodes a Kotlin [List] from a Collection of FLValues, usually an FLArray. */
+private class ArrayDecoder(array: Collection<FLValue>): AbstractValueDecoder(array.size) {
+    val iter = array.iterator()
+    override val value get() = iter.next()
+}
+
+
+/** Decodes a Kotlin [Map] from a Map iterator. */
+private class MapDecoder(val iter: Iterator<Map.Entry<String,FLValue>>,
+                         val size: Int): AbstractDecoder()
+{
+    constructor(map: Map<String,FLValue>) :this(map.iterator(), map.size)
+
+    private var index = 0
+    private var curKey: String? = null
+    private var curValue: FLValue? = null
+
+    override val serializersModule: SerializersModule = EmptySerializersModule()
+
+    override fun decodeSequentially() = true
+
+    override fun decodeCollectionSize(descriptor: SerialDescriptor): Int = size
+
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int =
+        if (index < size) index else CompositeDecoder.DECODE_DONE
+
+    // Advances the iterator and returns the key.
+    private fun nextKey(): String {
+        require(curKey == null)
+        val (key, value) = iter.next()
+        curKey = key
+        curValue = value
+        index++
+        return key
+    }
+
+    // Returns the current value without advancing.
+    private fun nextValue(): FLValue {
+        val value = curValue
+        require(value != null) {"expected a map key to be decoded next"}
+        curKey = null
+        curValue = null
+        index++
+        return value
+    }
+
+    // A decoder for [StructureKind.MAP] is expected to provide alternating keys and values.
+    // And keys are always strings (already preflighted.) So [decodeString] may be called for either
+    // a key or a value. It checks if we've read the next entry, and if not advances the iterator
+    // and returns the key. Otherwise it returns the current value.
+    override fun decodeString(): String =
+        if (curValue == null) nextKey() else nextValue().asString() ?: ""
+
+    // The other decode methods are only called for values.
+    override fun decodeBoolean(): Boolean   = nextValue().asBool()
+    override fun decodeByte(): Byte         = decodeLong().toByte()
+    override fun decodeShort(): Short       = decodeLong().toShort()
+    override fun decodeInt(): Int           = decodeLong().toInt()
+    override fun decodeLong(): Long         = nextValue().asInt()
+    override fun decodeFloat(): Float       = nextValue().asFloat()
+    override fun decodeDouble(): Double     = nextValue().asDouble()
+    override fun decodeChar(): Char         = Char(decodeInt())
+}
+
+
+/** Decodes a Kotlin class instance from a Map iterator. */
+private class ClassDecoder(val iter: Iterator<Map.Entry<String,FLValue>>): CompositeDecoder {
+    constructor(map: Map<String,FLValue>) :this(map.iterator())
+
+    private var curKey: String? = null
+    private var curValue: FLValue? = null
+    private var elementIndex = -1
+
+    override val serializersModule: SerializersModule = EmptySerializersModule()
+
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
+        // "Decodes the index of the next element to be decoded. Index represents a position of the
+        // current element in the serial descriptor element that can be found with
+        // SerialDescriptor.getElementIndex." -- Kotlin API docs
+        if (!iter.hasNext()) return CompositeDecoder.DECODE_DONE
+        val (key, value) = iter.next()
+        curKey = key
+        curValue = value
+        elementIndex = descriptor.getElementIndex(key)
+        return elementIndex
+    }
+
+    private fun nextValue(index: Int): FLValue {
+        require(index == elementIndex) {"unexpected element index"}
+        elementIndex = -1
+        return curValue!!
+    }
+
+    private fun decodeLong(index: Int) = nextValue(index).asInt()
+
+    override fun decodeBooleanElement(descriptor: SerialDescriptor, index: Int): Boolean   = nextValue(index).asBool()
+    override fun decodeByteElement(descriptor: SerialDescriptor, index: Int): Byte         = decodeLong(index).toByte()
+    override fun decodeShortElement(descriptor: SerialDescriptor, index: Int): Short       = decodeLong(index).toShort()
+    override fun decodeIntElement(descriptor: SerialDescriptor, index: Int): Int           = decodeLong(index).toInt()
+    override fun decodeLongElement(descriptor: SerialDescriptor, index: Int): Long         = decodeLong(index)
+    override fun decodeFloatElement(descriptor: SerialDescriptor, index: Int): Float       = nextValue(index).asFloat()
+    override fun decodeDoubleElement(descriptor: SerialDescriptor, index: Int): Double     = nextValue(index).asDouble()
+    override fun decodeCharElement(descriptor: SerialDescriptor, index: Int): Char         = Char(decodeLong(index).toInt())
+    override fun decodeStringElement(descriptor: SerialDescriptor, index: Int): String     = nextValue(index).asString() ?: ""
+
+    override fun decodeInlineElement(descriptor: SerialDescriptor, index: Int): Decoder =
+        ValueDecoder(nextValue(index))
+
+    override fun <T> decodeSerializableElement(descriptor: SerialDescriptor,
+                                               index: Int,
+                                               deserializer: DeserializationStrategy<T>,
+                                               previousValue: T?): T
+    {
+        return deserializer.deserialize(ValueDecoder(nextValue(index)))
+    }
+
+    override fun <T: Any> decodeNullableSerializableElement(descriptor: SerialDescriptor,
+                                                            index: Int,
+                                                            deserializer: DeserializationStrategy<T?>,
+                                                            previousValue: T?): T?
+    {
+        val value = nextValue(index)
+        if (value.type == FLValue.NULL)
+            return null
+        return deserializer.deserialize(ValueDecoder(value))
+    }
+
+    override fun endStructure(descriptor: SerialDescriptor) { /*no-op*/ }
+}
+
+
+// Creates an appropriate CompositeDecoder based on a SerialDescriptor.
+@ExperimentalSerializationApi
+private fun decoderForStructure(item: FLValue, descriptor: SerialDescriptor): CompositeDecoder {
+    return when (descriptor.kind) {
+        StructureKind.LIST -> {
+            if (item.type != FLValue.ARRAY) {throw FleeceSerializationException("expected an array") }
+            ArrayDecoder(item.asFLArray().asCollection)
+        }
+        StructureKind.MAP -> {
+            val keyDescriptor = descriptor.getElementDescriptor(0)
+            if (keyDescriptor.kind != PrimitiveKind.STRING)
+                throw FleeceSerializationException("Map keys must be Strings, not ${keyDescriptor.serialName}")
+            if (item.type != FLValue.DICT) {throw FleeceSerializationException("expected a dict") }
+            MapDecoder(item.asFLDict().asMap)
+        }
+        StructureKind.CLASS -> {
+            if (item.type != FLValue.DICT) {throw FleeceSerializationException("expected a dict") }
+            ClassDecoder(item.asFLDict().asMap)
+        }
+        else -> {
+            throw FleeceSerializationException("unsupported SerialDescriptor kind ${descriptor.kind}")
+        }
+    }
+}

--- a/common/main/kotlin/com/couchbase/lite/internal/fleece/FleeceSerialization.kt
+++ b/common/main/kotlin/com/couchbase/lite/internal/fleece/FleeceSerialization.kt
@@ -1,0 +1,246 @@
+//
+// Copyright (c) 2026 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.couchbase.lite.internal.fleece
+
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
+
+
+/** Uses Kotlin Serialization to encode an arbitrary object or collection to Fleece.
+ *  @param serializer  The SerializationStrategy to use.
+ *  @param value  The object to encode.
+ *  @param flEncoder  A Fleece [FLEncoder] to use; defaults to a fresh instance.
+ *  @return  The encoded Fleece data as an immovable [FLSliceResult]. (If you need a regular byte
+ *           array instead, call `getContent()` on it.) */
+@ExperimentalSerializationApi
+fun <T> serializeToFleece(serializer: SerializationStrategy<T>,
+                          value: T,
+                          flEncoder: FLEncoder? = null): FLSliceResult
+{
+    val encoder = FleeceRootEncoder(flEncoder)
+    encoder.encodeSerializableValue(serializer, value)
+    return encoder.container!!
+}
+
+/** Uses Kotlin Serialization to encode an arbitrary object or collection to Fleece.
+ *  @param value  The object to encode.
+ *  @param flEncoder  A Fleece [FLEncoder] to use; defaults to a fresh instance.
+ *  @return  The encoded Fleece data. */
+@ExperimentalSerializationApi
+inline fun <reified T> serializeToFleece(value: T, flEncoder: FLEncoder? = null): FLSliceResult =
+    serializeToFleece(serializer(), value, flEncoder)
+
+
+class FleeceSerializationException(message: String): Exception(message)
+
+
+/** Common interface of [FleeceRootEncoder] and [FleeceCollectionEncoder]. */
+private interface FleeceParentEncoder {
+    val flEncoder: FLEncoder
+
+    fun childFinished()
+
+    fun beginChild(descriptor: SerialDescriptor, collectionSize: Long = 0): CompositeEncoder {
+        require(descriptor.kind is StructureKind)
+        var isDict = false
+        if (descriptor.kind == StructureKind.LIST) {
+            flEncoder.beginArray(collectionSize)
+        } else {
+            if (descriptor.kind == StructureKind.MAP) {
+                val keyDescriptor = descriptor.getElementDescriptor(0)
+                if (keyDescriptor.kind != PrimitiveKind.STRING)
+                    throw FleeceSerializationException("Map keys must be Strings, not ${keyDescriptor.serialName}")
+            }
+            isDict = true
+            flEncoder.beginDict(collectionSize)
+        }
+        return FleeceCollectionEncoder(this, isDict = isDict)
+    }
+}
+
+
+/** The root-level Encoder. It just expects a [beginCollection] or [beginStructure] call. */
+private class FleeceRootEncoder(encoder: FLEncoder?) : AbstractEncoder(), FleeceParentEncoder {
+    override val flEncoder = encoder ?: FLEncoder.getManagedEncoder()
+    var container: FLSliceResult? = null
+
+    override val serializersModule: SerializersModule = EmptySerializersModule()
+
+    override fun encodeValue(value: Any) =
+        throw FleeceSerializationException("Fleece cannot serialize primitive types, only classes and collections.")
+
+    override fun beginCollection(descriptor: SerialDescriptor, collectionSize: Int): CompositeEncoder =
+        beginChild(descriptor, collectionSize.toLong())
+
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder =
+        beginChild(descriptor)
+
+    override fun childFinished() {
+        require(container == null)
+        container = flEncoder.finish2()
+    }
+}
+
+
+// https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-core/kotlinx.serialization.encoding/-composite-encoder/
+
+/** Child Encoder that does the real work. */
+private class FleeceCollectionEncoder (private val parent: FleeceParentEncoder,
+                                       private val isDict: Boolean)
+    : Encoder, CompositeEncoder, FleeceParentEncoder {
+
+    override val flEncoder = parent.flEncoder
+
+    override val serializersModule: SerializersModule = EmptySerializersModule()
+
+    // True when the current value being encoded is actually a Dict key.
+    private var valueIsKey: Boolean = false
+
+    // Always called before adding a value to the Fleece encoder.
+    private fun writeKey(descriptor: SerialDescriptor, index: Int, isString: Boolean = false) {
+        require(!valueIsKey)
+        when (descriptor.kind) {
+            StructureKind.CLASS -> {
+                // If encoding a class instance, then the key is available from the descriptor.
+                valueIsKey = true
+                actuallyWriteKey(descriptor.getElementName(index))
+            }
+            StructureKind.MAP -> {
+                // ...but if encoding a map, it's passed to us as alternating keys and values, so
+                // we have to keep track of which are the keys by setting [valueIsKey] appropriately.
+                valueIsKey = (index % 2 == 0)
+                if (valueIsKey && !isString)
+                    throw FleeceSerializationException("Map keys must be Strings to encode to Fleece")
+            }
+            else -> { }
+        }
+    }
+
+    // Actually writes a key to the DictEncoder.
+    private fun actuallyWriteKey(key: String) {
+        assert(valueIsKey)
+        flEncoder.writeKey(key)
+        valueIsKey = false
+    }
+
+    override fun childFinished() { /*no-op*/ }
+
+    //---- CompositeEncoder API:
+
+    override fun encodeBooleanElement(descriptor: SerialDescriptor, index: Int, value: Boolean) {
+        writeKey(descriptor, index)
+        encodeBoolean(value)
+    }
+
+    override fun encodeByteElement(descriptor: SerialDescriptor, index: Int, value: Byte) =
+        encodeIntElement(descriptor, index, value.toInt())
+
+    override fun encodeShortElement(descriptor: SerialDescriptor, index: Int, value: Short) =
+        encodeIntElement(descriptor, index, value.toInt())
+
+    override fun encodeCharElement(descriptor: SerialDescriptor, index: Int, value: Char) =
+        encodeIntElement(descriptor, index, value.code)
+
+    override fun encodeIntElement(descriptor: SerialDescriptor, index: Int, value: Int) {
+        writeKey(descriptor, index)
+        encodeInt(value)
+    }
+
+    override fun encodeLongElement(descriptor: SerialDescriptor, index: Int, value: Long) {
+        writeKey(descriptor, index)
+        encodeLong(value)
+    }
+
+    override fun encodeFloatElement(descriptor: SerialDescriptor, index: Int, value: Float) {
+        writeKey(descriptor, index)
+        encodeFloat(value)
+    }
+
+    override fun encodeDoubleElement(descriptor: SerialDescriptor, index: Int, value: Double) {
+        writeKey(descriptor, index)
+        encodeDouble(value)
+    }
+
+    override fun encodeStringElement(descriptor: SerialDescriptor, index: Int, value: String) {
+        writeKey(descriptor, index, isString = true)
+        encodeString(value)
+    }
+
+    override fun encodeInlineElement(descriptor: SerialDescriptor, index: Int): Encoder = this
+
+    override fun <T> encodeSerializableElement(descriptor: SerialDescriptor,
+                                               index: Int,
+                                               serializer: SerializationStrategy<T>,
+                                               value: T)
+    {
+        writeKey(descriptor, index, isString = true)
+        serializer.serialize(this, value)
+    }
+
+    override fun <T : Any> encodeNullableSerializableElement(descriptor: SerialDescriptor,
+                                                             index: Int,
+                                                             serializer: SerializationStrategy<T>,
+                                                             value: T?)
+    {
+        if (value != null) {
+            encodeSerializableElement(descriptor, index, serializer, value)
+        } else if (!descriptor.isElementOptional(index)) {
+            writeKey(descriptor, index)
+            encodeNull()
+        }
+    }
+
+    override fun endStructure(descriptor: SerialDescriptor) {
+        if (isDict) flEncoder.endDict() else flEncoder.endArray()
+        parent.childFinished()
+    }
+
+    //---- Encoder API:
+
+    override fun encodeNull()                   {flEncoder.writeNull()}
+    override fun encodeBoolean(value: Boolean)  {flEncoder.writeValue(value)}
+    override fun encodeByte(value: Byte)        {flEncoder.writeValue(value.toInt())}
+    override fun encodeShort(value: Short)      {flEncoder.writeValue(value.toInt())}
+    override fun encodeChar(value: Char)        {flEncoder.writeValue(value.code)}
+    override fun encodeInt(value: Int)          {flEncoder.writeValue(value)}
+    override fun encodeLong(value: Long)        {flEncoder.writeValue(value)}
+    override fun encodeFloat(value: Float)      {flEncoder.writeValue(value)}
+    override fun encodeDouble(value: Double)    {flEncoder.writeValue(value)}
+
+    override fun encodeString(value: String) {
+        if (valueIsKey)
+            actuallyWriteKey(value)
+        else
+            flEncoder.writeString(value)
+    }
+
+    override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) {
+        flEncoder.writeValue(index)
+    }
+
+    override fun encodeInline(descriptor: SerialDescriptor): Encoder = this
+
+    override fun beginCollection(descriptor: SerialDescriptor, collectionSize: Int) =
+        beginChild(descriptor, collectionSize.toLong())
+
+    override fun beginStructure(descriptor: SerialDescriptor) =
+        beginChild(descriptor)
+}

--- a/common/test/java/com/couchbase/lite/CollectionTest.kt
+++ b/common/test/java/com/couchbase/lite/CollectionTest.kt
@@ -17,6 +17,8 @@
 package com.couchbase.lite
 
 import com.couchbase.lite.internal.utils.SlowTest
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import org.junit.Assert
 import org.junit.Test
 
@@ -1213,4 +1215,52 @@ class CollectionTest : BaseDbTest() {
 
         Assert.assertEquals(scope, testDatabase.getScope(Scope.DEFAULT_NAME))
     }
+
+    //---------------------------------------------
+    //  Model-based (serialization) API
+    //---------------------------------------------
+
+    @Test
+    fun saveNewDocInCollectionFromModel() {
+        val id = getUniqueName("test_doc")
+
+        // Create a new model and save it:
+        val model = TestModel("Nigel", 12)
+        testCollection.save(model, id)
+        Assert.assertEquals(testCollection, model.documentMeta?.collection)
+        Assert.assertEquals(id, model.documentMeta?.id)
+
+        // Read it back:
+        Assert.assertEquals(1, testCollection.count)
+        val gotModel = testCollection.getDocumentAs<TestModel>(id)!!
+        Assert.assertEquals(model, gotModel)
+
+        // Modify and save again:
+        gotModel.favorites = listOf("XTC", "Elvis Costello")
+        Assert.assertTrue(testCollection.save(gotModel))
+        Assert.assertNotEquals(model.documentMeta?.revisionID, gotModel.documentMeta?.revisionID)
+
+        // Get it as a regular Document and verify the contents:
+        val doc = testCollection.getDocument(id)!!
+        Assert.assertEquals(gotModel.documentMeta?.revisionID, doc.revisionID)
+        Assert.assertEquals("Nigel", doc.getString("name"))
+        Assert.assertEquals(12, doc.getInt("age"))
+        val faves = doc.getArray("favorites")!!
+        Assert.assertEquals(2, faves.count())
+        Assert.assertEquals("XTC", faves.getString(0))
+        Assert.assertEquals("Elvis Costello", faves.getString(1))
+
+        // Delete the model. `model` is out of date, so it will fail, but `gotModel` is OK:
+        Assert.assertFalse(testCollection.delete(model, ConcurrencyControl.FAIL_ON_CONFLICT))
+        Assert.assertTrue(testCollection.delete(gotModel, ConcurrencyControl.FAIL_ON_CONFLICT))
+    }
+}
+
+
+// Simple Model class for tests
+@Serializable
+data class TestModel(var name: String,
+                     var age: Int,
+                     var favorites: List<String>? = null): DocumentModel {
+    @Transient override var documentMeta: DocumentMeta? = null
 }

--- a/common/test/java/com/couchbase/lite/ResultTest.kt
+++ b/common/test/java/com/couchbase/lite/ResultTest.kt
@@ -1,0 +1,70 @@
+//
+// Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http:// www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.couchbase.lite
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import org.junit.Assert.*
+import org.junit.Test
+
+/** Tests serialization-based Result and ResultSet accessors implemented in QueryExtensions.kt. */
+class ResultSerializationTest : BaseQueryTest() {
+    @Test @OptIn(ExperimentalSerializationApi::class)
+    fun testResultToModel() {
+        // Note: For simplicity this uses a class that implements DocumentModel, but it isn't necessary.
+        val doc = MutableDocument("nigel")
+        doc.setString("name", "Nigel")
+        doc.setInt("age", 12)
+        testCollection.save(doc)
+
+        val query = testDatabase.createQuery("SELECT name, age FROM " + testCollection.fullName)
+        val rows = query.execute().data<TestModel>()
+        val iter = rows.iterator()
+
+        assertTrue(iter.hasNext())
+        val nigel: TestModel = iter.next()
+        assertEquals("Nigel", nigel.name)
+        assertEquals(12, nigel.age)
+        assertNull(nigel.favorites)
+        assertNull(nigel.documentMeta)  // query doesn't return `meta`
+
+        assertFalse(iter.hasNext())
+    }
+
+    @Test @OptIn(ExperimentalSerializationApi::class)
+    fun testResultToModelWithMeta() {
+        val doc = MutableDocument("nigel")
+        doc.setString("name", "Nigel")
+        doc.setInt("age", 12)
+        testCollection.save(doc)
+
+        val query = testDatabase.createQuery("SELECT * as doc, meta() as meta FROM " + testCollection.fullName)
+        val resultSet = query.execute()
+        val rows = resultSet.data<TestModel>("doc", "meta")
+        val iter = rows.iterator()
+
+        assertTrue(iter.hasNext())
+        val nigel: TestModel = iter.next()
+        assertEquals("Nigel", nigel.name)
+        assertEquals(12, nigel.age)
+        assertNull(nigel.favorites)
+        // Verify the documentMeta got set:
+        assertEquals(doc.id, nigel.documentMeta?.id)
+        assertEquals(doc.revisionID, nigel.documentMeta?.revisionID)
+
+        assertFalse(iter.hasNext())
+    }
+}

--- a/common/test/java/com/couchbase/lite/internal/fleece/FleeceSerializationTest.kt
+++ b/common/test/java/com/couchbase/lite/internal/fleece/FleeceSerializationTest.kt
@@ -1,0 +1,208 @@
+package com.couchbase.lite.internal.fleece
+
+import com.couchbase.lite.BaseTest
+import kotlinx.serialization.*
+import org.junit.Assert
+import org.junit.Test
+
+
+@Serializable
+data class Project(val name: String, val owner: User?, val votes: Int)
+
+@Serializable
+data class ProjectOpt(val name: String, val owner: User? = null, val votes: Int)
+
+@Serializable
+data class User(val name: String, val age: Age)
+
+@Serializable @JvmInline
+value class Age(val years: UInt)
+
+
+private fun fleeceToJSON(container: FLSliceResult): String =
+    FLValue.fromData(container)!!.toJSON()!!
+
+private fun encode(fn: FLEncoder.()->Boolean): FLValue {
+    val encoder = FLEncoder.getManagedEncoder()
+    encoder.fn()
+    return FLValue.fromData(encoder.finish())
+}
+
+
+@OptIn(ExperimentalSerializationApi::class)
+class SerializationTests: BaseTest() {
+    @Test
+    fun encodeList() {
+        serializeToFleece(listOf("hello", "there")).use { container ->
+            Assert.assertEquals("[\"hello\",\"there\"]", fleeceToJSON(container))
+        }
+    }
+
+    @Test
+    fun encodeMap() {
+        serializeToFleece(mapOf("key" to "value", "foo" to "bar")).use { container ->
+            val json = fleeceToJSON(container)
+            Assert.assertEquals("""{"foo":"bar","key":"value"}""", json)
+        }
+    }
+
+    @Test
+    fun encodeInvalidTypes() {
+        Assert.assertThrows(FleeceSerializationException::class.java) {
+            serializeToFleece("hello")  // Can't encode just a scalar
+        }
+        Assert.assertThrows(FleeceSerializationException::class.java) {
+            serializeToFleece(Age(14u)) // ...even if it's wrapped in a value class
+        }
+        Assert.assertThrows(FleeceSerializationException::class.java) {
+            serializeToFleece(mapOf(99 to "value", 30 to "bar"))    // Map keys must be Strings
+        }
+    }
+
+    @Test
+    fun encodeSimpleClass() {
+        val data = User("kotlin", Age(17u))
+        serializeToFleece(data).use { container ->
+        val json = fleeceToJSON(container)
+        Assert.assertEquals("""{"age":17,"name":"kotlin"}""", json)
+            }
+    }
+
+    @Test
+    fun encodeNestedClasses() {
+        val data = Project("kotlinx.serialization", User("kotlin", Age(17u)), 9000)
+        serializeToFleece(data).use { container ->
+            val json = fleeceToJSON(container)
+            Assert.assertEquals(
+                """{"name":"kotlinx.serialization","owner":{"age":17,"name":"kotlin"},"votes":9000}""",
+                json
+            )
+        }
+    }
+
+    @Test
+    fun encodeNestedClassesWithNull() {
+        val data = Project("kotlinx.serialization", null, 9000)
+        serializeToFleece(data).use { container ->
+            val json = fleeceToJSON(container)
+            // "owner" appears with a null value because Project.owner doesn't default to null.
+            Assert.assertEquals(
+                """{"name":"kotlinx.serialization","owner":null,"votes":9000}""",
+                json
+            )
+        }
+    }
+
+    @Test
+    fun encodeNestedClassesWithOptionalNull() {
+        val data = ProjectOpt("kotlinx.serialization", null, 9000)
+        serializeToFleece(data).use { container ->
+            val json = fleeceToJSON(container)
+            // "owner" is omitted because ProjectOpt.owner has a default value of null.
+            Assert.assertEquals("""{"name":"kotlinx.serialization","votes":9000}""", json)
+        }
+    }
+
+
+    //---- DECODING:
+
+
+    @Test fun decodeList() {
+        val encoded = encode {
+            beginArray(0)
+            writeString("hi")
+            writeString("there")
+            endArray()
+        }
+        val list = deserializeFromFleece<List<String>>(encoded)
+        Assert.assertEquals(listOf("hi", "there"), list)
+    }
+
+    @Test fun decodeMap() {
+        val encoded = encode {
+            beginDict(0)
+            writeKey("hi")
+            writeValue(19)
+            writeKey("bye")
+            writeValue(-1)
+            endDict()
+        }
+        val map = deserializeFromFleece<Map<String,Int>>(encoded)
+        Assert.assertEquals(mapOf("hi" to 19, "bye" to -1), map)
+    }
+
+    @Test fun decodeClass() {
+        val encoded = encode {
+            beginDict(0)
+            writeKey("name")
+            writeValue("pupshaw")
+            writeKey("age")
+            writeValue(29)
+            endDict()
+        }
+        val user = deserializeFromFleece<User>(encoded)
+        Assert.assertEquals(User("pupshaw", Age(29u)), user)
+    }
+
+    @Test fun decodeNestedClasses() {
+        val encoded = encode {
+            beginDict(0)
+            writeKey("name")
+            writeValue("Fleece")
+            writeKey("votes")
+            writeValue(9000)
+            writeKey("owner")
+
+            beginDict(0)
+            writeKey("name")
+            writeValue("pupshaw")
+            writeKey("age")
+            writeValue(29)
+            endDict()
+
+            endDict()
+        }
+
+        val user = deserializeFromFleece<Project>(encoded)
+        Assert.assertEquals(Project("Fleece", User("pupshaw", Age(29u)), 9000), user)
+    }
+
+    @Test fun decodeNestedClassesWithNull() {
+        val encoded = encode {
+            beginDict(0)
+            writeKey("name")
+            writeValue("Fleece")
+            writeKey("votes")
+            writeValue(9000)
+            writeKey("owner")
+            writeNull()
+            endDict()
+        }
+
+        val user = deserializeFromFleece<Project>(encoded)
+        Assert.assertEquals(Project("Fleece", null, 9000), user)
+    }
+
+    @Test fun decodeNestedClassesWithOptionalNull() {
+        val encoded = encode {
+            beginDict(0)
+            writeKey("name")
+            writeValue("Fleece")
+            writeKey("votes")
+            writeValue(9000)
+            endDict()
+        }
+
+        val user = deserializeFromFleece<ProjectOpt>(encoded)
+        Assert.assertEquals(ProjectOpt("Fleece", null, 9000), user)
+    }
+
+    @Test fun roundTripNestedClassesWithNull() {
+        val data = Project("Fleece", null, 9000)
+        serializeToFleece(data).use { encoded ->
+            print(fleeceToJSON(encoded))
+            val user = deserializeFromFleece<Project>(FLValue.fromData(encoded)!!)
+            Assert.assertEquals(Project("Fleece", null, 9000), user)
+        }
+    }
+}


### PR DESCRIPTION
Ported Kotlin Serialization from master branch (5b0328ad8ecd1cc838f49ccd2db6772a9c7079e4)

-- 

* Implemented serialization-based API extensions
- Collection.getDocumentAs(), save()
- Result.data()
- ResultSet.data()

* Implemented Collection.delete(DocumentModel)

* Allow null docID when saving new DocumentModel

* Fixes from code review (not all fixed)
- serializeToFleece() now returns a FLSliceResult not a ByteArray.
- Callers of the above use `use` to release the memory when done.
- Use `use` to release Fleece iterators.
- Collection.save(DocumentModel) interprets a null conflict handler as last-write-wins. This fixes a NPE bug too.

* FLValue.asString() should be marked @Nullable per Jim. Fixed FleeceDeserialization to handle null by returning "" instead.

* Ensure MutableDocument.setContentFromModel doesn't lose backing store