### PR TITLE
Fix checkStyle final local var and PDM SingularField warning in Document class

### DIFF
--- a/common/main/java/com/couchbase/lite/Document.java
+++ b/common/main/java/com/couchbase/lite/Document.java
@@ -136,6 +136,7 @@ public class Document implements DictionaryInterface, JSONEncodable, Iterable<St
 
     // Set by setData(FLSliceResult,boolean) to keep the Fleece backing store from being GC'd.
     // (This is kind of a hack, and it's only used ephemerally by Kotlin serialization.)
+    @SuppressWarnings("PMD.SingularField")
     @GuardedBy("lock")
     @Nullable
     private FLSliceResult extraBackingStore;
@@ -632,7 +633,7 @@ public class Document implements DictionaryInterface, JSONEncodable, Iterable<St
     // for use by CollectionExtensions.kt
     void setContent(@NonNull FLSliceResult fleeceData, boolean mutable) {
         synchronized (lock) {
-            var data = FLValue.fromData(fleeceData).asFLDict();
+            final FLDict data = FLValue.fromData(fleeceData).asFLDict();
             extraBackingStore = fleeceData;
             setContentLocked(data, mutable);
         }


### PR DESCRIPTION
Fix using var and PDM SingularField warning in Document class

* As var is unavailable for source Java 8 source level, use FLDict type explicitly.

* Made local data variable in Document’s setContent() final per check style warning.

* Suppress the PMD SingularField warning on extraBackingStore, which is written but never read. It cannot be made a local variable as PMD suggests because it is for keeping the native Fleece backing store from being GC’d while the Document is alive.