### PR TITLE
CBL-8585: Bounds check the peer ID

### DIFF
--- a/common/main/cpp/native_c4btsocketfactory.cc
+++ b/common/main/cpp/native_c4btsocketfactory.cc
@@ -176,7 +176,7 @@ static void btAttached(C4Socket* socket) {
         return;
     }
 
-    jstring jPeerID = env->NewStringUTF((const char *)ctx->peerID.buf);
+    jstring jPeerID = toJString(env, ctx->peerID);
 
     env->CallStaticVoidMethod(
             cls_C4BTSocketFactory, m_attached,


### PR DESCRIPTION
This was mistakenly passed as-is to JNI, but it is not always null terminated