### PR TITLE
CBL-8468 : Fix incoming BLE L2CAP socket double-free on connection teardown

### DIFF
--- a/common/main/cpp/native_c4btsocketfactory.cc
+++ b/common/main/cpp/native_c4btsocketfactory.cc
@@ -79,6 +79,7 @@ static void btOpen(C4Socket*       socket,
     jint envState = attachJVM(&env, "btOpen");
     if (envState != JNI_OK && envState != JNI_EDETACHED) return;
 
+    // Balanced by the c4socket_release in NativeC4Socket_closed.
     c4socket_retain(socket);
 
     // addr->hostname carries the CBL peer-ID / BT MAC address as a C4Slice.
@@ -177,6 +178,9 @@ static void btAttached(C4Socket* socket) {
     }
 
     jstring jPeerID = env->NewStringUTF((const char *)ctx->peerID.buf);
+
+    // Balanced by the c4socket_release in NativeC4Socket_closed. Mirrors btOpen.
+    c4socket_retain(socket);
 
     env->CallStaticVoidMethod(
             cls_C4BTSocketFactory, m_attached,


### PR DESCRIPTION
The btAttached() (incoming) now calls c4socket_retain, matching btOpen(), to balance the c4socket_release in NativeC4Socket_closed. Without it the incoming socket was double-freed on teardown (SIGABRT, invalid refCount -6666666).