### PR TITLE
CBL-8707: Add VERBOSE logging methods to Log class

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/logging/Log.java
+++ b/common/main/java/com/couchbase/lite/internal/logging/Log.java
@@ -164,7 +164,7 @@ public final class Log {
     }
 
     /**
-     * Send an VERBOSE message.
+     * Send a VERBOSE message.
      *
      * @param domain The log domain.
      * @param msg    The string you would like logged plus format specifiers.

--- a/common/main/java/com/couchbase/lite/internal/logging/Log.java
+++ b/common/main/java/com/couchbase/lite/internal/logging/Log.java
@@ -145,6 +145,48 @@ public final class Log {
     }
 
     /**
+     * Send a VERBOSE message.
+     *
+     * @param domain The log domain.
+     * @param msg    The message you would like logged.
+     */
+    public static void v(@NonNull LogDomain domain, @NonNull String msg) { log(LogLevel.VERBOSE, domain, null, msg); }
+
+    /**
+     * Send a VERBOSE message and log the exception.
+     *
+     * @param domain The log domain.
+     * @param msg    The message you would like logged.
+     * @param err    An exception to log
+     */
+    public static void v(@NonNull LogDomain domain, @NonNull String msg, @Nullable Throwable err) {
+        log(LogLevel.VERBOSE, domain, err, msg);
+    }
+
+    /**
+     * Send an VERBOSE message.
+     *
+     * @param domain The log domain.
+     * @param msg    The string you would like logged plus format specifiers.
+     * @param args   Variable number of Object args to be used as params to formatString.
+     */
+    public static void v(@NonNull LogDomain domain, @NonNull String msg, Object... args) {
+        log(LogLevel.VERBOSE, domain, null, msg, args);
+    }
+
+    /**
+     * Send a VERBOSE message and log the exception.
+     *
+     * @param domain The log domain.
+     * @param msg    The string you would like logged plus format specifiers.
+     * @param err    An exception to log
+     * @param args   Variable number of Object args to be used as params to formatString.
+     */
+    public static void v(@NonNull LogDomain domain, @NonNull String msg, @Nullable Throwable err, Object... args) {
+        log(LogLevel.VERBOSE, domain, err, msg, args);
+    }
+
+    /**
      * Send a WARN message.
      *
      * @param domain The log domain.


### PR DESCRIPTION
* Added Log.v() overloads for logging VERBOSE messages. This change is driven by a requirement from `CBL-RN` but it’s also useful for CBL-Java / Android itself when it wants to log messages at the VERBOSE log level.

* `CBL-RN`'s `LogSinksManager` can drop the reflection call to the log() method (which is also public now) and remove the keep rules for the internal Log's methods() from the `consumer-rules.pro`.

* The change will be ported to 3.3, 3.4 and 4.1 when a new MR is scheduled.