### PR TITLE
CBL-8663 : Fix warn-once check in warnIfNoFileLogSink

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/logging/LogSinksImpl.java
+++ b/common/main/java/com/couchbase/lite/internal/logging/LogSinksImpl.java
@@ -318,7 +318,10 @@ public final class LogSinksImpl implements LogSinks {
 
     private void warnIfNoFileLogSink() {
         final FileLogSink sink = fileLogSink;
-        if ((sink != null) && (sink.getLevel() != LogLevel.NONE) && !warned.getAndSet(true)) { return; }
+        if ((sink != null) && (sink.getLevel() != LogLevel.NONE)) { return; }
+        // Warn only once
+        if (warned.getAndSet(true)) { return; }
+
         ((AbstractLogSink) new ConsoleLogSink(LogLevel.WARNING, LogDomain.DATABASE)).writeLog(
             LogLevel.WARNING,
             LogDomain.DATABASE,


### PR DESCRIPTION
- Directly ported from master branch (8808a474d348cd16607d7f222bb0caaa6737ecf7).

- Fixed the reversed logic and separated warned flag check (CBSE-23317)