### PR TITLE
CBL-8662 : Fix warn-once check in warnIfNoFileLogSink

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/logging/LogSinksImpl.java
+++ b/common/main/java/com/couchbase/lite/internal/logging/LogSinksImpl.java
@@ -318,7 +318,10 @@ public final class LogSinksImpl implements LogSinks {
 
     private void warnIfNoFileLogSink() {
         final FileLogSink sink = fileLogSink;
-        if ((sink != null) && (sink.getLevel() != LogLevel.NONE) && !warned.getAndSet(true)) { return; }
+        if ((sink != null) && (sink.getLevel() != LogLevel.NONE)) { return; }
+        // Warn only once
+        if (warned.getAndSet(true)) { return; }
+
         ((AbstractLogSink) new ConsoleLogSink(LogLevel.WARNING, LogDomain.DATABASE)).writeLog(
             LogLevel.WARNING,
             LogDomain.DATABASE,


### PR DESCRIPTION
Fixed the reversed logic and seperated warned flag check.